### PR TITLE
Security: Fix unsafe tar.extractall() in re-encode upload (Issue #430)

### DIFF
--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -2164,7 +2164,7 @@ async def upload_reencode_result(
             await extract_tar_async(
                 tmp_path,
                 temp_dir,
-                allowed_extensions=(".m3u8", ".ts", ".m4s", ".mp4", ".mpd", ".jpg", ".vtt"),
+                allowed_extensions=(".m3u8", ".ts", ".m4s", ".mp4", ".mpd", ".jpg", ".png", ".vtt"),
                 max_files=MAX_HLS_ARCHIVE_FILES,
                 max_size=MAX_HLS_ARCHIVE_SIZE,
                 max_single_file=MAX_HLS_SINGLE_FILE_SIZE,


### PR DESCRIPTION
## Summary

Fixes a **critical** path traversal vulnerability (CWE-22, CVE-2007-4559) in tar extraction.

### Changes

**1. API endpoint fix** (`api/worker_api.py`)
- Replaced vulnerable `tar.extractall()` in `/api/reencode/{job_id}/upload` with secure `extract_tar_async()`
- Added `.png` to allowed extensions (supports existing PNG thumbnails during re-encoding)

**2. Worker fix** (`worker/remote_transcoder.py`) - Defense-in-depth
- Added `extract_tar_secure()` function with same protections
- Replaced vulnerable extraction in `try_process_reencode_job()`

### Security Protections Applied

Both fixes provide:
- **File extension allowlisting** - Only permitted file types
- **Path traversal validation** - Rejects `..` in paths and absolute paths  
- **Symlink/hardlink detection** - Prevents file access attacks
- **Archive limits** - File count, total size, per-file size limits
- **Permission normalization** - Sets safe permissions (0o644/0o755)

### Risk Assessment

| Location | Risk Before | Risk After |
|----------|-------------|------------|
| API `/api/reencode/{job_id}/upload` | **Critical** - Internet-facing, arbitrary file write | Fixed |
| Worker `try_process_reencode_job()` | Medium - Requires server compromise first | Fixed (defense-in-depth) |

## Test plan

- [x] Ruff linting passes
- [x] Both modules import successfully
- [x] Related unit tests pass
- [ ] CI tests pass

## References

- Closes #430
- CWE-22: Path Traversal
- CVE-2007-4559: Python tarfile vulnerability

🤖 Generated with [Claude Code](https://claude.com/claude-code)