### PR TITLE
Phase 4: Player Improvements (Issue #413)

### DIFF
--- a/web/public/static/css/pages/player.css
+++ b/web/public/static/css/pages/player.css
@@ -958,6 +958,19 @@
     }
 }
 
+/* Screen reader only - visually hidden but accessible */
+.player-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Theater mode styles */
 .player-container.theater-mode {
     position: fixed;
@@ -969,12 +982,29 @@
     background: #000;
 }
 
-/* Theater mode body overlay */
+/* Theater mode body overlay - CSS :has() version (modern browsers) */
 body:has(.player-container.theater-mode) {
     overflow: hidden;
 }
 
 body:has(.player-container.theater-mode)::after {
+    content: '';
+    position: fixed;
+    top: 70vh;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 99;
+    pointer-events: none;
+}
+
+/* Theater mode body fallback - for browsers without :has() support */
+body.player-theater-active {
+    overflow: hidden;
+}
+
+body.player-theater-active::after {
     content: '';
     position: fixed;
     top: 70vh;


### PR DESCRIPTION
## Summary

This PR implements Phase 4 of the Public UI Design Overhaul (Issue #413), focusing on player improvements and enhanced user experience.

### Player Enhancements
- **Playback speed control (0.25x - 2x)**: New speed button with dropdown menu, keyboard shortcuts (Shift+< to slow down, Shift+> to speed up)
- **Theater mode toggle**: Expands player to 70% viewport height with dimmed background (T key)
- **Extended control visibility**: Increased timeout from 3s to 5s for better usability during interaction
- **Auto quality indicator**: Shows current resolution when in Auto mode (e.g., "1080p (Auto)")
- **Keyboard shortcut hints**: Button tooltips now show keyboard shortcuts
- **Keyboard shortcuts help dialog**: Press '?' to see all available shortcuts
- **Number key seeking**: Press 0-9 to jump to 0-90% of video

### Mobile Improvements
- Fixed time display sizing (13px instead of 11px for better readability)
- Improved control bar layout with proper flex-shrink behavior
- Hidden theater mode button on mobile (not useful on small screens)
- Centered modals on mobile screens

### Technical Changes
- Added Shaka Player 'adaptation' event listener for ABR quality tracking
- Added HLS.js LEVEL_SWITCHED event listener for quality display
- New CSS for speed modal, shortcuts modal, and theater mode styles

## Test Plan
- [ ] Verify playback speed control works with both Shaka Player and HLS.js
- [ ] Test theater mode toggle and Escape to exit
- [ ] Verify Auto quality shows current resolution when ABR switches
- [ ] Test all keyboard shortcuts (Space, K, M, F, T, P, C, ?, <, >, 0-9)
- [ ] Verify keyboard shortcuts help modal opens with '?'
- [ ] Test on mobile: control bar layout, modals centered, theater button hidden
- [ ] Verify time display is readable on mobile (13px)

Closes #413 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)