### PR TITLE
Fix streaming HLS upload and database pool config

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import sqlalchemy as sa
 from databases import Database
 
-from config import DATABASE_PATH, DATABASE_POOL_MAX_SIZE, DATABASE_POOL_MIN_SIZE
+from config import DATABASE_PATH
 
 DATABASE_URL = f"sqlite:///{DATABASE_PATH}"
 
@@ -13,12 +13,11 @@ SQLITE_TIMEOUT = 30.0
 
 # Note: SQLite per-connection pragmas are configured in configure_sqlite_pragmas()
 # The timeout kwarg is passed to aiosqlite/sqlite3 and sets the connection busy_timeout
-# Pool size configuration helps manage concurrent reads (writes are serialized by SQLite)
+# Note: min_size/max_size pool parameters are NOT supported by the SQLite backend
+# of the databases library - aiosqlite handles connections differently
 database = Database(
     DATABASE_URL,
     timeout=SQLITE_TIMEOUT,
-    min_size=DATABASE_POOL_MIN_SIZE,
-    max_size=DATABASE_POOL_MAX_SIZE,
 )
 metadata = sa.MetaData()
 


### PR DESCRIPTION
## Summary
- Replace memory-hungry `files=` upload with streaming multipart upload to fix OOM issues when uploading large HLS outputs
- Add dynamic timeout scaling for large uploads (5min base + 1min per 100MB, max 1 hour)
- Add progress callback during upload to extend job claim for long uploads
- Remove unsupported `min_size`/`max_size` params from SQLite Database config

## Problem
For the "Driving Impressions of the 2017 Lexus NX 300h" video (4K, 17.7 min, 7 quality variants), the HLS tar.gz output was ~5-15GB. The old code used httpx's `files=` parameter which loads the **entire file into memory** before uploading. This caused:

1. Memory exhaustion on the worker (OOM)
2. Timeout before upload even started
3. Worker API memory pressure (was at 7.5GB/8GB limit)

## Solution
- Stream the multipart form data in 1MB chunks - never loads entire file into memory
- Use dynamic timeout based on file size
- Call progress callback every 60 seconds during upload to extend job claim

## Test plan
- [x] Linting passes (`ruff check`)
- [x] Worker API tests pass (46 tests)
- [x] Worker API restarts successfully with database fix
- [ ] Test upload of large 4K video to verify streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)