### PR TITLE
Fix DateTime timezone=True consistency in migration 001

### DIFF
--- a/migrations/versions/001_initial_schema.py
+++ b/migrations/versions/001_initial_schema.py
@@ -29,7 +29,7 @@ def upgrade() -> None:
         sa.Column("name", sa.String(100), nullable=False),
         sa.Column("slug", sa.String(100), unique=True, nullable=False),
         sa.Column("description", sa.Text, server_default=""),
-        sa.Column("created_at", sa.DateTime),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
     )
 
     # Videos table
@@ -45,9 +45,9 @@ def upgrade() -> None:
         sa.Column("source_height", sa.Integer, server_default="0"),
         sa.Column("status", sa.String(20), server_default="pending"),
         sa.Column("error_message", sa.Text, nullable=True),
-        sa.Column("created_at", sa.DateTime),
-        sa.Column("published_at", sa.DateTime, nullable=True),
-        sa.Column("deleted_at", sa.DateTime, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True)),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
     )
     op.create_index("ix_videos_status", "videos", ["status"])
     op.create_index("ix_videos_category_id", "videos", ["category_id"])
@@ -71,8 +71,8 @@ def upgrade() -> None:
         "viewers",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("session_id", sa.String(64), unique=True, nullable=False),
-        sa.Column("first_seen", sa.DateTime),
-        sa.Column("last_seen", sa.DateTime),
+        sa.Column("first_seen", sa.DateTime(timezone=True)),
+        sa.Column("last_seen", sa.DateTime(timezone=True)),
     )
 
     # Playback sessions table (analytics)
@@ -82,8 +82,8 @@ def upgrade() -> None:
         sa.Column("video_id", sa.Integer, sa.ForeignKey("videos.id", ondelete="CASCADE"), nullable=False),
         sa.Column("viewer_id", sa.Integer, sa.ForeignKey("viewers.id", ondelete="SET NULL"), nullable=True),
         sa.Column("session_token", sa.String(64), unique=True, nullable=False),
-        sa.Column("started_at", sa.DateTime),
-        sa.Column("ended_at", sa.DateTime, nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True)),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("duration_watched", sa.Float, server_default="0"),
         sa.Column("max_position", sa.Float, server_default="0"),
         sa.Column("quality_used", sa.String(10), nullable=True),
@@ -101,9 +101,9 @@ def upgrade() -> None:
         sa.Column("worker_id", sa.String(36), nullable=True),
         sa.Column("current_step", sa.String(50), nullable=True),
         sa.Column("progress_percent", sa.Integer, server_default="0"),
-        sa.Column("started_at", sa.DateTime, nullable=True),
-        sa.Column("last_checkpoint", sa.DateTime, nullable=True),
-        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_checkpoint", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("attempt_number", sa.Integer, server_default="1"),
         sa.Column("max_attempts", sa.Integer, server_default="3"),
         sa.Column("last_error", sa.Text, nullable=True),
@@ -119,8 +119,8 @@ def upgrade() -> None:
         sa.Column("segments_total", sa.Integer, nullable=True),
         sa.Column("segments_completed", sa.Integer, server_default="0"),
         sa.Column("progress_percent", sa.Integer, server_default="0"),
-        sa.Column("started_at", sa.DateTime, nullable=True),
-        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("error_message", sa.Text, nullable=True),
         sa.UniqueConstraint("job_id", "quality", name="uq_job_quality"),
     )
@@ -132,8 +132,8 @@ def upgrade() -> None:
         sa.Column("video_id", sa.Integer, sa.ForeignKey("videos.id", ondelete="CASCADE"), nullable=False, unique=True),
         sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
         sa.Column("language", sa.String(10), server_default="en"),
-        sa.Column("started_at", sa.DateTime, nullable=True),
-        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("duration_seconds", sa.Float, nullable=True),
         sa.Column("transcript_text", sa.Text, nullable=True),
         sa.Column("vtt_path", sa.String(255), nullable=True),


### PR DESCRIPTION
## Summary
- Updates migration 001 to use `sa.DateTime(timezone=True)` for all DateTime columns, matching the ORM definitions in `database.py`
- Fixes inconsistency where migration used `sa.DateTime` (naive) but ORM used `sa.DateTime(timezone=True)` (aware)
- Prevents potential timezone bugs when comparing dates between SQLite/PostgreSQL instances

## Test plan
- [ ] CI tests pass
- [ ] Verify new databases created with this migration have timezone-aware DateTime columns
- [ ] Existing databases are unaffected (only affects new schema creation)

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)