### PR TITLE
Fix pub/sub publishing errors logged at DEBUG level

### DIFF
--- a/api/pubsub.py
+++ b/api/pubsub.py
@@ -93,7 +93,7 @@ class Publisher:
             await redis.publish(channel_name("progress", "all"), payload)
             return True
         except Exception as e:
-            logger.debug(f"Failed to publish progress: {e}")
+            logger.warning(f"Failed to publish progress: {e}")
             return False
 
     @staticmethod
@@ -144,7 +144,7 @@ class Publisher:
             await redis.publish(channel_name("workers", "status"), json.dumps(message))
             return True
         except Exception as e:
-            logger.debug(f"Failed to publish worker status: {e}")
+            logger.warning(f"Failed to publish worker status: {e}")
             return False
 
     @staticmethod
@@ -196,7 +196,7 @@ class Publisher:
             await redis.publish(channel_name("progress", "all"), payload)
             return True
         except Exception as e:
-            logger.debug(f"Failed to publish job completion: {e}")
+            logger.warning(f"Failed to publish job completion: {e}")
             return False
 
     @staticmethod
@@ -253,7 +253,7 @@ class Publisher:
             await redis.publish(channel_name("progress", "all"), payload)
             return True
         except Exception as e:
-            logger.debug(f"Failed to publish job failure: {e}")
+            logger.warning(f"Failed to publish job failure: {e}")
             return False
 
 


### PR DESCRIPTION
## Summary
- Change exception logging in all `Publisher` methods from DEBUG to WARNING level
- Ensures Redis publishing failures are visible in production logs where DEBUG is typically disabled

## Changes
Updated 4 methods in `api/pubsub.py`:
- `publish_progress`
- `publish_worker_status`
- `publish_job_completed`
- `publish_job_failed`

Fixes #337

## Test plan
- [x] All existing tests pass (1010 tests)
- [x] Ruff linting passes
- [ ] Verify warnings appear in production logs when Redis is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)