### PR TITLE
chore: make test workflow manual-only for PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,29 @@
 name: Tests
 
 on:
+  # Run automatically when merged to main/dev
   push:
     branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
+  # Manual trigger - use "Run workflow" button in GitHub Actions UI
+  workflow_dispatch:
+    inputs:
+      test_type:
+        description: 'Test type to run'
+        required: true
+        default: 'quick'
+        type: choice
+        options:
+          - quick
+          - full
 
 jobs:
   # Quick tests for dev branch - faster feedback
   test-quick:
     name: Quick Tests
     runs-on: self-hosted
-    if: github.base_ref == 'dev' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && inputs.test_type == 'quick')
 
     services:
       postgres:
@@ -84,7 +96,9 @@ jobs:
   test-full:
     name: Full Tests (PostgreSQL)
     runs-on: self-hosted
-    if: github.base_ref == 'main' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.test_type == 'full')
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

Changes the test workflow to not run automatically on every PR commit.

## Changes

- **Removed**: Automatic `pull_request` trigger
- **Added**: `workflow_dispatch` for manual runs with quick/full option
- **Kept**: Automatic runs on `push` to main/dev (when PRs are merged)

## How to run tests manually

1. Go to **Actions** tab
2. Select **Tests** workflow
3. Click **Run workflow**
4. Choose `quick` or `full` test suite
5. Click **Run workflow** button

## Behavior

| Event | Tests Run? |
|-------|-----------|
| PR opened/updated | ❌ No (manual only) |
| PR merged to dev | ✅ Quick tests |
| PR merged to main | ✅ Full tests |
| Manual trigger | ✅ Your choice |

🤖 Generated with [Claude Code](https://claude.com/claude-code)