### PR TITLE
Fix test assertion to match actual error message

### DIFF
--- a/tests/test_worker_hls_upload_streaming.py
+++ b/tests/test_worker_hls_upload_streaming.py
@@ -258,7 +258,7 @@ class TestHLSUploadStreaming:
         )
 
         assert response.status_code == 400
-        assert "unexpected file type" in response.json()["detail"].lower()
+        assert "invalid file type" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
     async def test_upload_hls_resets_permissions(


### PR DESCRIPTION
## Summary
Fix failing test `test_upload_hls_rejects_unexpected_file_types` by updating the assertion to match the actual API error message.

## Problem
The test was asserting for "unexpected file type" but the API (`api/worker_api.py:146`) returns "Invalid file type".

## Solution
Updated the test assertion from:
```python
assert "unexpected file type" in response.json()["detail"].lower()
```
to:
```python
assert "invalid file type" in response.json()["detail"].lower()
```

## Test plan
- [x] `test_upload_hls_rejects_unexpected_file_types` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)