### PR TITLE
Fix worker eviction and uploading status validation

### DIFF
--- a/api/worker_schemas.py
+++ b/api/worker_schemas.py
@@ -205,7 +205,7 @@ class ClaimJobResponse(BaseModel):
 # Progress updates
 class QualityProgressUpdate(BaseModel):
     name: str
-    status: str = Field(pattern="^(pending|in_progress|completed|uploaded|failed|skipped)$")
+    status: str = Field(pattern="^(pending|in_progress|uploading|completed|uploaded|failed|skipped)$")
     progress: int = Field(ge=0, le=100)
 
 

--- a/k8s/worker-deployment-intel.yaml
+++ b/k8s/worker-deployment-intel.yaml
@@ -125,7 +125,7 @@ spec:
       volumes:
       - name: work-dir
         emptyDir:
-          sizeLimit: 50Gi
+          sizeLimit: 150Gi
       # Host path for GPU device access
       - name: dri
         hostPath:


### PR DESCRIPTION
## Summary
- Increase Intel worker EmptyDir from 50Gi to 150Gi to handle large 4K videos (28GB+ source files were causing pod eviction)
- Add "uploading" to allowed QualityProgressUpdate status values to fix progress reporting during upload phase

## Test plan
- [x] Verified worker pod no longer gets evicted with large video files
- [x] Verified progress updates no longer fail during upload phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)