### PR TITLE
Add volume slider control to video player

### DIFF
--- a/web/public/static/js/player-controls.js
+++ b/web/public/static/js/player-controls.js
@@ -62,6 +62,7 @@ class VLogPlayerControls {
         this.createControlsUI();
         this.bindEvents();
         this.updatePlayPauseButton();
+        this.updateVolumeButton();
         this.updateTimeDisplay();
         this.showControls();
     }
@@ -154,14 +155,27 @@ class VLogPlayerControls {
             </div>
             <span class="player-time-display">0:00 / 0:00</span>
             <div class="player-controls-right">
-                <button class="player-btn volume-btn" title="Volume">
-                    <svg viewBox="0 0 24 24" fill="currentColor" class="volume-high">
-                        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
-                    </svg>
-                    <svg viewBox="0 0 24 24" fill="currentColor" class="volume-muted">
-                        <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/>
-                    </svg>
-                </button>
+                <div class="player-volume-container">
+                    <button class="player-btn volume-btn" title="Volume">
+                        <svg viewBox="0 0 24 24" fill="currentColor" class="volume-high">
+                            <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
+                        </svg>
+                        <svg viewBox="0 0 24 24" fill="currentColor" class="volume-low">
+                            <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/>
+                        </svg>
+                        <svg viewBox="0 0 24 24" fill="currentColor" class="volume-muted">
+                            <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/>
+                        </svg>
+                    </button>
+                    <div class="player-volume-slider-container">
+                        <div class="player-volume-slider">
+                            <div class="player-volume-track">
+                                <div class="player-volume-fill"></div>
+                                <div class="player-volume-thumb"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <button class="player-btn quality-btn" title="Quality">
                     <svg viewBox="0 0 24 24" fill="currentColor">
                         <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8 12H9.5v-2h-2v2H6V9h1.5v2.5h2V9H11v6zm7-1c0 .55-.45 1-1 1h-.75v1.5h-1.5V15H14c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v4zm-3.5-.5h2v-3h-2v3z"/>
@@ -211,7 +225,13 @@ class VLogPlayerControls {
         this.progressThumb = this.controlBar.querySelector('.player-progress-thumb');
         this.progressTooltip = this.controlBar.querySelector('.player-progress-tooltip');
         this.timeDisplay = this.controlBar.querySelector('.player-time-display');
+        this.volumeContainer = this.controlBar.querySelector('.player-volume-container');
         this.volumeBtn = this.controlBar.querySelector('.volume-btn');
+        this.volumeSliderContainer = this.controlBar.querySelector('.player-volume-slider-container');
+        this.volumeSlider = this.controlBar.querySelector('.player-volume-slider');
+        this.volumeTrack = this.controlBar.querySelector('.player-volume-track');
+        this.volumeFill = this.controlBar.querySelector('.player-volume-fill');
+        this.volumeThumb = this.controlBar.querySelector('.player-volume-thumb');
         this.qualityBtn = this.controlBar.querySelector('.quality-btn');
         this.qualityLabel = this.qualityBtn.querySelector('.quality-label');
         this.captionsBtn = this.controlBar.querySelector('.captions-btn');
@@ -274,6 +294,13 @@ class VLogPlayerControls {
             e.stopPropagation();
             this.toggleMute();
         });
+
+        // Volume slider interaction
+        this.volumeSlider.addEventListener('mousedown', (e) => this.startVolumeSeek(e));
+        this.volumeSlider.addEventListener('touchstart', (e) => {
+            e.stopPropagation();
+            this.startVolumeSeek(e);
+        }, { passive: false });
         this.qualityBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             this.showQualityModal();
@@ -470,7 +497,51 @@ class VLogPlayerControls {
 
     updateVolumeButton() {
         const muted = this.video.muted || this.video.volume === 0;
+        const volume = this.video.muted ? 0 : this.video.volume;
+
+        // Update icon based on volume level
         this.volumeBtn.classList.toggle('muted', muted);
+        this.volumeBtn.classList.toggle('low', !muted && volume > 0 && volume < 0.5);
+        this.volumeBtn.classList.toggle('high', !muted && volume >= 0.5);
+
+        // Update slider fill
+        this.updateVolumeSlider(volume);
+    }
+
+    updateVolumeSlider(volume) {
+        const percent = volume * 100;
+        this.volumeFill.style.width = `${percent}%`;
+        this.volumeThumb.style.left = `${percent}%`;
+    }
+
+    startVolumeSeek(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.updateVolumeFromEvent(e);
+
+        const onMove = (moveEvent) => {
+            this.updateVolumeFromEvent(moveEvent);
+        };
+
+        const onEnd = () => {
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onEnd);
+            document.removeEventListener('touchmove', onMove);
+            document.removeEventListener('touchend', onEnd);
+        };
+
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onEnd);
+        document.addEventListener('touchmove', onMove, { passive: false });
+        document.addEventListener('touchend', onEnd);
+    }
+
+    updateVolumeFromEvent(e) {
+        const rect = this.volumeTrack.getBoundingClientRect();
+        const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+        let percent = (clientX - rect.left) / rect.width;
+        percent = Math.max(0, Math.min(1, percent));
+        this.setVolume(percent);
     }
 
     setVolume(value) {

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -316,16 +316,95 @@
         }
 
         /* Volume button icons */
+        .volume-btn .volume-low,
         .volume-btn .volume-muted {
             display: none;
         }
 
-        .volume-btn.muted .volume-high {
+        .volume-btn.muted .volume-high,
+        .volume-btn.muted .volume-low {
             display: none;
         }
 
         .volume-btn.muted .volume-muted {
             display: block;
+        }
+
+        .volume-btn.low .volume-high,
+        .volume-btn.low .volume-muted {
+            display: none;
+        }
+
+        .volume-btn.low .volume-low {
+            display: block;
+        }
+
+        /* Volume container and slider */
+        .player-volume-container {
+            display: flex;
+            align-items: center;
+            position: relative;
+        }
+
+        .player-volume-slider-container {
+            width: 0;
+            overflow: hidden;
+            transition: width 0.2s ease;
+        }
+
+        .player-volume-container:hover .player-volume-slider-container,
+        .player-volume-container:focus-within .player-volume-slider-container {
+            width: 80px;
+        }
+
+        .player-volume-slider {
+            width: 80px;
+            height: 44px;
+            display: flex;
+            align-items: center;
+            padding: 0 8px;
+            cursor: pointer;
+        }
+
+        .player-volume-track {
+            position: relative;
+            width: 100%;
+            height: 4px;
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 2px;
+        }
+
+        .player-volume-slider:hover .player-volume-track {
+            height: 6px;
+        }
+
+        .player-volume-fill {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            background: white;
+            border-radius: 2px;
+            pointer-events: none;
+        }
+
+        .player-volume-thumb {
+            position: absolute;
+            top: 50%;
+            left: 100%;
+            width: 12px;
+            height: 12px;
+            background: white;
+            border-radius: 50%;
+            transform: translate(-50%, -50%);
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            pointer-events: none;
+        }
+
+        .player-volume-slider:hover .player-volume-thumb {
+            opacity: 1;
         }
 
         /* Fullscreen button icons */
@@ -569,6 +648,20 @@
                 left: 50%;
                 right: auto;
                 transform: translate(-50%, -50%);
+            }
+
+            /* Volume slider - always visible on mobile since no hover */
+            .player-volume-slider-container {
+                width: 60px;
+            }
+
+            .player-volume-slider {
+                width: 60px;
+                padding: 0 4px;
+            }
+
+            .player-volume-thumb {
+                opacity: 1;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- Add horizontal volume slider that expands on hover over the volume button
- Volume button now shows 3 states: muted, low (< 50%), and high (>= 50%)
- Mobile-responsive: slider always visible on mobile since touch has no hover

## Test plan
- [ ] Hover over volume button on desktop - slider should expand
- [ ] Click/drag slider to adjust volume
- [ ] Verify volume icon changes based on level (muted/low/high)
- [ ] Test on mobile - slider should be visible without hover
- [ ] Verify mute button still toggles mute/unmute

🤖 Generated with [Claude Code](https://claude.com/claude-code)