### PR TITLE
Show "Original" instead of duplicate resolution in quality selector

### DIFF
--- a/web/public/static/js/player-controls.js
+++ b/web/public/static/js/player-controls.js
@@ -594,7 +594,8 @@ class VLogPlayerControls {
         if (this.currentQualityIndex === -1) {
             this.qualityLabel.textContent = 'Auto';
         } else if (this.qualities && this.qualities[this.currentQualityIndex]) {
-            this.qualityLabel.textContent = this.qualities[this.currentQualityIndex].height + 'p';
+            const level = this.qualities[this.currentQualityIndex];
+            this.qualityLabel.textContent = level.isOriginal ? 'Original' : level.height + 'p';
         }
     }
 
@@ -616,7 +617,7 @@ class VLogPlayerControls {
         this.qualities.forEach((level, index) => {
             const option = document.createElement('button');
             option.className = 'quality-option' + (index === this.currentQualityIndex ? ' active' : '');
-            option.textContent = level.height + 'p';
+            option.textContent = level.isOriginal ? 'Original' : level.height + 'p';
             option.addEventListener('click', () => {
                 this.selectQuality(index);
             });

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -927,6 +927,22 @@
                             debugLog('HLS manifest parsed, levels:', data.levels);
                             // Populate quality levels for selector (sorted by height descending)
                             this.hlsLevels = data.levels.slice().sort((a, b) => b.height - a.height);
+
+                            // Mark the original quality: highest bitrate at max resolution
+                            // The "original" is a remux of the source, so it has the highest bitrate
+                            // at the source resolution (which is the max height in the list)
+                            if (this.hlsLevels.length > 0) {
+                                const maxHeight = this.hlsLevels[0].height;
+                                const levelsAtMaxHeight = this.hlsLevels.filter(l => l.height === maxHeight);
+                                if (levelsAtMaxHeight.length > 1) {
+                                    // Multiple levels at max resolution - highest bitrate is original
+                                    const original = levelsAtMaxHeight.reduce((a, b) =>
+                                        (a.bitrate || 0) > (b.bitrate || 0) ? a : b
+                                    );
+                                    original.isOriginal = true;
+                                }
+                            }
+
                             // Update custom player controls with quality levels
                             if (this.playerControls) {
                                 this.playerControls.setQualities(this.hlsLevels, -1);


### PR DESCRIPTION
## Summary
- Fixed confusing UX where original and transcoded qualities at the same resolution both showed the same label (e.g., "1080p" appearing twice)
- Now displays "Original" for the remuxed source quality, making it clear which is which
- Original quality identified by highest bitrate at max resolution

## Test plan
- [ ] Open a video that has both original and transcoded qualities at the same resolution
- [ ] Open the quality selector dropdown
- [ ] Verify "Original" appears instead of a duplicate resolution label
- [ ] Select "Original" quality and verify it switches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)