### PR TITLE
Fix: settings API response unwrapping in admin UI

### DIFF
--- a/web/admin/src/api/endpoints/settings.ts
+++ b/web/admin/src/api/endpoints/settings.ts
@@ -9,6 +9,16 @@ import type {
   SettingsExportResponse,
 } from '../types';
 
+// Response types matching backend schemas
+interface SettingsByCategoryResponse {
+  categories: Record<string, SettingDefinition[]>;
+}
+
+interface SettingsCategoryResponse {
+  category: string;
+  settings: SettingDefinition[];
+}
+
 export const settingsApi = {
   // ===========================================================================
   // General Settings
@@ -18,7 +28,8 @@ export const settingsApi = {
    * Get all settings
    */
   async getAll(): Promise<Record<string, SettingDefinition[]>> {
-    return apiClient.fetch<Record<string, SettingDefinition[]>>('/api/settings');
+    const response = await apiClient.fetch<SettingsByCategoryResponse>('/api/settings');
+    return response.categories ?? {};
   },
 
   /**
@@ -32,7 +43,8 @@ export const settingsApi = {
    * Get settings for a specific category
    */
   async getCategory(category: string): Promise<SettingDefinition[]> {
-    return apiClient.fetch<SettingDefinition[]>(`/api/settings/category/${category}`);
+    const response = await apiClient.fetch<SettingsCategoryResponse>(`/api/settings/category/${category}`);
+    return response.settings ?? [];
   },
 
   /**


### PR DESCRIPTION
## Summary

Fixed settings tabs (CDN, Storage, Streaming, Transcoding, Transcription, Workers) not loading in admin UI.

Same issue as PR #469 - the backend returns wrapped responses but frontend expected direct values.

## Changes

| Endpoint | Backend Returns | Fix |
|----------|----------------|-----|
| `/api/settings` | `{ categories: {...} }` | Extract `.categories ?? {}` |
| `/api/settings/category/{cat}` | `{ category, settings: [...] }` | Extract `.settings ?? []` |

## Test plan

- [x] TypeScript type check passes
- [x] Build succeeds  
- [ ] Verify all settings tabs load in admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)