### PR TITLE
docs: Update documentation for PostgreSQL and Redis architecture

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -670,6 +670,71 @@ DELETE /api/workers/{worker_id}
 
 Removes worker registration (does not revoke API key).
 
+### Server-Sent Events (SSE)
+
+Real-time updates for transcoding progress and worker status.
+
+#### Progress Updates
+```
+GET /api/events/progress?video_ids=1,2,3
+```
+
+Streams real-time transcoding progress updates.
+
+Query parameters:
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| video_ids | string | Comma-separated video IDs to monitor |
+
+SSE Event Types:
+- `progress` - Transcoding progress update
+- `heartbeat` - Keep-alive (every 30s)
+
+Event data format:
+```json
+{
+  "type": "progress",
+  "video_id": 1,
+  "job_id": 16,
+  "current_step": "transcode",
+  "progress_percent": 45,
+  "qualities": [
+    {"name": "1080p", "status": "completed", "progress": 100},
+    {"name": "720p", "status": "in_progress", "progress": 60}
+  ],
+  "status": "processing",
+  "timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+#### Worker Status Updates
+```
+GET /api/events/workers
+```
+
+Streams real-time worker status changes.
+
+SSE Event Types:
+- `worker_status` - Worker status change
+- `heartbeat` - Keep-alive (every 30s)
+
+Event data format:
+```json
+{
+  "type": "worker_status",
+  "worker_id": "uuid-string",
+  "worker_name": "k8s-worker-1",
+  "status": "active",
+  "current_job_id": 16,
+  "timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+**Notes:**
+- SSE uses Redis Pub/Sub when available for instant updates
+- Falls back to database polling if Redis is unavailable
+- Client should handle reconnection via `EventSource` API
+
 ---
 
 ## Rate Limiting


### PR DESCRIPTION
## Summary

- Comprehensive documentation update to reflect architectural changes from SQLite to PostgreSQL
- Added documentation for Redis integration (job queue, pub/sub, SSE)
- Added documentation for new features (parallel encoding, SSE endpoints)

## Changes by File

### ARCHITECTURE.md
- Updated system diagram to show PostgreSQL and Redis instead of SQLite
- Added Redis section describing job queue, pub/sub, and circuit breaker
- Added SSE endpoints to Admin API description
- Updated shared utilities table with new Redis modules
- Updated technology stack (PostgreSQL + asyncpg, Redis Streams, SSE)
- Updated scalability section to reflect current capabilities

### DATABASE.md
- Rewrote overview for PostgreSQL instead of SQLite
- Updated all timestamp columns to PostgreSQL format (`TIMESTAMP WITH TIME ZONE`)
- Added missing columns to `transcoding_jobs` and `worker_api_keys` tables
- Fixed workers table status values
- Added Alembic migrations section
- Updated all SQL examples to PostgreSQL syntax
- Replaced SQLite commands with PostgreSQL equivalents

### CONFIGURATION.md
- Added Database Configuration section with `VLOG_DATABASE_URL`
- Added Redis Configuration section (pool, timeouts, job queue mode, streams, pub/sub)
- Added SSE Settings section
- Added Parallel Quality Encoding section
- Added Error Message Truncation section
- Updated Multi-Instance section for PostgreSQL

### API.md
- Added Server-Sent Events (SSE) section documenting:
  - `GET /api/events/progress` - Real-time transcoding progress
  - `GET /api/events/workers` - Real-time worker status

### DEPLOYMENT.md
- Added PostgreSQL setup instructions (development and production)
- Added Redis setup instructions
- Updated troubleshooting to use PostgreSQL commands
- Updated backup commands to use `pg_dump`/`pg_restore`

## Test plan

- [ ] Review documentation for accuracy
- [ ] Verify all PostgreSQL commands work
- [ ] Verify Redis setup instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)