### PR TITLE
Update architecture docs with tags system and alerts module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ worker/
 ├── remote_transcoder.py # Containerized worker for distributed transcoding via Worker API
 ├── hwaccel.py          # GPU detection and hardware encoder selection (NVENC, VAAPI)
 ├── http_client.py      # HTTP client for worker-to-API communication
-└── transcription.py    # Whisper transcription worker
+├── transcription.py    # Whisper transcription worker
+└── alerts.py           # Webhook alerting for transcoding events (stale jobs, failures, etc.)
 
 web/
 ├── public/       # Tailwind + Alpine.js frontend for browsing
@@ -114,7 +115,14 @@ k8s/              # Kubernetes manifests for containerized workers
 
 migrations/
 ├── env.py        # Alembic environment config (loads from config.py)
-└── versions/     # Migration scripts (001_initial_schema.py, 002_add_session_token_unique_constraint.py, 003_add_workers_table.py, 004_add_missing_indexes.py)
+└── versions/     # Migration scripts:
+    ├── 001_initial_schema.py
+    ├── 002_add_session_token_unique_constraint.py
+    ├── 003_add_workers_table.py
+    ├── 004_add_missing_indexes.py
+    ├── 005_add_workers_current_job_fk.py
+    ├── 006_add_processed_by_worker.py
+    └── 007_add_tags_tables.py
 ```
 
 ### Key Flows
@@ -218,6 +226,7 @@ Alert payload format (JSON):
 ### Database Schema
 
 Core tables: `categories`, `videos` (with `deleted_at` for soft-delete), `video_qualities`
+Tags: `tags`, `video_tags` (many-to-many relationship for granular content organization)
 Analytics: `viewers`, `playback_sessions` (cookie-based viewer tracking, watch progress)
 Transcoding: `transcoding_jobs`, `quality_progress` (checkpoint-based resumable transcoding)
 Workers: `workers`, `worker_api_keys` (remote worker registration with API key auth)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,6 +140,16 @@ Event-driven background process for local video transcoding:
 - Configurable retry attempts with exponential backoff
 - Graceful shutdown handling
 
+### Shared Worker Utilities
+
+**Location:** `worker/` directory
+
+| Module | Purpose |
+|--------|---------|
+| `hwaccel.py` | GPU detection and hardware encoder selection (NVENC, VAAPI) |
+| `http_client.py` | HTTP client for worker-to-API communication |
+| `alerts.py` | Webhook alerting for transcoding events (stale jobs, failures, retries) |
+
 ### 5. Remote Transcoding Workers (Kubernetes)
 
 **Location:** `worker/remote_transcoder.py`, `Dockerfile.worker.gpu`
@@ -228,6 +238,8 @@ PostgreSQL provides concurrent read/write support, making it suitable for multi-
 - `categories` - Video organization
 - `videos` - Video metadata and status (with soft-delete via `deleted_at`)
 - `video_qualities` - Available HLS variants per video
+- `tags` - Tag definitions for granular content organization
+- `video_tags` - Many-to-many relationship between videos and tags
 - `viewers` - Cookie-based viewer tracking
 - `playback_sessions` - Watch analytics
 - `transcoding_jobs` - Job tracking with checkpoints and job claiming

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -250,6 +250,35 @@ API keys for worker authentication (SHA-256 hashed).
 - Revoked keys remain in table for audit trail
 - `last_used_at` tracks recent activity
 
+### tags
+
+Tag definitions for granular content organization.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | INTEGER | PRIMARY KEY | Auto-increment ID |
+| name | VARCHAR(50) | UNIQUE, NOT NULL | Display name |
+| slug | VARCHAR(50) | UNIQUE, NOT NULL | URL-safe identifier |
+| created_at | TIMESTAMP WITH TIME ZONE | DEFAULT NOW() | Creation timestamp |
+
+**Indexes:**
+- `ix_tags_slug` - Fast tag lookup by slug
+
+### video_tags
+
+Many-to-many relationship between videos and tags.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| video_id | INTEGER | FK(videos.id) CASCADE, PK | Video reference |
+| tag_id | INTEGER | FK(tags.id) CASCADE, PK | Tag reference |
+
+**Indexes:**
+- `ix_video_tags_video_id` - Find tags for a video
+- `ix_video_tags_tag_id` - Find videos with a tag
+
+**Cascade Behavior:** Deleting a video or tag removes the association.
+
 ---
 
 ## Entity Relationships
@@ -261,6 +290,7 @@ videos (1) ───────────────────────
 videos (1) ─────────────────────────────── (N) playback_sessions
 videos (1) ─────────────────────────────── (1) transcoding_jobs
 videos (1) ─────────────────────────────── (1) transcriptions
+videos (N) ─────────────────────────────── (N) tags (via video_tags)
                                                 │
 transcoding_jobs (1) ──────────────────── (N) quality_progress
 transcoding_jobs (N) ──────────────────── (1) workers
@@ -280,6 +310,8 @@ viewers (1) ──────────────────────�
 | videos | playback_sessions | CASCADE |
 | videos | transcoding_jobs | CASCADE |
 | videos | transcriptions | CASCADE |
+| videos | video_tags | CASCADE |
+| tags | video_tags | CASCADE |
 | transcoding_jobs | quality_progress | CASCADE |
 | workers | worker_api_keys | CASCADE |
 | workers | transcoding_jobs.worker_id | SET NULL |


### PR DESCRIPTION
## Summary
- Add `tags` and `video_tags` tables to DATABASE.md with full schema documentation
- Update entity relationships and cascade behavior for the tags system
- Add `worker/alerts.py` to ARCHITECTURE.md shared worker utilities table
- Update CLAUDE.md migration list (now shows all 7 migrations, was only showing 4)
- Add tags tables to database schema summaries in both CLAUDE.md and ARCHITECTURE.md

## Test plan
- [x] Verify all documentation renders correctly in markdown preview
- [x] Confirm schema matches actual `api/database.py` definitions
- [x] Confirm migration list matches `migrations/versions/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)