### PR TITLE
Add Redis backend support for analytics cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -283,6 +283,11 @@ VLOG_ANALYTICS_CACHE_TTL=60
 # Client-side Cache-Control max-age in seconds
 VLOG_ANALYTICS_CLIENT_CACHE_MAX_AGE=60
 
+# Analytics cache storage backend
+# Use "memory://" for single instance, or Redis URL for multi-instance:
+# VLOG_ANALYTICS_CACHE_STORAGE_URL=redis://localhost:6379/0
+VLOG_ANALYTICS_CACHE_STORAGE_URL=memory://
+
 # =============================================================================
 # Audit Logging
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,10 +227,10 @@ Transcription: `transcriptions` (whisper-generated subtitles with VTT output)
 
 When running multiple API instances (e.g., behind a load balancer):
 
-- **Analytics cache is per-instance**: The in-memory analytics cache (`api/analytics_cache.py`) is local to each process. In multi-instance deployments, different instances may show slightly different analytics counts until caches expire (default: 60 seconds).
-  - To disable caching: `VLOG_ANALYTICS_CACHE_ENABLED=false`
-  - For shared cache state, configure Redis: `VLOG_RATE_LIMIT_STORAGE_URL=redis://localhost:6379` (rate limiting) - note that analytics cache does not yet support Redis
-  - Analytics are eventually consistent, which is typically acceptable for view counts
+- **Analytics cache**: By default uses in-memory storage (per-process). For consistent analytics across instances, use Redis: `VLOG_ANALYTICS_CACHE_STORAGE_URL=redis://localhost:6379`
+  - To disable caching entirely: `VLOG_ANALYTICS_CACHE_ENABLED=false`
+  - With in-memory cache, different instances may show slightly different analytics counts until caches expire (default: 60 seconds)
+  - With Redis cache, all instances share the same cache state for consistent results
 
 - **Rate limiting storage**: By default uses in-memory storage (per-process). For consistent rate limiting across instances, use Redis: `VLOG_RATE_LIMIT_STORAGE_URL=redis://localhost:6379`
 
@@ -265,6 +265,7 @@ When running multiple API instances (e.g., behind a load balancer):
   - Hardware acceleration: `VLOG_HWACCEL_TYPE` (auto, nvidia, intel, none), `VLOG_HWACCEL_PREFERRED_CODEC` (h264, hevc, av1)
   - Parallel encoding: `VLOG_PARALLEL_QUALITIES` (default: 1), `VLOG_PARALLEL_QUALITIES_AUTO` (default: true)
   - Audit logging: `VLOG_AUDIT_LOG_ENABLED` (default: true), `VLOG_AUDIT_LOG_PATH` (default: /var/log/vlog/audit.log)
+  - Analytics cache: `VLOG_ANALYTICS_CACHE_ENABLED`, `VLOG_ANALYTICS_CACHE_TTL`, `VLOG_ANALYTICS_CACHE_STORAGE_URL` (memory:// or redis://)
   - Redis: `VLOG_REDIS_URL` (empty = disabled), `VLOG_JOB_QUEUE_MODE` (database, redis, hybrid), `VLOG_REDIS_POOL_SIZE` (default: 10)
   - SSE: `VLOG_SSE_HEARTBEAT_INTERVAL` (default: 30s), `VLOG_SSE_RECONNECT_TIMEOUT_MS` (default: 3000)
   - Alerting: `VLOG_ALERT_WEBHOOK_URL` (empty = disabled), `VLOG_ALERT_WEBHOOK_TIMEOUT` (default: 10s), `VLOG_ALERT_RATE_LIMIT_SECONDS` (default: 300)

--- a/api/admin.py
+++ b/api/admin.py
@@ -27,7 +27,7 @@ from slowapi.errors import RateLimitExceeded
 from slugify import slugify
 from sse_starlette.sse import EventSourceResponse
 
-from api.analytics_cache import AnalyticsCache
+from api.analytics_cache import create_analytics_cache
 from api.audit import AuditAction, log_audit
 from api.common import (
     RequestIDMiddleware,
@@ -110,6 +110,7 @@ from config import (
     ADMIN_CORS_ALLOWED_ORIGINS,
     ADMIN_PORT,
     ANALYTICS_CACHE_ENABLED,
+    ANALYTICS_CACHE_STORAGE_URL,
     ANALYTICS_CACHE_TTL,
     ANALYTICS_CLIENT_CACHE_MAX_AGE,
     ARCHIVE_DIR,
@@ -139,8 +140,12 @@ limiter = Limiter(
     enabled=RATE_LIMIT_ENABLED,
 )
 
-# Initialize analytics cache
-analytics_cache = AnalyticsCache(ttl_seconds=ANALYTICS_CACHE_TTL, enabled=ANALYTICS_CACHE_ENABLED)
+# Initialize analytics cache (uses Redis if ANALYTICS_CACHE_STORAGE_URL is set to redis://)
+analytics_cache = create_analytics_cache(
+    storage_url=ANALYTICS_CACHE_STORAGE_URL,
+    ttl_seconds=ANALYTICS_CACHE_TTL,
+    enabled=ANALYTICS_CACHE_ENABLED,
+)
 
 # Use centralized video extensions from config
 ALLOWED_VIDEO_EXTENSIONS = SUPPORTED_VIDEO_EXTENSIONS

--- a/config.py
+++ b/config.py
@@ -239,6 +239,11 @@ ANALYTICS_CACHE_ENABLED = os.getenv("VLOG_ANALYTICS_CACHE_ENABLED", "true").lowe
 # Cache TTL in seconds (default: 60 seconds)
 ANALYTICS_CACHE_TTL = int(os.getenv("VLOG_ANALYTICS_CACHE_TTL", "60"))
 
+# Storage backend for analytics cache
+# Options: "memory" (default, per-process), or a Redis URL like "redis://localhost:6379"
+# When Redis is configured, analytics cache is shared across all API instances
+ANALYTICS_CACHE_STORAGE_URL = os.getenv("VLOG_ANALYTICS_CACHE_STORAGE_URL", "memory://")
+
 # Client-side cache max-age in seconds (default: 60 seconds)
 # This controls the Cache-Control header sent to clients
 ANALYTICS_CLIENT_CACHE_MAX_AGE = int(os.getenv("VLOG_ANALYTICS_CLIENT_CACHE_MAX_AGE", "60"))

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -339,14 +339,20 @@ Encode multiple quality variants simultaneously to reduce transcoding time.
 
 When running multiple API instances (e.g., behind a load balancer):
 
-### Analytics Cache Limitations
+### Analytics Cache
 
-The in-memory analytics cache (`api/analytics_cache.py`) is local to each process. In multi-instance deployments, different instances may show slightly different analytics counts until caches expire (default: 60 seconds TTL).
+By default, the analytics cache uses in-memory storage (per-process). For consistent analytics across instances, use Redis:
+```bash
+VLOG_ANALYTICS_CACHE_STORAGE_URL=redis://localhost:6379
+```
 
-**Workarounds:**
+**Options:**
 - `VLOG_ANALYTICS_CACHE_ENABLED=false` - Disable caching entirely (higher database load)
-- Analytics are eventually consistent, which is typically acceptable for view counts
-- Note: The analytics cache does not yet support Redis for shared state
+- `VLOG_ANALYTICS_CACHE_TTL=60` - Cache TTL in seconds (default: 60)
+- `VLOG_ANALYTICS_CACHE_STORAGE_URL=memory://` - In-memory cache (default, per-process)
+- `VLOG_ANALYTICS_CACHE_STORAGE_URL=redis://localhost:6379` - Redis-backed shared cache
+
+With in-memory cache, different instances may show slightly different analytics counts until caches expire. With Redis, all instances share the same cache state.
 
 ### Rate Limiting
 


### PR DESCRIPTION
## Summary

- Add optional Redis-backed analytics cache for consistent analytics across multiple API instances
- Implements `RedisAnalyticsCache` class with the same interface as the existing `AnalyticsCache`
- Add `create_analytics_cache()` factory function that selects the appropriate implementation based on config
- Gracefully falls back to cache misses if Redis becomes unavailable

## Configuration

New environment variable:
```bash
# Use memory cache (default, per-process)
VLOG_ANALYTICS_CACHE_STORAGE_URL=memory://

# Use Redis cache (shared across instances)
VLOG_ANALYTICS_CACHE_STORAGE_URL=redis://localhost:6379
```

## Changes

- `config.py` - Add `ANALYTICS_CACHE_STORAGE_URL` config option
- `api/analytics_cache.py` - Add `RedisAnalyticsCache` class and factory function
- `api/admin.py` - Update to use factory function
- `tests/test_analytics_cache.py` - Add 22 new tests
- `.env.example` - Document new config option
- `CLAUDE.md` - Update multi-instance notes
- `docs/CONFIGURATION.md` - Update analytics cache section

## Test plan

- [x] All existing analytics cache tests pass
- [x] New Redis cache tests pass (with mocked Redis)
- [x] Factory function tests pass
- [x] Full test suite passes (869 tests)
- [x] Ruff linting passes

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)