### PR TITLE
Add CSRF protection to admin forms

### DIFF
--- a/web/admin/index.html
+++ b/web/admin/index.html
@@ -1671,23 +1671,24 @@ VLOG_WATERMARK_PADDING=16  # pixels from edge</pre>
                 // Note: Authentication is now via HTTP-only cookies (set by /api/auth/login)
                 // Cookies are sent automatically with same-origin requests
                 // CSRF token is included for state-changing requests (POST, PUT, DELETE, PATCH)
-                async apiFetch(url, options = {}, timeoutMs = 30000) {
+                // If CSRF validation fails, automatically refreshes token and retries once
+                async apiFetch(url, options = {}, timeoutMs = 30000, _isRetry = false) {
+                    // Clone options to avoid mutating the original
+                    const fetchOptions = { ...options, headers: { ...options.headers } };
+
                     // Add CSRF token header for state-changing requests
-                    const method = (options.method || 'GET').toUpperCase();
+                    const method = (fetchOptions.method || 'GET').toUpperCase();
                     const csrfMethods = ['POST', 'PUT', 'DELETE', 'PATCH'];
                     if (csrfMethods.includes(method) && this.csrfToken) {
-                        options.headers = {
-                            ...options.headers,
-                            'X-CSRF-Token': this.csrfToken
-                        };
+                        fetchOptions.headers['X-CSRF-Token'] = this.csrfToken;
                     }
 
                     const response = await VLogUtils.fetchWithTimeout(url, {
-                        ...options,
+                        ...fetchOptions,
                         credentials: 'same-origin',  // Ensure cookies are sent
                     }, timeoutMs);
 
-                    // Handle auth errors (including CSRF failures which return 403)
+                    // Handle auth errors
                     if (response.status === 401) {
                         this.authRequired = true;
                         this.isAuthenticated = false;
@@ -1699,9 +1700,13 @@ VLOG_WATERMARK_PADDING=16  # pixels from edge</pre>
                     if (response.status === 403) {
                         const data = await response.clone().json().catch(() => ({}));
                         if (data.detail && data.detail.includes('CSRF')) {
-                            // CSRF token might be stale, try to refresh it
-                            await this.fetchCsrfToken();
-                            throw new Error('CSRF validation failed. Please try again.');
+                            // CSRF token might be stale - refresh and retry once
+                            if (!_isRetry) {
+                                await this.fetchCsrfToken();
+                                return this.apiFetch(url, options, timeoutMs, true);
+                            }
+                            // Already retried, give up
+                            throw new Error('CSRF validation failed');
                         }
                         this.authRequired = true;
                         this.isAuthenticated = false;


### PR DESCRIPTION
## Summary
- Implements defense-in-depth CSRF protection for the admin API (Closes #336)
- CSRF tokens are derived from session tokens using HMAC (no database changes needed)
- State-changing requests (POST/PUT/DELETE/PATCH) require valid CSRF token when using cookie auth
- API clients using X-Admin-Secret header bypass CSRF (not vulnerable to CSRF)

## Changes

**Server-side (`api/admin.py`):**
- Add `generate_csrf_token()` and `validate_csrf_token()` functions using HMAC
- Add `/api/auth/csrf-token` endpoint to retrieve CSRF token for authenticated sessions
- Modify `AdminAuthMiddleware` to validate CSRF tokens on state-changing requests
- Return 403 with clear message when CSRF validation fails

**Client-side (`web/admin/index.html`):**
- Add `csrfToken` property to Alpine.js state
- Add `fetchCsrfToken()` to retrieve token from server
- Call `fetchCsrfToken()` after login and on init
- Modify `apiFetch()` to include `X-CSRF-Token` header for POST/PUT/DELETE/PATCH
- Update XHR uploads (video, reupload, watermark) to include CSRF header
- Clear token on logout

**Tests (`tests/test_admin_api.py`):**
- 7 new tests covering all CSRF scenarios:
  - Token endpoint returns valid token for authenticated sessions
  - Token endpoint requires authentication
  - POST without CSRF fails with 403
  - POST with valid CSRF succeeds
  - POST with wrong CSRF fails
  - GET without CSRF succeeds (not required)
  - X-Admin-Secret auth bypasses CSRF

## Test plan
- [x] All existing admin API tests pass (117 passed)
- [x] All new CSRF tests pass (7 passed)
- [x] Ruff linting passes
- [ ] Manual testing: login, upload video, create category, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)