### PR TITLE
Add client-side watermark overlay support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,10 @@ migrations/
 
 **Rate limiting**: Configurable per-endpoint rate limits using slowapi. Supports memory or Redis storage.
 
+**Watermark overlay**: Client-side watermark displayed on the video player (does not modify video files). Two types available:
+- **Image watermark**: Set `VLOG_WATERMARK_TYPE=image` and `VLOG_WATERMARK_IMAGE=watermark.png`. Upload via Admin API (`POST /api/settings/watermark/upload`) or place directly in NAS storage. Supports PNG (with transparency), JPEG, WebP, SVG, GIF.
+- **Text watermark**: Set `VLOG_WATERMARK_TYPE=text` and `VLOG_WATERMARK_TEXT="© 2025 MyBrand"`. Configure font size with `VLOG_WATERMARK_TEXT_SIZE` and color with `VLOG_WATERMARK_TEXT_COLOR`.
+
 **Database migrations**: Schema changes are managed by Alembic. New databases get all tables via `python api/database.py`. Existing databases being upgraded should first run `python api/database.py stamp 001` to mark current state, then future migrations apply normally.
 
 **Distributed transcoding**: Remote workers register via Worker API and receive API keys. Workers poll for jobs, claim them atomically, download source files via HTTP, transcode locally, and upload HLS output as tar.gz. Progress updates are sent to the API and visible in the admin UI.
@@ -285,6 +289,7 @@ When running multiple API instances (e.g., behind a load balancer):
   - Redis: `VLOG_REDIS_URL` (empty = disabled), `VLOG_JOB_QUEUE_MODE` (database, redis, hybrid), `VLOG_REDIS_POOL_SIZE` (default: 10)
   - SSE: `VLOG_SSE_HEARTBEAT_INTERVAL` (default: 30s), `VLOG_SSE_RECONNECT_TIMEOUT_MS` (default: 3000)
   - Alerting: `VLOG_ALERT_WEBHOOK_URL` (empty = disabled), `VLOG_ALERT_WEBHOOK_TIMEOUT` (default: 10s), `VLOG_ALERT_RATE_LIMIT_SECONDS` (default: 300)
+  - Watermark: `VLOG_WATERMARK_ENABLED` (default: false), `VLOG_WATERMARK_TYPE` (image or text), `VLOG_WATERMARK_IMAGE` (path for image type), `VLOG_WATERMARK_TEXT` (text content for text type), `VLOG_WATERMARK_TEXT_SIZE` (8-72px, default: 16), `VLOG_WATERMARK_TEXT_COLOR` (CSS color, default: white), `VLOG_WATERMARK_POSITION` (top-left, top-right, bottom-left, bottom-right, center), `VLOG_WATERMARK_OPACITY` (0.0-1.0, default: 0.5), `VLOG_WATERMARK_PADDING` (pixels, default: 16), `VLOG_WATERMARK_MAX_WIDTH_PERCENT` (1-50, default: 15, for images only)
 - NAS mount: Configure your NAS share in `/etc/fstab` to mount at `/mnt/nas`
 - systemd services: Located in `systemd/` folder, use venv Python with security hardening
 - Package installed in development mode: `pip install -e .` makes `vlog` CLI available

--- a/api/audit.py
+++ b/api/audit.py
@@ -71,6 +71,9 @@ class AuditAction(str, Enum):
     WORKER_ENABLE = "worker_enable"
     WORKER_DELETE = "worker_delete"
 
+    # Settings actions
+    SETTINGS_CHANGE = "settings_change"
+
 
 class AuditLogger:
     """

--- a/config.py
+++ b/config.py
@@ -381,3 +381,27 @@ ALERT_WEBHOOK_TIMEOUT = get_int_env("VLOG_ALERT_WEBHOOK_TIMEOUT", 10, min_val=1)
 # Minimum interval between alerts for the same event type (seconds)
 # Prevents alert flooding when multiple jobs fail in quick succession
 ALERT_RATE_LIMIT_SECONDS = get_int_env("VLOG_ALERT_RATE_LIMIT_SECONDS", 300, min_val=0)
+
+# Watermark Configuration (client-side overlay, does not modify video files)
+# Enable/disable watermark overlay on video player
+WATERMARK_ENABLED = os.getenv("VLOG_WATERMARK_ENABLED", "false").lower() in ("true", "1", "yes")
+# Watermark type: "image" or "text"
+WATERMARK_TYPE = os.getenv("VLOG_WATERMARK_TYPE", "image")
+# Path to watermark image (relative to NAS_STORAGE, e.g., "watermark.png")
+# Only used when WATERMARK_TYPE is "image"
+WATERMARK_IMAGE = os.getenv("VLOG_WATERMARK_IMAGE", "")
+# Text to display as watermark (e.g., "© 2025 MyBrand" or "Example.com")
+# Only used when WATERMARK_TYPE is "text"
+WATERMARK_TEXT = os.getenv("VLOG_WATERMARK_TEXT", "")
+# Text watermark font size in pixels (default: 16)
+WATERMARK_TEXT_SIZE = get_int_env("VLOG_WATERMARK_TEXT_SIZE", 16, min_val=8, max_val=72)
+# Text watermark color (CSS color value, e.g., "white", "#ffffff", "rgba(255,255,255,0.8)")
+WATERMARK_TEXT_COLOR = os.getenv("VLOG_WATERMARK_TEXT_COLOR", "white")
+# Position: top-left, top-right, bottom-left, bottom-right, center
+WATERMARK_POSITION = os.getenv("VLOG_WATERMARK_POSITION", "bottom-right")
+# Opacity: 0.0 (invisible) to 1.0 (fully opaque)
+WATERMARK_OPACITY = get_float_env("VLOG_WATERMARK_OPACITY", 0.5, min_val=0.0, max_val=1.0)
+# Padding from edge in pixels
+WATERMARK_PADDING = get_int_env("VLOG_WATERMARK_PADDING", 16, min_val=0)
+# Maximum width as percentage of video player (keeps watermark proportional, for images only)
+WATERMARK_MAX_WIDTH_PERCENT = get_int_env("VLOG_WATERMARK_MAX_WIDTH_PERCENT", 15, min_val=1, max_val=50)

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -18,6 +18,41 @@
             height: 100%;
             background: #000;
         }
+
+        /* Watermark overlay */
+        .player-watermark {
+            position: absolute;
+            z-index: 15;
+            pointer-events: none;
+            user-select: none;
+            -webkit-user-drag: none;
+        }
+        .player-watermark img {
+            display: block;
+            height: auto;
+        }
+        .player-watermark-text {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-weight: 500;
+            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+            white-space: nowrap;
+        }
+        .player-watermark.top-left { top: var(--watermark-padding); left: var(--watermark-padding); }
+        .player-watermark.top-right { top: var(--watermark-padding); right: var(--watermark-padding); }
+        .player-watermark.bottom-left { bottom: calc(var(--watermark-padding) + 60px); left: var(--watermark-padding); }
+        .player-watermark.bottom-right { bottom: calc(var(--watermark-padding) + 60px); right: var(--watermark-padding); }
+        .player-watermark.center {
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+        /* Hide watermark when controls are visible to avoid overlap */
+        .player-container.controls-visible .player-watermark.bottom-left,
+        .player-container.controls-visible .player-watermark.bottom-right {
+            opacity: 0.3;
+            transition: opacity 0.3s ease;
+        }
+
         /* Caption styling */
         #player::cue {
             background: rgba(0, 0, 0, 0.8);
@@ -714,6 +749,34 @@
                         :aria-label="video?.title"
                     >
                     </video>
+                    <!-- Watermark overlay (loaded dynamically if enabled) -->
+                    <template x-if="watermark?.enabled && watermark?.type === 'image'">
+                        <div
+                            class="player-watermark"
+                            :class="watermark?.position"
+                            :style="`--watermark-padding: ${watermark?.padding || 16}px; opacity: ${watermark?.opacity || 0.5};`"
+                        >
+                            <img
+                                :src="watermark?.image_url"
+                                :style="`max-width: ${watermark?.max_width_percent || 15}%;`"
+                                alt=""
+                                draggable="false"
+                            >
+                        </div>
+                    </template>
+                    <template x-if="watermark?.enabled && watermark?.type === 'text'">
+                        <div
+                            class="player-watermark"
+                            :class="watermark?.position"
+                            :style="`--watermark-padding: ${watermark?.padding || 16}px; opacity: ${watermark?.opacity || 0.5};`"
+                        >
+                            <span
+                                class="player-watermark-text"
+                                :style="`font-size: ${watermark?.text_size || 16}px; color: ${watermark?.text_color || 'white'};`"
+                                x-text="watermark?.text"
+                            ></span>
+                        </div>
+                    </template>
                     <!-- Custom controls are injected by VLogPlayerControls (native controls removed on init) -->
                 </div>
             </div>
@@ -869,8 +932,12 @@
                 hlsLevels: [],
                 captionsEnabled: false,
                 captionsTrack: null,
+                watermark: null,
 
                 async init() {
+                    // Fetch watermark config (non-blocking)
+                    this.loadWatermarkConfig();
+
                     const slug = window.location.pathname.split('/').pop();
                     if (!slug) {
                         this.error = 'Video not found';
@@ -901,6 +968,18 @@
                     } catch (e) {
                         this.error = e.message;
                         this.loading = false;
+                    }
+                },
+
+                async loadWatermarkConfig() {
+                    try {
+                        const res = await VLogUtils.fetchWithTimeout('/api/config/watermark', {}, 5000);
+                        if (res.ok) {
+                            this.watermark = await res.json();
+                        }
+                    } catch (e) {
+                        // Watermark is optional, don't show errors
+                        debugLog('Failed to load watermark config:', e);
                     }
                 },
 


### PR DESCRIPTION
## Summary
- Implements watermark feature from issue #220 with client-side CSS overlay (does not modify video files)
- Supports both **image watermarks** (logo overlay) and **text watermarks** (custom text)
- Configurable position, opacity, padding, and styling via environment variables

## Features

### Image Watermark
```bash
export VLOG_WATERMARK_ENABLED=true
export VLOG_WATERMARK_TYPE=image
export VLOG_WATERMARK_IMAGE=watermark.png
```

### Text Watermark
```bash
export VLOG_WATERMARK_ENABLED=true
export VLOG_WATERMARK_TYPE=text
export VLOG_WATERMARK_TEXT="© 2025 MyBrand"
export VLOG_WATERMARK_TEXT_SIZE=16
export VLOG_WATERMARK_TEXT_COLOR=white
```

### Position Options
- `top-left`, `top-right`, `bottom-left`, `bottom-right`, `center`
- Auto-fades when player controls are visible (for bottom watermarks)

## API Endpoints

**Public API:**
- `GET /api/config/watermark` - Returns watermark config for player

**Admin API:**
- `GET /api/settings/watermark` - Get current watermark configuration
- `GET /api/settings/watermark/image` - Serve watermark image preview
- `POST /api/settings/watermark/upload` - Upload watermark image
- `DELETE /api/settings/watermark` - Delete watermark image

## Test plan
- [ ] Enable image watermark with test logo, verify overlay appears on video player
- [ ] Enable text watermark, verify text appears with correct styling
- [ ] Test all 5 position options
- [ ] Verify watermark fades when player controls appear (bottom positions)
- [ ] Test watermark upload via Admin API
- [ ] CI tests pass

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)