### PR TITLE
Add Kubernetes security hardening (Issue #414, PR #2)

### DIFF
--- a/Dockerfile.worker-cpu-only
+++ b/Dockerfile.worker-cpu-only
@@ -54,9 +54,10 @@ RUN echo "$VERSION" > /build/VERSION
 # =============================================================================
 FROM python:${PYTHON_VERSION} AS runtime
 
-# Install FFmpeg
+# Install FFmpeg and curl (for health checks)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
@@ -90,9 +91,13 @@ ENV VLOG_WORKER_API_URL=http://vlog-worker-api:9002 \
     VLOG_WORKER_POLL_INTERVAL=10 \
     PYTHONUNBUFFERED=1
 
-# Health check - verify worker module can be imported
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD python -c "from worker import remote_transcoder; print('ok')" || exit 1
+# Health check - verify worker's health server is responding
+# The worker exposes /health on port 8080 which verifies:
+# - Worker process is alive
+# - API connection is working
+# - FFmpeg is available
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
 
 # Run the remote transcoder
 CMD ["python", "-m", "worker.remote_transcoder"]

--- a/Dockerfile.worker.gpu
+++ b/Dockerfile.worker.gpu
@@ -78,11 +78,12 @@ RUN dnf install -y epel-release && \
         https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-10.noarch.rpm && \
     dnf clean all
 
-# Install FFmpeg with hardware acceleration support
+# Install FFmpeg with hardware acceleration support and curl for health checks
 # RPM Fusion's FFmpeg 7.1.2 includes nvenc, vaapi, and qsv encoders
 RUN dnf install -y \
     ffmpeg \
     ffmpeg-libs \
+    curl \
     && dnf clean all
 
 # Install Intel VAAPI driver for Arc/Battlemage support
@@ -138,9 +139,13 @@ ENV VLOG_WORKER_API_URL=http://vlog-worker-api:9002 \
     # Python settings
     PYTHONUNBUFFERED=1
 
-# Health check - verify worker module can be imported
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD python3 -c "from worker import remote_transcoder; print('ok')" || exit 1
+# Health check - verify worker's health server is responding
+# The worker exposes /health on port 8080 which verifies:
+# - Worker process is alive
+# - API connection is working
+# - FFmpeg is available (including GPU codecs)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
 
 # Run the remote transcoder
 CMD ["python3", "-m", "worker.remote_transcoder"]

--- a/k8s/cleanup-cronjob.yaml
+++ b/k8s/cleanup-cronjob.yaml
@@ -16,9 +16,17 @@ spec:
         spec:
           serviceAccountName: pod-cleanup
           restartPolicy: OnFailure
+          # Security context for the pod
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: cleanup
-            image: bitnami/kubectl:latest
+            # Pin kubectl version to match cluster version
+            # Update this when upgrading Kubernetes
+            image: bitnami/kubectl:1.31
             command:
             - /bin/sh
             - -c

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -55,23 +55,31 @@ spec:
     # =========================================================================
     # WORKER API EGRESS - CONFIGURATION REQUIRED
     # =========================================================================
-    # Uncomment ONE of the options below based on your deployment:
+    # Workers need to communicate with the Worker API for job polling,
+    # status updates, and file uploads. Configure this based on your deployment.
     #
-    # Option A: Worker API runs externally (specific IP/CIDR)
+    # OPTION A (enabled below): External Worker API with specific IP/CIDR
     # Replace the CIDR with your Worker API server's IP address or range.
-    # Example: 192.168.1.100/32 for a single host, or 10.0.0.0/24 for a subnet
+    # Examples:
+    #   - 192.168.1.100/32  (single host)
+    #   - 10.0.0.0/24       (entire subnet)
+    #   - 10.0.1.1/32       (your VLog server)
     #
-    # - to:
-    #     - ipBlock:
-    #         cidr: 192.168.1.100/32  # REPLACE with your Worker API IP/CIDR
-    #   ports:
-    #     - protocol: TCP
-    #       port: 9002
-    #
-    # Option B: Worker API runs in-cluster
-    # Use this if the Worker API is deployed as a Kubernetes service.
-    # Adjust the namespace and labels to match your API deployment.
-    #
+    - to:
+        - ipBlock:
+            # REQUIRED: Replace with your Worker API server IP/CIDR
+            cidr: 10.0.0.0/8  # Default: Allow entire private 10.x.x.x range
+            # Optionally exclude specific IPs within the range:
+            # except:
+            #   - 10.0.0.1/32
+      ports:
+        - protocol: TCP
+          port: 9002  # Worker API port
+        - protocol: TCP
+          port: 443   # HTTPS (if using TLS)
+
+    # OPTION B (commented): In-cluster Worker API
+    # Use this instead of Option A if the Worker API runs as a K8s service.
     # - to:
     #     - namespaceSelector:
     #         matchLabels:
@@ -85,13 +93,21 @@ spec:
     #       port: 9002
 
     # =========================================================================
-    # REDIS EGRESS - OPTIONAL
+    # REDIS EGRESS - OPTIONAL (for instant job dispatch)
     # =========================================================================
-    # Uncomment ONE of the options below if using Redis for instant job dispatch.
+    # Enable this if using Redis pub/sub for real-time job notifications.
+    # Without Redis, workers poll the API periodically (still works, just slower).
     #
-    # Option A: Redis runs in-cluster
-    # Adjust the namespace and labels to match your Redis deployment.
-    #
+    # OPTION A (enabled below): External Redis with specific IP/CIDR
+    - to:
+        - ipBlock:
+            # Replace with your Redis server IP/CIDR (or comment out if not using Redis)
+            cidr: 10.0.0.0/8  # Default: Allow entire private 10.x.x.x range
+      ports:
+        - protocol: TCP
+          port: 6379  # Redis default port
+
+    # OPTION B (commented): In-cluster Redis
     # - to:
     #     - namespaceSelector:
     #         matchLabels:
@@ -102,13 +118,18 @@ spec:
     #   ports:
     #     - protocol: TCP
     #       port: 6379
-    #
-    # Option B: Redis is external (specific IP/CIDR)
-    # Replace the CIDR with your Redis server's IP address or range.
+
+    # =========================================================================
+    # NFS/SMB STORAGE EGRESS - OPTIONAL (for NAS storage)
+    # =========================================================================
+    # If workers access video storage over NFS or SMB, enable this.
+    # Note: hostPath volumes don't require network egress.
     #
     # - to:
     #     - ipBlock:
-    #         cidr: 192.168.1.101/32  # REPLACE with your Redis IP/CIDR
+    #         cidr: 10.0.0.0/8  # Replace with your NAS IP/CIDR
     #   ports:
     #     - protocol: TCP
-    #       port: 6379
+    #       port: 2049  # NFS
+    #     - protocol: TCP
+    #       port: 445   # SMB

--- a/k8s/worker-deployment-intel.yaml
+++ b/k8s/worker-deployment-intel.yaml
@@ -5,8 +5,8 @@
 # 1. Intel GPU device plugin installed (intel/intel-device-plugins-for-kubernetes)
 # 2. Nodes labeled with intel.feature.node.kubernetes.io/gpu=true
 # 3. Build and push GPU worker image:
-#    docker build -f Dockerfile.worker.gpu -t your-registry/vlog-worker-gpu:latest .
-#    docker push your-registry/vlog-worker-gpu:latest
+#    docker build -f Dockerfile.worker.gpu -t your-registry/vlog-worker-gpu:v1.0.0 .
+#    docker push your-registry/vlog-worker-gpu:v1.0.0
 # 4. Create the secret with your API key (see secret.yaml)
 # 5. Update the ConfigMap with your API URL (see configmap.yaml)
 
@@ -41,6 +41,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 44  # video group
+        seccompProfile:
+          type: RuntimeDefault
 
       containers:
       - name: worker

--- a/k8s/worker-deployment-nvidia.yaml
+++ b/k8s/worker-deployment-nvidia.yaml
@@ -5,8 +5,8 @@
 # 1. NVIDIA GPU Operator installed on cluster
 # 2. Nodes labeled with nvidia.com/gpu.present=true
 # 3. Build and push GPU worker image:
-#    docker build -f Dockerfile.worker.gpu -t your-registry/vlog-worker-gpu:latest .
-#    docker push your-registry/vlog-worker-gpu:latest
+#    docker build -f Dockerfile.worker.gpu -t your-registry/vlog-worker-gpu:v1.0.0 .
+#    docker push your-registry/vlog-worker-gpu:v1.0.0
 # 4. Create the secret with your API key (see secret.yaml)
 # 5. Update the ConfigMap with your API URL (see configmap.yaml)
 
@@ -42,12 +42,15 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
 
       containers:
       - name: worker
         # GPU-enabled worker image
-        image: vlog-worker-gpu:latest
-        imagePullPolicy: Always
+        # IMPORTANT: Always use specific version tags, never use 'latest'
+        image: vlog-worker-gpu:v1.0.0
+        imagePullPolicy: IfNotPresent
 
         # Load environment from ConfigMap and Secret
         envFrom:

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -3,9 +3,9 @@
 #
 # Prerequisites:
 # 1. Build and push worker image to your registry:
-#    docker build -f Dockerfile.worker -t your-registry/vlog-worker:latest .
-#    docker push your-registry/vlog-worker:latest
-# 2. Update the image reference below
+#    docker build -f Dockerfile.worker-cpu-only -t your-registry/vlog-worker:v1.0.0 .
+#    docker push your-registry/vlog-worker:v1.0.0
+# 2. Update the image reference below to match your version tag
 # 3. Create the secret with your API key (see secret.yaml)
 # 4. Update the ConfigMap with your API URL (see configmap.yaml)
 
@@ -35,12 +35,15 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
 
       containers:
       - name: worker
-        # Update this to your container registry
-        image: vlog-worker:latest
-        imagePullPolicy: Always
+        # Update this to your container registry and version tag
+        # IMPORTANT: Always use specific version tags, never use 'latest'
+        image: vlog-worker:v1.0.0
+        imagePullPolicy: IfNotPresent
 
         # Load environment from ConfigMap and Secret
         envFrom:


### PR DESCRIPTION
## Summary

This PR addresses medium-priority security items from the infrastructure review (Issue #414). It's the second of three planned PRs for this issue.

### Changes

**K8s Manifest Security:**
- Pin Docker image versions (remove `latest` tags) for reproducible deployments
- Add `seccompProfile: RuntimeDefault` to all pod security contexts for syscall filtering
- Update `imagePullPolicy` from `Always` to `IfNotPresent` for pinned versions
- Pin `bitnami/kubectl` to version 1.31 in cleanup CronJob
- Add security context to cleanup CronJob pod

**Docker Health Check Improvements:**
- Replace basic Python import check with `curl` to `/health` endpoint
- Health check now verifies the actual worker health server (port 8080)
- Increased `start-period` from 30s to 60s to allow worker initialization
- Added `curl` package to both Dockerfiles

**NetworkPolicy Egress Rules:**
- Enable egress rules for Worker API (ports 9002, 443)
- Enable egress rules for Redis (port 6379) for instant job dispatch
- Add commented example for NFS/SMB storage egress
- Default to `10.0.0.0/8` CIDR (users should customize for their network)
- Clear documentation for both external and in-cluster service options

### Files Changed
- `Dockerfile.worker-cpu-only` - Added curl, improved health check
- `Dockerfile.worker.gpu` - Added curl, improved health check
- `k8s/worker-deployment.yaml` - Pinned image, added seccompProfile
- `k8s/worker-deployment-intel.yaml` - Added seccompProfile
- `k8s/worker-deployment-nvidia.yaml` - Pinned image, added seccompProfile
- `k8s/cleanup-cronjob.yaml` - Pinned image, added security context
- `k8s/networkpolicy.yaml` - Enabled egress rules with documentation

### Issue #414 Progress
- [x] PR #1: Add security scanning to CI/CD (Trivy) - Merged as PR #422
- [x] **PR #2: Kubernetes Security Hardening** (this PR)
- [ ] PR #3: Operational Improvements (backups, observability, log rotation)

## Test plan
- [ ] Verify K8s manifests apply cleanly: `kubectl apply -f k8s/ --dry-run=client`
- [ ] Build Docker images with new health checks
- [ ] Verify health endpoint is checked correctly in container logs
- [ ] Test NetworkPolicy allows required egress traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)