### PR TITLE
Add HTTP health server for K8s worker liveness/readiness probes

### DIFF
--- a/config.py
+++ b/config.py
@@ -235,6 +235,9 @@ WORKER_POLL_INTERVAL = get_int_env("VLOG_WORKER_POLL_INTERVAL", 10, min_val=1)
 WORKER_WORK_DIR = Path(os.getenv("VLOG_WORKER_WORK_DIR", "/tmp/vlog-worker"))
 WORKER_OFFLINE_THRESHOLD_MINUTES = get_int_env("VLOG_WORKER_OFFLINE_THRESHOLD", 5, min_val=1)
 
+# Worker health check server port (for K8s liveness/readiness probes)
+WORKER_HEALTH_PORT = get_int_env("VLOG_WORKER_HEALTH_PORT", 8080, min_val=1, max_val=65535)
+
 # How often to check for stale jobs from offline workers (in seconds)
 STALE_JOB_CHECK_INTERVAL = get_int_env("VLOG_STALE_JOB_CHECK_INTERVAL", 60, min_val=1)
 

--- a/k8s/worker-deployment-intel.yaml
+++ b/k8s/worker-deployment-intel.yaml
@@ -89,28 +89,26 @@ spec:
         - name: dri
           mountPath: /dev/dri
 
-        # Liveness probe
+        # Liveness probe - worker process is alive
+        # Checks /health endpoint on built-in health server (port 8080)
         livenessProbe:
-          exec:
-            command:
-            - python3
-            - -c
-            - "import sys; sys.exit(0)"
+          httpGet:
+            path: /health
+            port: 8080
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
-        # Readiness probe
+        # Readiness probe - worker can accept jobs
+        # Checks /ready endpoint which verifies API connection and FFmpeg availability
         readinessProbe:
-          exec:
-            command:
-            - python3
-            - -c
-            - "import sys; sys.exit(0)"
-          initialDelaySeconds: 10
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
           periodSeconds: 30
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
         # Security context

--- a/k8s/worker-deployment-nvidia.yaml
+++ b/k8s/worker-deployment-nvidia.yaml
@@ -84,28 +84,26 @@ spec:
         - name: work-dir
           mountPath: /tmp/vlog-worker
 
-        # Liveness probe
+        # Liveness probe - worker process is alive
+        # Checks /health endpoint on built-in health server (port 8080)
         livenessProbe:
-          exec:
-            command:
-            - python3
-            - -c
-            - "import sys; sys.exit(0)"
+          httpGet:
+            path: /health
+            port: 8080
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
-        # Readiness probe
+        # Readiness probe - worker can accept jobs
+        # Checks /ready endpoint which verifies API connection and FFmpeg availability
         readinessProbe:
-          exec:
-            command:
-            - python3
-            - -c
-            - "import sys; sys.exit(0)"
-          initialDelaySeconds: 10
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
           periodSeconds: 30
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
         # Security context

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -64,28 +64,26 @@ spec:
         - name: work-dir
           mountPath: /tmp/vlog-worker
 
-        # Liveness probe - worker is alive
+        # Liveness probe - worker process is alive
+        # Checks /health endpoint on built-in health server (port 8080)
         livenessProbe:
-          exec:
-            command:
-            - python
-            - -c
-            - "import sys; sys.exit(0)"
+          httpGet:
+            path: /health
+            port: 8080
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
         # Readiness probe - worker can accept jobs
+        # Checks /ready endpoint which verifies API connection and FFmpeg availability
         readinessProbe:
-          exec:
-            command:
-            - python
-            - -c
-            - "import sys; sys.exit(0)"
-          initialDelaySeconds: 10
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
           periodSeconds: 30
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
 
         # Security context for container

--- a/worker/health_server.py
+++ b/worker/health_server.py
@@ -1,0 +1,144 @@
+"""
+Health check HTTP server for remote transcoding workers.
+
+Provides Kubernetes-compatible health endpoints:
+- /health (liveness): Process is running
+- /ready (readiness): Worker can accept jobs (API connected, FFmpeg available)
+
+Runs on port 8080 by default (configurable via VLOG_WORKER_HEALTH_PORT).
+"""
+
+import asyncio
+import shutil
+from http import HTTPStatus
+from typing import Callable, Optional
+
+from config import WORKER_API_URL
+
+# Default health check port
+DEFAULT_HEALTH_PORT = 8080
+
+
+class HealthServer:
+    """Simple async HTTP health server for worker liveness/readiness probes."""
+
+    def __init__(
+        self,
+        port: int = DEFAULT_HEALTH_PORT,
+        api_check_fn: Optional[Callable[[], bool]] = None,
+    ):
+        """
+        Initialize health server.
+
+        Args:
+            port: Port to listen on (default: 8080)
+            api_check_fn: Optional callback that returns True if API is connected
+        """
+        self.port = port
+        self.api_check_fn = api_check_fn
+        self._server: Optional[asyncio.Server] = None
+        self._is_ready = False
+        self._last_heartbeat_ok = False
+
+    def set_ready(self, ready: bool):
+        """Set readiness state (called after successful API connection)."""
+        self._is_ready = ready
+
+    def set_heartbeat_status(self, ok: bool):
+        """Update heartbeat status (called after each heartbeat)."""
+        self._last_heartbeat_ok = ok
+
+    async def _check_ffmpeg(self) -> bool:
+        """Check if FFmpeg is available."""
+        return shutil.which("ffmpeg") is not None
+
+    async def _handle_request(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        """Handle incoming HTTP request."""
+        try:
+            # Read request line
+            request_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            request_text = request_line.decode("utf-8", errors="replace")
+
+            # Parse path from request
+            parts = request_text.split()
+            path = parts[1] if len(parts) > 1 else "/"
+
+            # Drain remaining headers (we don't need them)
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+                if line == b"\r\n" or line == b"\n" or line == b"":
+                    break
+
+            # Handle endpoints
+            if path == "/health":
+                # Liveness check - just verify process is running
+                status = HTTPStatus.OK
+                body = '{"status": "alive"}'
+            elif path == "/ready":
+                # Readiness check - verify worker can accept jobs
+                checks = {
+                    "ffmpeg": await self._check_ffmpeg(),
+                    "api_connected": self._is_ready and self._last_heartbeat_ok,
+                }
+                all_ok = all(checks.values())
+                status = HTTPStatus.OK if all_ok else HTTPStatus.SERVICE_UNAVAILABLE
+                body = (
+                    f'{{"status": "ready", "checks": {{"ffmpeg": {str(checks["ffmpeg"]).lower()}, '
+                    f'"api_connected": {str(checks["api_connected"]).lower()}}}}}'
+                )
+            elif path == "/":
+                # Root endpoint with basic info
+                status = HTTPStatus.OK
+                body = f'{{"service": "vlog-worker", "api_url": "{WORKER_API_URL}"}}'
+            else:
+                status = HTTPStatus.NOT_FOUND
+                body = '{"error": "not found"}'
+
+            # Send response
+            response = (
+                f"HTTP/1.1 {status.value} {status.phrase}\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                f"Connection: close\r\n"
+                f"\r\n"
+                f"{body}"
+            )
+            writer.write(response.encode())
+            await writer.drain()
+
+        except asyncio.TimeoutError:
+            pass
+        except Exception:
+            # Return 500 on any error
+            error_response = (
+                "HTTP/1.1 500 Internal Server Error\r\n"
+                "Content-Type: application/json\r\n"
+                "Content-Length: 25\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+                '{"error": "server error"}'
+            )
+            writer.write(error_response.encode())
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def start(self):
+        """Start the health server."""
+        self._server = await asyncio.start_server(
+            self._handle_request, "0.0.0.0", self.port
+        )
+        print(f"  Health server listening on port {self.port}")
+
+    async def stop(self):
+        """Stop the health server."""
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None


### PR DESCRIPTION
## Summary
- Adds a built-in HTTP health server to remote transcoder workers (port 8080)
- Provides proper liveness (`/health`) and readiness (`/ready`) endpoints
- Readiness checks verify FFmpeg availability and API connection status
- Updates all K8s deployments to use `httpGet` probes instead of weak `exec` probes

## Problem
The existing health probes only checked if Python could be imported:
```yaml
livenessProbe:
  exec:
    command:
    - python
    - -c
    - "import sys; sys.exit(0)"
```

This meant pods could be marked as ready while:
- Worker couldn't connect to the Worker API
- FFmpeg was missing or broken
- Worker was in a broken state

## Solution
New HTTP health server provides meaningful health checks:
- `/health`: Returns 200 if process is alive (liveness)
- `/ready`: Returns 200 only if FFmpeg is available AND API is connected (readiness)

K8s deployments now use:
```yaml
livenessProbe:
  httpGet:
    path: /health
    port: 8080

readinessProbe:
  httpGet:
    path: /ready
    port: 8080
```

## Configuration
New env var: `VLOG_WORKER_HEALTH_PORT` (default: 8080)

## Test plan
- [ ] CI tests pass
- [ ] Verify health server starts with worker: `curl http://localhost:8080/health`
- [ ] Verify readiness endpoint: `curl http://localhost:8080/ready`
- [ ] Deploy to K8s and verify probe behavior

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)