### PR TITLE
Add mobile-responsive custom video player controls (#227 Phase 1)

### DIFF
--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -362,6 +362,11 @@
             background: rgba(59, 130, 246, 0.5);
         }
 
+        /* Hidden state for buttons */
+        .player-btn.hidden {
+            display: none !important;
+        }
+
         /* Progress container */
         .player-progress-container {
             flex: 1;
@@ -602,10 +607,12 @@
                         id="player"
                         preload="auto"
                         playsinline
+                        controls
                         :poster="video?.thumbnail_url"
+                        :aria-label="video?.title"
                     >
                     </video>
-                    <!-- Custom controls are injected by VLogPlayerControls -->
+                    <!-- Custom controls are injected by VLogPlayerControls (native controls removed on init) -->
                 </div>
             </div>
 
@@ -758,7 +765,6 @@
                 analytics: null,
                 hls: null,
                 hlsLevels: [],
-                selectedQuality: '-1',
                 captionsEnabled: false,
                 captionsTrack: null,
 
@@ -865,15 +871,30 @@
                         return;
                     }
 
-                    // Initialize custom player controls
-                    this.playerControls = new VLogPlayerControls(container, video, {
-                        onQualityChange: (index) => this.changeQuality(index),
-                        onCaptionsToggle: () => this.toggleCaptions()
-                    });
+                    // Initialize custom player controls with fallback to native controls
+                    try {
+                        if (window.VLogPlayerControls) {
+                            // Remove native controls as custom controls are available
+                            video.removeAttribute('controls');
+                            this.playerControls = new VLogPlayerControls(container, video, {
+                                onQualityChange: (index) => this.changeQuality(index),
+                                onCaptionsToggle: () => this.toggleCaptions()
+                            });
 
-                    // Set captions availability
-                    if (this.video.captions_url) {
-                        this.playerControls.setCaptionsAvailable(true);
+                            // Set captions availability
+                            if (this.video.captions_url) {
+                                this.playerControls.setCaptionsAvailable(true);
+                            }
+                        } else {
+                            // Fallback: keep native controls if custom controls are unavailable
+                            console.warn('Custom player controls not available, using native controls');
+                            this.playerControls = null;
+                        }
+                    } catch (e) {
+                        // Fallback: re-enable native controls if custom controls initialization fails
+                        console.error('Failed to initialize custom player controls:', e);
+                        video.controls = true;
+                        this.playerControls = null;
                     }
 
                     // Initialize analytics
@@ -975,7 +996,7 @@
                             debugLog('Quality set to', targetLevel.height + 'p');
                         }
                     }
-                    this.selectedQuality = String(idx);
+                    // Note: selectedQuality state removed - player controls maintain their own quality state
                 }
             };
         }


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of issue #227 (Mobile-responsive player and PWA support), focusing on the mobile player improvements.

### Changes

- **Custom Control Bar**: Replaces native HTML5 video controls with a touch-optimized custom control bar
  - Play/pause button with loading state
  - Progress bar with draggable thumb and buffer visualization
  - Time display (current / duration)
  - Quality selector (modal on mobile, dropdown reference)
  - Captions toggle button
  - Picture-in-Picture button
  - Fullscreen button with orientation lock

- **Touch Gesture System**:
  - Double-tap left third → Skip back 10 seconds
  - Double-tap right third → Skip forward 10 seconds
  - Double-tap center → Toggle play/pause
  - Horizontal swipe → Seek with time preview
  - Vertical swipe (left side) → Adjust brightness (CSS filter)
  - Vertical swipe (right side) → Adjust volume
  - Single tap → Show/hide controls

- **Visual Feedback**:
  - Skip indicators with ripple animation
  - Center play/pause indicator
  - Volume/brightness adjustment bar
  - Seek preview tooltip
  - Loading spinner during buffering

- **Accessibility**:
  - Minimum 44x44px touch targets (Apple HIG)
  - Keyboard shortcuts: space/k (play/pause), arrows (seek/volume), f (fullscreen), m (mute), c (captions)
  - Auto-hide controls after 3 seconds

### Files Changed

- `web/public/static/js/player-controls.js` - New file (~850 lines)
- `web/public/watch.html` - Updated HTML structure and added CSS styles

### Browser Compatibility

| Feature | Chrome | Safari | Firefox | Edge |
|---------|--------|--------|---------|------|
| Custom Controls | ✅ | ✅ | ✅ | ✅ |
| Touch Gestures | ✅ | ✅ | ✅ | ✅ |
| PiP | ✅ | ✅ (different API) | ✅ | ✅ |
| Orientation Lock | ✅ | ❌ | ❌ | ✅ |
| CSS brightness filter | ✅ | ✅ | ✅ | ✅ |

### Test plan

- [ ] Test play/pause via click and keyboard
- [ ] Test seeking via progress bar drag
- [ ] Test double-tap skip on mobile (left/right/center)
- [ ] Test swipe gestures for seek, volume, brightness
- [ ] Test quality selector modal on mobile
- [ ] Test fullscreen with orientation lock
- [ ] Test Picture-in-Picture
- [ ] Test captions toggle
- [ ] Verify controls auto-hide after 3 seconds
- [ ] Test keyboard shortcuts on desktop

### Related Issue

Closes partially: #227 (Phase 1 only - future phases will add PWA features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)