### PR TITLE
Fix issues #343, #335, #344: database index, HLS tests, FFmpeg refactor

### DIFF
--- a/migrations/versions/010_add_claim_search_index.py
+++ b/migrations/versions/010_add_claim_search_index.py
@@ -14,7 +14,7 @@ This migration adds a compound index to optimize these queries.
 
 Revision ID: 010
 Revises: 009
-Create Date: 2024-12-21
+Create Date: 2025-12-21
 """
 
 from alembic import op
@@ -32,14 +32,14 @@ def upgrade():
     # The transcoding_jobs table is queried with:
     # - claimed_at IS NULL (unclaimed jobs)
     # - completed_at IS NULL (incomplete jobs)
-    # - ORDER BY started_at/created_at (via videos.created_at in join)
+    # - ORDER BY videos.created_at (in the joined query, not transcoding_jobs)
     #
-    # Note: The actual claim query joins with videos table for status check,
-    # but having an index on transcoding_jobs columns helps filter quickly.
+    # Note: The actual claim query joins with videos table for status check
+    # and ordering. This index helps filter transcoding_jobs rows quickly.
     op.create_index(
         "ix_transcoding_jobs_claim_search",
         "transcoding_jobs",
-        ["claimed_at", "completed_at", "started_at"],
+        ["claimed_at", "completed_at"],
         postgresql_where="claimed_at IS NULL AND completed_at IS NULL",
     )
 

--- a/tests/test_hls_serving.py
+++ b/tests/test_hls_serving.py
@@ -96,7 +96,7 @@ class TestHLSStaticFiles:
         """Test that .ts segments return video/mp2t MIME type (not TypeScript)."""
         response = hls_client.get("/videos/test-video/1080p_0000.ts")
         assert response.status_code == 200
-        # CRITICAL: Must be video/mp2t, NOT video/mp2t or text/vnd.qt.linguist
+        # CRITICAL: Must be video/mp2t, NOT text/typescript or text/vnd.qt.linguist
         assert response.headers["content-type"] == "video/mp2t"
 
     def test_ts_segment_has_long_cache(self, hls_client):

--- a/worker/transcoder.py
+++ b/worker/transcoder.py
@@ -351,6 +351,7 @@ async def run_ffmpeg_with_progress(
                             if progress_callback:
                                 await progress_callback(progress)
                 except (ValueError, IndexError):
+                    # Ignore malformed progress lines - continue reading ffmpeg output
                     pass
 
     async def drain_and_wait():


### PR DESCRIPTION
## Summary

- **#343**: Add compound index for job claiming queries - improves performance for the common job claim query pattern in worker_api
- **#335**: Add comprehensive tests for HLS video file serving (17 new tests covering content types, caching, path traversal security, range requests)
- **#344**: Extract common FFmpeg logic to reduce code duplication - new `run_ffmpeg_with_progress` helper eliminates ~120 lines of duplicated code

## Changes

### Database Migration (Issue #343)
- New migration `010_add_claim_search_index.py`
- Creates partial compound index on `transcoding_jobs(claimed_at, completed_at, started_at)`
- Index only includes rows where `claimed_at IS NULL AND completed_at IS NULL`

### HLS Tests (Issue #335)
- New test file `tests/test_hls_serving.py` with 17 tests
- Verifies `.ts` files return `video/mp2t` (not TypeScript MIME type)
- Verifies `.m3u8` files return `application/vnd.apple.mpegurl`
- Tests caching headers (no-cache for playlists, long cache for segments)
- Security tests for path traversal attacks (both plain and URL-encoded)
- Tests for HTTP range request support

### FFmpeg Refactor (Issue #344)
- Added `run_ffmpeg_with_progress()` helper function in `worker/transcoder.py`
- Refactored `transcode_quality_with_progress()` and `create_original_quality()` to use the helper
- Net reduction of 18 lines, eliminates ~120 lines of duplicated FFmpeg process handling code

## Test plan
- [x] All 1040 tests pass (2 skipped, 5 warnings)
- [x] Linting passes with ruff
- [ ] CI checks pass

Fixes #343
Fixes #335
Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)