### PR TITLE
Add NetworkPolicy for K8s worker pods

### DIFF
--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -12,6 +12,9 @@
 # does NOT enforce NetworkPolicy without a compatible CNI.
 #
 # Verify your CNI supports NetworkPolicy before relying on this.
+#
+# CONFIGURATION REQUIRED: You must customize the Worker API egress rule
+# below to match your deployment. See comments for options.
 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -38,39 +41,37 @@ spec:
 
   egress:
     # Allow DNS resolution (required for external API URLs)
-    # CoreDNS/kube-dns runs in kube-system namespace
+    # Targets the kube-system namespace where CoreDNS/kube-dns runs
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
-        - podSelector:
-            matchLabels:
-              k8s-app: kube-dns
       ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
 
-    # Allow egress to Worker API
-    # Option 1: If Worker API runs externally (outside cluster)
-    # This allows egress to any external IP on port 9002
-    # For stricter security, replace with specific CIDR blocks
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            # Exclude private networks if API is only accessible externally
-            # Uncomment to restrict to public IPs only:
-            # except:
-            #   - 10.0.0.0/8
-            #   - 172.16.0.0/12
-            #   - 192.168.0.0/16
-      ports:
-        - protocol: TCP
-          port: 9002
-
-    # Option 2: If Worker API runs in-cluster (uncomment and customize)
-    # Replace the ipBlock rule above with this for in-cluster API:
+    # =========================================================================
+    # WORKER API EGRESS - CONFIGURATION REQUIRED
+    # =========================================================================
+    # Uncomment ONE of the options below based on your deployment:
+    #
+    # Option A: Worker API runs externally (specific IP/CIDR)
+    # Replace the CIDR with your Worker API server's IP address or range.
+    # Example: 192.168.1.100/32 for a single host, or 10.0.0.0/24 for a subnet
+    #
+    # - to:
+    #     - ipBlock:
+    #         cidr: 192.168.1.100/32  # REPLACE with your Worker API IP/CIDR
+    #   ports:
+    #     - protocol: TCP
+    #       port: 9002
+    #
+    # Option B: Worker API runs in-cluster
+    # Use this if the Worker API is deployed as a Kubernetes service.
+    # Adjust the namespace and labels to match your API deployment.
+    #
     # - to:
     #     - namespaceSelector:
     #         matchLabels:
@@ -83,11 +84,31 @@ spec:
     #     - protocol: TCP
     #       port: 9002
 
-    # Optional: Allow Redis access for job queue
-    # Uncomment if using Redis for instant job dispatch
+    # =========================================================================
+    # REDIS EGRESS - OPTIONAL
+    # =========================================================================
+    # Uncomment ONE of the options below if using Redis for instant job dispatch.
+    #
+    # Option A: Redis runs in-cluster
+    # Adjust the namespace and labels to match your Redis deployment.
+    #
+    # - to:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: vlog
+    #       podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: redis
+    #   ports:
+    #     - protocol: TCP
+    #       port: 6379
+    #
+    # Option B: Redis is external (specific IP/CIDR)
+    # Replace the CIDR with your Redis server's IP address or range.
+    #
     # - to:
     #     - ipBlock:
-    #         cidr: 0.0.0.0/0
+    #         cidr: 192.168.1.101/32  # REPLACE with your Redis IP/CIDR
     #   ports:
     #     - protocol: TCP
     #       port: 6379


### PR DESCRIPTION
## Summary
- Add `k8s/networkpolicy.yaml` to restrict network access for worker pods
- Deny all ingress (workers don't need incoming connections)
- Allow egress only to Worker API (port 9002) and DNS (port 53)
- Include commented options for Redis egress and in-cluster API selector
- Update `k8s/README.md` with Network Security documentation

## Security Impact
This policy limits the blast radius if a worker pod is compromised by preventing:
- Access to other services in the cluster
- Data exfiltration to arbitrary external endpoints
- Internal network scanning

## Test plan
- [ ] Verify NetworkPolicy YAML is valid: `kubectl apply --dry-run=client -f k8s/networkpolicy.yaml`
- [ ] Deploy policy and confirm workers can still claim jobs and upload results
- [ ] Confirm workers cannot reach unauthorized endpoints (if using a CNI that supports NetworkPolicy)

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)