### PR TITLE
Fix: reliability and security improvements

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -116,7 +116,6 @@ jobs:
           # - GHSA-34jh-p97f-mpxf: aiohttp CRLF injection - we don't use aiohttp client with untrusted URLs
           # Last reviewed: 2025-12-27
           pip-audit --ignore-vuln PYSEC-2024-87 --ignore-vuln GHSA-34jh-p97f-mpxf
-        continue-on-error: true
 
   security-summary:
     name: Security Scan Summary

--- a/config.py
+++ b/config.py
@@ -196,7 +196,14 @@ UPLOADS_DIR = NAS_STORAGE / os.getenv("VLOG_UPLOADS_SUBDIR", "uploads")
 ARCHIVE_DIR = NAS_STORAGE / os.getenv("VLOG_ARCHIVE_SUBDIR", "archive")
 # Database configuration - PostgreSQL is the default
 # Set VLOG_DATABASE_URL to override (e.g., for SQLite: sqlite:///./vlog.db)
-DATABASE_URL = os.getenv("VLOG_DATABASE_URL", "postgresql://vlog:vlog_password@localhost/vlog")
+# IMPORTANT: Always set VLOG_DATABASE_URL in production with a secure password
+_default_db_url = "postgresql://vlog@localhost/vlog"
+DATABASE_URL = os.getenv("VLOG_DATABASE_URL", _default_db_url)
+if DATABASE_URL == _default_db_url and not os.environ.get("VLOG_TEST_MODE"):
+    logger.warning(
+        "VLOG_DATABASE_URL not set - using default without password. "
+        "Set VLOG_DATABASE_URL with credentials for production use."
+    )
 
 # Legacy SQLite path (kept for migration scripts)
 DATABASE_PATH = Path(os.getenv("VLOG_DATABASE_PATH", str(BASE_DIR / "vlog.db")))


### PR DESCRIPTION
## Summary

This PR addresses four issues from the reliability and security reviews:

- **#447**: Remove `continue-on-error: true` from pip-audit CI step so new vulnerabilities fail the build
- **#434**: Remove hardcoded password from default `DATABASE_URL` and add warning log when not configured
- **#460**: Add deadlock detection limit to database retry logic - limits deadlock retries to 3 attempts and logs chronic deadlocks at ERROR level
- **#454**: Add exponential backoff to worker loop on API failures - prevents workers from hammering an overloaded API

## Changes

### CI: pip-audit now fails on new vulnerabilities
Previously, pip-audit had `continue-on-error: true` which allowed new vulnerabilities to pass unnoticed. Now the build will fail if new vulnerabilities are found.

### Config: Remove hardcoded password from DATABASE_URL
The default `DATABASE_URL` no longer contains a password. A warning is logged at startup if no custom URL is configured (except in test mode).

### Database retry: Deadlock detection limit
- New `is_deadlock_error()` function to detect PostgreSQL deadlocks specifically
- New `DeadlockError` exception for chronic deadlock conditions
- Limit deadlock retries to 3 (regardless of `max_retries` setting)
- Log at ERROR level after 2+ consecutive deadlocks

### Worker loop: Exponential backoff
- Track consecutive failures separately
- Apply exponential backoff: `poll_interval * (2 ** failures)`
- Cap maximum backoff at 5 minutes
- Reset failure counter on successful job completion

## Test plan
- [x] Existing database retry tests pass (31 tests)
- [x] Linting passes with ruff
- [ ] Verify CI runs successfully
- [ ] Test worker behavior with API unavailable (should see increasing backoff)

Closes #447, #434, #460, #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)