### PR TITLE
Add API versioning and OpenAPI documentation improvements (Issue #218)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,47 @@ VLOG_ADMIN_PORT=9001
 VLOG_ADMIN_SESSION_EXPIRY_HOURS=24
 
 # =============================================================================
+# API Versioning (Issue #218)
+# =============================================================================
+
+# Current API version (format: v1, v2, etc.)
+# All API routes will be available at /api/v1/*, /api/v2/*, etc.
+VLOG_API_VERSION=v1
+
+# Enable deprecation notices for older API versions
+# When enabled, deprecated versions include Deprecation and Sunset headers
+VLOG_API_DEPRECATION_NOTICE=true
+
+# Sunset date for deprecated API versions (RFC 5322 format)
+# Example: Sat, 01 Jan 2028 00:00:00 GMT
+# VLOG_API_DEPRECATION_SUNSET=
+
+# Include legacy unversioned routes (/api/videos) that alias to current version
+# Set to false to require explicit version in all API requests
+VLOG_API_INCLUDE_LEGACY_ROUTES=true
+
+# =============================================================================
+# OpenAPI Documentation
+# =============================================================================
+
+# OpenAPI documentation title
+VLOG_OPENAPI_TITLE=VLog API
+
+# OpenAPI documentation description
+VLOG_OPENAPI_DESCRIPTION=Self-hosted video platform API with versioned endpoints
+
+# Terms of service URL (optional)
+# VLOG_OPENAPI_TERMS_OF_SERVICE=https://example.com/terms
+
+# API contact information (optional)
+# VLOG_OPENAPI_CONTACT_NAME=API Support
+# VLOG_OPENAPI_CONTACT_EMAIL=api@example.com
+
+# API license information (optional)
+# VLOG_OPENAPI_LICENSE_NAME=MIT
+# VLOG_OPENAPI_LICENSE_URL=https://opensource.org/licenses/MIT
+
+# =============================================================================
 # Worker Settings
 # =============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -90,8 +90,9 @@ VLOG_API_VERSION=v1
 # When enabled, deprecated versions include Deprecation and Sunset headers
 VLOG_API_DEPRECATION_NOTICE=true
 
-# Sunset date for deprecated API versions (RFC 5322 format)
-# Example: Sat, 01 Jan 2028 00:00:00 GMT
+# Sunset date for deprecated API versions.
+# RFC 5322 format is recommended (e.g. Sat, 01 Jan 2028 00:00:00 GMT),
+# but any format supported by the HTTP Sunset header specification may be used.
 # VLOG_API_DEPRECATION_SUNSET=
 
 # Include legacy unversioned routes (/api/videos) that alias to current version

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -66,6 +66,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
           format: 'table'
+          trivyignores: '.trivyignore'
 
       - name: Run Trivy image scan (SARIF)
         uses: aquasecurity/trivy-action@0.33.1
@@ -76,6 +77,7 @@ jobs:
           exit-code: '0'
           format: 'sarif'
           output: 'trivy-image-results.sarif'
+          trivyignores: '.trivyignore'
 
       - name: Upload image scan results
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -115,8 +115,9 @@ jobs:
           # - PYSEC-2024-87: Jinja2 sandbox escape - not exploitable in our use case (no user templates)
           # - GHSA-34jh-p97f-mpxf: aiohttp CRLF injection - we don't use aiohttp client with untrusted URLs
           # - GHSA-qmgc-5h2g-mvrw: filelock TOCTOU - fix requires Python 3.10+, container image is patched
-          # Last reviewed: 2026-01-17
-          pip-audit --ignore-vuln PYSEC-2024-87 --ignore-vuln GHSA-34jh-p97f-mpxf --ignore-vuln GHSA-qmgc-5h2g-mvrw
+          # - GHSA-w853-jp5j-5j7f: filelock TOCTOU (CVE-2025-68146) - same as above, fix requires Python 3.10+
+          # Last reviewed: 2026-01-18
+          pip-audit --ignore-vuln PYSEC-2024-87 --ignore-vuln GHSA-34jh-p97f-mpxf --ignore-vuln GHSA-qmgc-5h2g-mvrw --ignore-vuln GHSA-w853-jp5j-5j7f
 
   security-summary:
     name: Security Scan Summary

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,10 @@
+# Trivy vulnerability ignores
+# Review quarterly with pip-audit ignores
+
+# GHSA-58pv-8j8x-9vj2: jaraco.context path traversal
+# Ignored for setuptools vendored copy only - the vendored package is used
+# internally by setuptools for its own operations, not exposed to user input.
+# Main jaraco-context package is upgraded to 6.1.0.
+# setuptools upstream has not yet updated their vendored copy.
+# Last reviewed: 2026-01-18
+GHSA-58pv-8j8x-9vj2

--- a/Dockerfile.worker.gpu
+++ b/Dockerfile.worker.gpu
@@ -75,7 +75,11 @@ COPY api/ api/
 COPY worker/ worker/
 COPY cli/ cli/
 
-RUN pip3 install --no-cache-dir --prefix=/install .
+RUN pip3 install --no-cache-dir --prefix=/install . && \
+    # Force upgrade security-patched packages after all deps are resolved
+    pip3 install --no-cache-dir --prefix=/install --upgrade \
+        "filelock>=3.20.3" \
+        "jaraco-context>=6.1.0"
 
 # =============================================================================
 # Stage 2: Runtime - Minimal production image

--- a/Dockerfile.worker.gpu
+++ b/Dockerfile.worker.gpu
@@ -75,11 +75,10 @@ COPY api/ api/
 COPY worker/ worker/
 COPY cli/ cli/
 
-RUN pip3 install --no-cache-dir --prefix=/install . && \
-    # Force upgrade security-patched packages after all deps are resolved
-    pip3 install --no-cache-dir --prefix=/install --upgrade \
-        "filelock>=3.20.3" \
-        "jaraco-context>=6.1.0"
+# Create constraints file for security-patched transitive dependencies
+RUN echo "filelock>=3.20.3" > /tmp/constraints.txt && \
+    echo "jaraco-context>=6.1.0" >> /tmp/constraints.txt && \
+    pip3 install --no-cache-dir --prefix=/install -c /tmp/constraints.txt .
 
 # =============================================================================
 # Stage 2: Runtime - Minimal production image

--- a/Dockerfile.worker.gpu
+++ b/Dockerfile.worker.gpu
@@ -125,6 +125,12 @@ WORKDIR /app
 # Copy installed Python packages from builder
 COPY --from=builder /install /usr/local
 
+# Ensure security-patched packages are at correct versions
+# (dnf-installed Python packages may have brought in older transitive deps)
+RUN pip3 install --no-cache-dir --upgrade \
+    "filelock>=3.20.3" \
+    "jaraco-context>=6.1.0"
+
 # Copy source code
 COPY --chown=vlog:vlog config.py ./
 COPY --chown=vlog:vlog code_version.py ./

--- a/api/admin.py
+++ b/api/admin.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import sqlalchemy as sa
-from fastapi import FastAPI, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, FastAPI, File, Form, HTTPException, Query, Request, Response, UploadFile
 from fastapi import Path as FastAPIPath
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
@@ -206,6 +206,10 @@ from api.settings_service import (
 )
 from api.worker_auth import authenticate_api_key
 from config import (
+    API_INCLUDE_LEGACY_ROUTES,
+    API_VERSION,
+    OPENAPI_DESCRIPTION,
+    OPENAPI_TITLE,
     ADMIN_API_SECRET,
     ADMIN_CORS_ALLOWED_ORIGINS,
     ADMIN_PORT,
@@ -241,6 +245,8 @@ from config import (
     check_deprecated_env_vars,
 )
 from worker.transcoder import generate_thumbnail, get_video_info
+
+from api.versioning import VersionHeaderMiddleware, configure_openapi_schema
 
 logger = logging.getLogger(__name__)
 
@@ -938,7 +944,15 @@ async def lifespan(app: FastAPI):
     await database.disconnect()
 
 
-app = FastAPI(title="VLog Admin", description="Video management API", lifespan=lifespan)
+app = FastAPI(
+    title=f"{OPENAPI_TITLE} Admin",
+    description=f"{OPENAPI_DESCRIPTION} - Admin API",
+    version=API_VERSION,
+    lifespan=lifespan,
+)
+
+# Create versioned API router for admin endpoints
+v1_router = APIRouter(tags=["Admin API v1"])
 
 # Register rate limiter with the app
 app.state.limiter = limiter
@@ -958,6 +972,7 @@ async def database_locked_handler(request: Request, exc: DatabaseLockedError):
 
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(RequestIDMiddleware)
+app.add_middleware(VersionHeaderMiddleware)
 
 # Admin API authentication middleware (see AdminAuthMiddleware class)
 # Only active when VLOG_ADMIN_API_SECRET is configured
@@ -1085,7 +1100,7 @@ async def metrics_endpoint(request: Request):
 # See: https://github.com/filthyrake/vlog/issues/324
 
 
-@app.post("/api/auth/login")
+@v1_router.post("/auth/login")
 @limiter.limit("10/minute")
 async def auth_login(request: Request, response: Response):
     """
@@ -1143,7 +1158,7 @@ async def auth_login(request: Request, response: Response):
     return {"authenticated": True, "message": "Login successful"}
 
 
-@app.post("/api/auth/logout")
+@v1_router.post("/auth/logout")
 async def auth_logout(request: Request, response: Response):
     """
     Log out and destroy the current session.
@@ -1173,7 +1188,7 @@ async def auth_logout(request: Request, response: Response):
     return {"authenticated": False, "message": "Logged out"}
 
 
-@app.get("/api/auth/check")
+@v1_router.get("/auth/check")
 async def auth_check(request: Request):
     """
     Check if the current session is authenticated.
@@ -1200,7 +1215,7 @@ async def auth_check(request: Request):
     return {"authenticated": False, "auth_required": True}
 
 
-@app.get("/api/auth/csrf-token")
+@v1_router.get("/auth/csrf-token")
 async def get_csrf_token(request: Request):
     """
     Get a CSRF token for the current session.
@@ -1233,7 +1248,7 @@ async def get_csrf_token(request: Request):
 # ============ Categories ============
 
 
-@app.get("/api/categories")
+@v1_router.get("/categories")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_categories(request: Request) -> List[CategoryResponse]:
     """List all categories."""
@@ -1259,7 +1274,7 @@ async def list_categories(request: Request) -> List[CategoryResponse]:
     ]
 
 
-@app.post("/api/categories")
+@v1_router.post("/categories")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_category(request: Request, data: CategoryCreate) -> CategoryResponse:
     """Create a new category."""
@@ -1299,7 +1314,7 @@ async def create_category(request: Request, data: CategoryCreate) -> CategoryRes
     )
 
 
-@app.delete("/api/categories/{category_id}")
+@v1_router.delete("/categories/{category_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_category(request: Request, category_id: int):
     """Delete a category."""
@@ -1331,7 +1346,7 @@ async def delete_category(request: Request, category_id: int):
 # ============ Tags ============
 
 
-@app.get("/api/tags")
+@v1_router.get("/tags")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_tags(request: Request) -> List[TagResponse]:
     """List all tags with video counts (including non-ready videos for admin)."""
@@ -1357,7 +1372,7 @@ async def list_tags(request: Request) -> List[TagResponse]:
     ]
 
 
-@app.post("/api/tags")
+@v1_router.post("/tags")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_tag(request: Request, data: TagCreate) -> TagResponse:
     """Create a new tag."""
@@ -1395,7 +1410,7 @@ async def create_tag(request: Request, data: TagCreate) -> TagResponse:
     )
 
 
-@app.put("/api/tags/{tag_id}")
+@v1_router.put("/tags/{tag_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_tag(request: Request, tag_id: int, data: TagUpdate) -> TagResponse:
     """Update a tag name."""
@@ -1442,7 +1457,7 @@ async def update_tag(request: Request, tag_id: int, data: TagUpdate) -> TagRespo
     )
 
 
-@app.delete("/api/tags/{tag_id}")
+@v1_router.delete("/tags/{tag_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_tag(request: Request, tag_id: int):
     """Delete a tag. Videos with this tag will have it removed."""
@@ -1475,7 +1490,7 @@ async def delete_tag(request: Request, tag_id: int):
 # ============ Videos ============
 
 
-@app.get("/api/videos")
+@v1_router.get("/videos")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_all_videos(
     request: Request,
@@ -1598,7 +1613,7 @@ async def list_all_videos(
     )
 
 
-@app.get("/api/videos/archived")
+@v1_router.get("/videos/archived")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_archived_videos(
     request: Request,
@@ -1638,7 +1653,7 @@ async def list_archived_videos(
     }
 
 
-@app.get("/api/videos/{video_id}")
+@v1_router.get("/videos/{video_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video(request: Request, video_id: int) -> VideoResponse:
     """Get video details."""
@@ -1703,7 +1718,7 @@ async def get_video(request: Request, video_id: int) -> VideoResponse:
     )
 
 
-@app.post("/api/videos")
+@v1_router.post("/videos")
 @limiter.limit(RATE_LIMIT_ADMIN_UPLOAD)
 async def upload_video(
     request: Request,
@@ -1890,7 +1905,7 @@ async def upload_video(
     }
 
 
-@app.put("/api/videos/{video_id}")
+@v1_router.put("/videos/{video_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_video(
     request: Request,
@@ -1963,7 +1978,7 @@ async def update_video(
     return {"status": "ok"}
 
 
-@app.post("/api/videos/{video_id}/publish")
+@v1_router.post("/videos/{video_id}/publish")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def publish_video(request: Request, video_id: int):
     """Publish a video (make it visible on the public site)."""
@@ -1994,7 +2009,7 @@ async def publish_video(request: Request, video_id: int):
     return {"status": "ok", "published": True}
 
 
-@app.post("/api/videos/{video_id}/unpublish")
+@v1_router.post("/videos/{video_id}/unpublish")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def unpublish_video(request: Request, video_id: int):
     """Unpublish a video (hide it from the public site)."""
@@ -2023,7 +2038,7 @@ async def unpublish_video(request: Request, video_id: int):
     return {"status": "ok", "published": False}
 
 
-@app.get("/api/videos/{video_id}/tags")
+@v1_router.get("/videos/{video_id}/tags")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_tags(request: Request, video_id: int) -> List[VideoTagInfo]:
     """Get all tags for a video."""
@@ -2043,7 +2058,7 @@ async def get_video_tags(request: Request, video_id: int) -> List[VideoTagInfo]:
     return [VideoTagInfo(id=row["id"], name=row["name"], slug=row["slug"]) for row in rows]
 
 
-@app.put("/api/videos/{video_id}/tags")
+@v1_router.put("/videos/{video_id}/tags")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def set_video_tags(request: Request, video_id: int, data: VideoTagsUpdate) -> List[VideoTagInfo]:
     """Set tags for a video (replaces all existing tags)."""
@@ -2094,7 +2109,7 @@ async def set_video_tags(request: Request, video_id: int, data: VideoTagsUpdate)
     return [VideoTagInfo(id=row["id"], name=row["name"], slug=row["slug"]) for row in rows]
 
 
-@app.delete("/api/videos/{video_id}/tags/{tag_id}")
+@v1_router.delete("/videos/{video_id}/tags/{tag_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def remove_video_tag(request: Request, video_id: int, tag_id: int):
     """Remove a single tag from a video."""
@@ -2170,7 +2185,7 @@ def _cleanup_frames_directory(slug: str) -> None:
         shutil.rmtree(frames_dir)
 
 
-@app.get("/api/videos/{video_id}/thumbnail")
+@v1_router.get("/videos/{video_id}/thumbnail")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_thumbnail_info(request: Request, video_id: int) -> ThumbnailInfoResponse:
     """Get current thumbnail information for a video."""
@@ -2192,7 +2207,7 @@ async def get_thumbnail_info(request: Request, video_id: int) -> ThumbnailInfoRe
     )
 
 
-@app.post("/api/videos/{video_id}/thumbnail/frames")
+@v1_router.post("/videos/{video_id}/thumbnail/frames")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def generate_thumbnail_frames(request: Request, video_id: int) -> ThumbnailFramesResponse:
     """
@@ -2249,7 +2264,7 @@ async def generate_thumbnail_frames(request: Request, video_id: int) -> Thumbnai
     return ThumbnailFramesResponse(video_id=video_id, frames=frames)
 
 
-@app.post("/api/videos/{video_id}/thumbnail/upload")
+@v1_router.post("/videos/{video_id}/thumbnail/upload")
 @limiter.limit(RATE_LIMIT_ADMIN_UPLOAD)
 async def upload_custom_thumbnail(
     request: Request,
@@ -2362,7 +2377,7 @@ async def upload_custom_thumbnail(
             temp_path.unlink()
 
 
-@app.post("/api/videos/{video_id}/thumbnail/select")
+@v1_router.post("/videos/{video_id}/thumbnail/select")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def select_thumbnail_frame(
     request: Request,
@@ -2433,7 +2448,7 @@ async def select_thumbnail_frame(
     )
 
 
-@app.post("/api/videos/{video_id}/thumbnail/revert")
+@v1_router.post("/videos/{video_id}/thumbnail/revert")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def revert_thumbnail(request: Request, video_id: int) -> ThumbnailResponse:
     """
@@ -2497,7 +2512,7 @@ async def revert_thumbnail(request: Request, video_id: int) -> ThumbnailResponse
     )
 
 
-@app.delete("/api/videos/{video_id}")
+@v1_router.delete("/videos/{video_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_video(
     request: Request,
@@ -2657,7 +2672,7 @@ async def delete_video(
 # ============ Bulk Operations ============
 
 
-@app.post("/api/videos/bulk/delete")
+@v1_router.post("/videos/bulk/delete")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def bulk_delete_videos(request: Request, data: BulkDeleteRequest) -> BulkDeleteResponse:
     """
@@ -2791,7 +2806,7 @@ async def bulk_delete_videos(request: Request, data: BulkDeleteRequest) -> BulkD
     )
 
 
-@app.post("/api/videos/bulk/update")
+@v1_router.post("/videos/bulk/update")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def bulk_update_videos(request: Request, data: BulkUpdateRequest) -> BulkUpdateResponse:
     """
@@ -2880,7 +2895,7 @@ async def bulk_update_videos(request: Request, data: BulkUpdateRequest) -> BulkU
     )
 
 
-@app.post("/api/videos/bulk/retranscode")
+@v1_router.post("/videos/bulk/retranscode")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def bulk_retranscode_videos(request: Request, data: BulkRetranscodeRequest) -> BulkRetranscodeResponse:
     """
@@ -2999,7 +3014,7 @@ async def bulk_retranscode_videos(request: Request, data: BulkRetranscodeRequest
     )
 
 
-@app.post("/api/videos/bulk/restore")
+@v1_router.post("/videos/bulk/restore")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def bulk_restore_videos(request: Request, data: BulkRestoreRequest) -> BulkRestoreResponse:
     """
@@ -3104,7 +3119,7 @@ async def bulk_restore_videos(request: Request, data: BulkRestoreRequest) -> Bul
     )
 
 
-@app.post("/api/videos/{video_id}/restore")
+@v1_router.post("/videos/{video_id}/restore")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def restore_video(request: Request, video_id: int):
     """Restore a soft-deleted video from archive."""
@@ -3189,7 +3204,7 @@ async def restore_video(request: Request, video_id: int):
     return {"status": "ok", "message": "Video restored from archive"}
 
 
-@app.post("/api/videos/{video_id}/retry")
+@v1_router.post("/videos/{video_id}/retry")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def retry_video(request: Request, video_id: int):
     """Retry processing a failed video."""
@@ -3234,7 +3249,7 @@ async def retry_video(request: Request, video_id: int):
     return {"status": "ok", "message": "Video queued for retry"}
 
 
-@app.post("/api/videos/{video_id}/re-upload")
+@v1_router.post("/videos/{video_id}/re-upload")
 @limiter.limit(RATE_LIMIT_ADMIN_UPLOAD)
 async def re_upload_video(
     request: Request,
@@ -3367,7 +3382,7 @@ async def re_upload_video(
     }
 
 
-@app.get("/api/videos/{video_id}/progress")
+@v1_router.get("/videos/{video_id}/progress")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_progress(request: Request, video_id: int) -> TranscodingProgressResponse:
     """Get transcoding progress for a video."""
@@ -3426,7 +3441,7 @@ async def get_video_progress(request: Request, video_id: int) -> TranscodingProg
     )
 
 
-@app.get("/api/videos/{video_id}/qualities")
+@v1_router.get("/videos/{video_id}/qualities")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_qualities(request: Request, video_id: int) -> VideoQualitiesResponse:
     """Get available and existing qualities for a video."""
@@ -3465,7 +3480,7 @@ async def get_video_qualities(request: Request, video_id: int) -> VideoQualities
     )
 
 
-@app.post("/api/videos/{video_id}/retranscode")
+@v1_router.post("/videos/{video_id}/retranscode")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def retranscode_video(
     request: Request,
@@ -3565,7 +3580,7 @@ async def retranscode_video(
 # ============ Transcription ============
 
 
-@app.get("/api/videos/{video_id}/transcript")
+@v1_router.get("/videos/{video_id}/transcript")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_transcript(request: Request, video_id: int) -> TranscriptionResponse:
     """Get transcription status and text for a video."""
@@ -3597,7 +3612,7 @@ async def get_video_transcript(request: Request, video_id: int) -> Transcription
     )
 
 
-@app.post("/api/videos/{video_id}/transcribe")
+@v1_router.post("/videos/{video_id}/transcribe")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def trigger_transcription(request: Request, video_id: int, data: TranscriptionTrigger = None):
     """Manually trigger transcription for a video."""
@@ -3669,7 +3684,7 @@ async def trigger_transcription(request: Request, video_id: int, data: Transcrip
     return {"status": "ok", "message": "Transcription queued"}
 
 
-@app.put("/api/videos/{video_id}/transcript")
+@v1_router.put("/videos/{video_id}/transcript")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_transcript(request: Request, video_id: int, data: TranscriptionUpdate):
     """Manually edit/correct transcript text and regenerate VTT."""
@@ -3709,7 +3724,7 @@ async def update_transcript(request: Request, video_id: int, data: Transcription
     return {"status": "ok", "message": "Transcript updated", "word_count": word_count}
 
 
-@app.delete("/api/videos/{video_id}/transcript")
+@v1_router.delete("/videos/{video_id}/transcript")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_transcript(request: Request, video_id: int):
     """Delete transcription and VTT file for a video."""
@@ -3748,7 +3763,7 @@ async def delete_transcript(request: Request, video_id: int):
 # ============ Analytics ============
 
 
-@app.get("/api/analytics/overview")
+@v1_router.get("/analytics/overview")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def analytics_overview(request: Request, response: Response) -> AnalyticsOverview:
     """Get global analytics overview."""
@@ -3859,7 +3874,7 @@ async def analytics_overview(request: Request, response: Response) -> AnalyticsO
     return AnalyticsOverview(**result_data)
 
 
-@app.get("/api/analytics/videos")
+@v1_router.get("/analytics/videos")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def analytics_videos(
     request: Request,
@@ -3971,7 +3986,7 @@ async def analytics_videos(
     return VideoAnalyticsListResponse(**result_data)
 
 
-@app.get("/api/analytics/videos/{video_id}")
+@v1_router.get("/analytics/videos/{video_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def analytics_video_detail(request: Request, response: Response, video_id: int) -> VideoAnalyticsDetail:
     """Get detailed analytics for a specific video."""
@@ -4083,7 +4098,7 @@ async def analytics_video_detail(request: Request, response: Response, video_id:
     return VideoAnalyticsDetail(**result_data)
 
 
-@app.get("/api/analytics/trends")
+@v1_router.get("/analytics/trends")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def analytics_trends(
     request: Request,
@@ -4157,7 +4172,7 @@ async def analytics_trends(
     return TrendsResponse(**result_data)
 
 
-@app.get("/api/videos/export")
+@v1_router.get("/videos/export")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def export_videos(
     request: Request,
@@ -4332,7 +4347,7 @@ def determine_worker_status(
     return "idle"
 
 
-@app.get("/api/workers")
+@v1_router.get("/workers")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_workers_dashboard(request: Request) -> WorkerDashboardResponse:
     """
@@ -4462,7 +4477,7 @@ async def list_workers_dashboard(request: Request) -> WorkerDashboardResponse:
     )
 
 
-@app.get("/api/workers/active-jobs")
+@v1_router.get("/workers/active-jobs")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_active_jobs(request: Request) -> ActiveJobsResponse:
     """
@@ -4560,7 +4575,7 @@ async def list_active_jobs(request: Request) -> ActiveJobsResponse:
     )
 
 
-@app.get("/api/workers/{worker_id}")
+@v1_router.get("/workers/{worker_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_worker_detail(request: Request, worker_id: str) -> WorkerDetailResponse:
     """
@@ -4696,7 +4711,7 @@ async def get_worker_detail(request: Request, worker_id: str) -> WorkerDetailRes
     )
 
 
-@app.put("/api/workers/{worker_id}/disable")
+@v1_router.put("/workers/{worker_id}/disable")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def disable_worker(request: Request, worker_id: str):
     """
@@ -4752,7 +4767,7 @@ async def disable_worker(request: Request, worker_id: str):
     return {"status": "ok", "message": "Worker disabled"}
 
 
-@app.put("/api/workers/{worker_id}/enable")
+@v1_router.put("/workers/{worker_id}/enable")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def enable_worker(request: Request, worker_id: str):
     """
@@ -4782,7 +4797,7 @@ async def enable_worker(request: Request, worker_id: str):
     return {"status": "ok", "message": "Worker enabled"}
 
 
-@app.delete("/api/workers/{worker_id}")
+@v1_router.delete("/workers/{worker_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_worker(
     request: Request,
@@ -4861,7 +4876,7 @@ async def delete_worker(
 # ============ Worker Remote Control (Issue #410) ============
 
 
-@app.post("/api/admin/workers/{worker_id}/restart")
+@v1_router.post("/admin/workers/{worker_id}/restart")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def restart_worker(request: Request, worker_id: str):
     """
@@ -4916,7 +4931,7 @@ async def restart_worker(request: Request, worker_id: str):
     return {"status": "ok", "message": f"Restart command sent to worker {worker['worker_name'] or worker_id[:8]}"}
 
 
-@app.post("/api/admin/workers/{worker_id}/stop")
+@v1_router.post("/admin/workers/{worker_id}/stop")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def stop_worker(request: Request, worker_id: str):
     """
@@ -4971,7 +4986,7 @@ async def stop_worker(request: Request, worker_id: str):
     return {"status": "ok", "message": f"Stop command sent to worker {worker['worker_name'] or worker_id[:8]}"}
 
 
-@app.post("/api/admin/workers/restart-all")
+@v1_router.post("/admin/workers/restart-all")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def restart_all_workers(request: Request):
     """
@@ -5025,7 +5040,7 @@ async def restart_all_workers(request: Request):
     return {"status": "ok", "message": f"Restart command broadcast to {len(online_workers)} workers"}
 
 
-@app.post("/api/admin/workers/{worker_id}/update")
+@v1_router.post("/admin/workers/{worker_id}/update")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_worker(request: Request, worker_id: str):
     """
@@ -5087,7 +5102,7 @@ async def update_worker(request: Request, worker_id: str):
 # ============ Deployment Events (Issue #410 Phase 4) ============
 
 
-@app.get("/api/admin/deployments")
+@v1_router.get("/admin/deployments")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_deployment_events(
     request: Request,
@@ -5161,7 +5176,7 @@ async def _log_deployment_event(
     return result
 
 
-@app.get("/api/admin/workers/{worker_id}/logs")
+@v1_router.get("/admin/workers/{worker_id}/logs")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_worker_logs(
     request: Request,
@@ -5228,7 +5243,7 @@ async def get_worker_logs(
     }
 
 
-@app.get("/api/admin/workers/{worker_id}/metrics")
+@v1_router.get("/admin/workers/{worker_id}/metrics")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_worker_metrics(request: Request, worker_id: str):
     """
@@ -5288,7 +5303,7 @@ async def get_worker_metrics(request: Request, worker_id: str):
 # ============ Server-Sent Events (SSE) Endpoints ============
 
 
-@app.get("/api/events/progress")
+@v1_router.get("/events/progress")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def sse_progress(
     request: Request,
@@ -5396,7 +5411,7 @@ async def sse_progress(
     return EventSourceResponse(event_generator())
 
 
-@app.get("/api/events/workers")
+@v1_router.get("/events/workers")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def sse_workers(request: Request):
     """
@@ -5653,7 +5668,7 @@ async def _get_workers_state() -> dict:
 # ============================================================================
 
 
-@app.get("/api/settings/watermark")
+@v1_router.get("/settings/watermark")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_admin_watermark_settings(request: Request):
     """
@@ -5689,7 +5704,7 @@ async def get_admin_watermark_settings(request: Request):
     }
 
 
-@app.get("/api/settings/watermark/image")
+@v1_router.get("/settings/watermark/image")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_admin_watermark_image(request: Request):
     """Serve the watermark image for admin preview."""
@@ -5718,7 +5733,7 @@ async def get_admin_watermark_image(request: Request):
     return FileResponse(watermark_path, media_type=content_type)
 
 
-@app.post("/api/settings/watermark/upload")
+@v1_router.post("/settings/watermark/upload")
 @limiter.limit(RATE_LIMIT_ADMIN_UPLOAD)
 async def upload_watermark_image(
     request: Request,
@@ -5812,7 +5827,7 @@ async def upload_watermark_image(
         raise HTTPException(status_code=500, detail="Failed to save watermark image")
 
 
-@app.delete("/api/settings/watermark")
+@v1_router.delete("/settings/watermark")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_watermark_image(request: Request):
     """
@@ -5861,7 +5876,7 @@ async def delete_watermark_image(request: Request):
 # =============================================================================
 
 
-@app.get("/api/settings")
+@v1_router.get("/settings")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_settings(request: Request) -> SettingsByCategoryResponse:
     """
@@ -5893,7 +5908,7 @@ async def list_settings(request: Request) -> SettingsByCategoryResponse:
     return SettingsByCategoryResponse(categories=categories_dict)
 
 
-@app.get("/api/settings/categories")
+@v1_router.get("/settings/categories")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_settings_categories(request: Request) -> List[str]:
     """
@@ -5906,7 +5921,7 @@ async def list_settings_categories(request: Request) -> List[str]:
     return await service.get_categories()
 
 
-@app.get("/api/settings/category/{category}")
+@v1_router.get("/settings/category/{category}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_settings_by_category(request: Request, category: str) -> SettingsCategoryResponse:
     """
@@ -5940,7 +5955,7 @@ async def get_settings_by_category(request: Request, category: str) -> SettingsC
     )
 
 
-@app.get("/api/settings/key/{key:path}")
+@v1_router.get("/settings/key/{key:path}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_setting(request: Request, key: str) -> SettingResponse:
     """
@@ -5966,7 +5981,7 @@ async def get_setting(request: Request, key: str) -> SettingResponse:
     )
 
 
-@app.put("/api/settings/key/{key:path}")
+@v1_router.put("/settings/key/{key:path}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_setting(request: Request, key: str, data: SettingUpdate) -> SettingResponse:
     """
@@ -6052,7 +6067,7 @@ async def update_setting(request: Request, key: str, data: SettingUpdate) -> Set
     )
 
 
-@app.post("/api/settings")
+@v1_router.post("/settings")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_setting(request: Request, data: SettingCreate) -> SettingResponse:
     """
@@ -6109,7 +6124,7 @@ async def create_setting(request: Request, data: SettingCreate) -> SettingRespon
     )
 
 
-@app.delete("/api/settings/key/{key:path}")
+@v1_router.delete("/settings/key/{key:path}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_setting(request: Request, key: str):
     """
@@ -6141,7 +6156,7 @@ async def delete_setting(request: Request, key: str):
     return {"status": "ok", "message": f"Setting deleted: {key}"}
 
 
-@app.post("/api/settings/export")
+@v1_router.post("/settings/export")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def export_settings(request: Request) -> SettingsExport:
     """
@@ -6176,7 +6191,7 @@ async def export_settings(request: Request) -> SettingsExport:
     )
 
 
-@app.post("/api/settings/import")
+@v1_router.post("/settings/import")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def import_settings(request: Request, data: SettingsImport):
     """
@@ -6238,7 +6253,7 @@ async def import_settings(request: Request, data: SettingsImport):
     }
 
 
-@app.post("/api/settings/invalidate-cache")
+@v1_router.post("/settings/invalidate-cache")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def invalidate_settings_cache(request: Request):
     """
@@ -6253,7 +6268,7 @@ async def invalidate_settings_cache(request: Request):
     return {"status": "ok", "message": "Settings cache invalidated"}
 
 
-@app.get("/api/settings/cache-stats")
+@v1_router.get("/settings/cache-stats")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_settings_cache_stats(request: Request):
     """
@@ -6265,7 +6280,7 @@ async def get_settings_cache_stats(request: Request):
     return service.get_cache_stats()
 
 
-@app.post("/api/settings/seed-from-env")
+@v1_router.post("/settings/seed-from-env")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def seed_settings_from_environment(request: Request):
     """
@@ -6294,7 +6309,7 @@ async def seed_settings_from_environment(request: Request):
 # =============================================================================
 
 
-@app.get("/api/reencode/status")
+@v1_router.get("/reencode/status")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_reencode_status(request: Request):
     """
@@ -6338,7 +6353,7 @@ async def get_reencode_status(request: Request):
     }
 
 
-@app.post("/api/reencode/queue")
+@v1_router.post("/reencode/queue")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def queue_videos_for_reencode(
     request: Request,
@@ -6406,7 +6421,7 @@ async def queue_videos_for_reencode(
     }
 
 
-@app.post("/api/reencode/queue-all")
+@v1_router.post("/reencode/queue-all")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def queue_all_legacy_videos(
     request: Request,
@@ -6466,7 +6481,7 @@ async def queue_all_legacy_videos(
     }
 
 
-@app.get("/api/reencode/jobs")
+@v1_router.get("/reencode/jobs")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_reencode_jobs(
     request: Request,
@@ -6538,7 +6553,7 @@ async def list_reencode_jobs(
     return {"jobs": jobs, "count": len(jobs), "total": total}
 
 
-@app.delete("/api/reencode/jobs/{job_id}")
+@v1_router.delete("/reencode/jobs/{job_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def cancel_reencode_job(request: Request, job_id: int):
     """
@@ -6565,7 +6580,7 @@ async def cancel_reencode_job(request: Request, job_id: int):
     return {"status": "ok", "message": f"Job {job_id} cancelled"}
 
 
-@app.post("/api/reencode/claim")
+@v1_router.post("/reencode/claim")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def claim_reencode_job(request: Request):
     """
@@ -6623,7 +6638,7 @@ async def claim_reencode_job(request: Request):
     }
 
 
-@app.patch("/api/reencode/{job_id}")
+@v1_router.patch("/reencode/{job_id}")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def update_reencode_job(
     request: Request,
@@ -6685,7 +6700,7 @@ async def update_reencode_job(
 # ============ Custom Fields ============
 
 
-@app.get("/api/custom-fields")
+@v1_router.get("/custom-fields")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_custom_fields(
     request: Request,
@@ -6772,7 +6787,7 @@ async def list_custom_fields(
     return CustomFieldListResponse(fields=fields, total_count=len(fields))
 
 
-@app.post("/api/custom-fields")
+@v1_router.post("/custom-fields")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_custom_field(
     request: Request,
@@ -6881,7 +6896,7 @@ async def create_custom_field(
     )
 
 
-@app.get("/api/custom-fields/{field_id}")
+@v1_router.get("/custom-fields/{field_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_custom_field(
     request: Request,
@@ -6943,7 +6958,7 @@ async def get_custom_field(
     )
 
 
-@app.put("/api/custom-fields/{field_id}")
+@v1_router.put("/custom-fields/{field_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_custom_field(
     request: Request,
@@ -7055,7 +7070,7 @@ async def update_custom_field(
     return await get_custom_field(request, field_id)
 
 
-@app.delete("/api/custom-fields/{field_id}")
+@v1_router.delete("/custom-fields/{field_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_custom_field(request: Request, field_id: int):
     """
@@ -7170,7 +7185,7 @@ def _validate_custom_field_value(field_type: str, value, options: list = None, c
     return value
 
 
-@app.get("/api/videos/{video_id}/custom-fields")
+@v1_router.get("/videos/{video_id}/custom-fields")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_custom_fields(
     request: Request,
@@ -7249,7 +7264,7 @@ async def get_video_custom_fields(
     return VideoCustomFieldsResponse(video_id=video_id, fields=fields)
 
 
-@app.put("/api/videos/{video_id}/custom-fields")
+@v1_router.put("/videos/{video_id}/custom-fields")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def set_video_custom_fields(
     request: Request,
@@ -7352,7 +7367,7 @@ async def set_video_custom_fields(
     return await get_video_custom_fields(request, video_id)
 
 
-@app.post("/api/videos/bulk/custom-fields")
+@v1_router.post("/videos/bulk/custom-fields")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def bulk_update_custom_fields(
     request: Request,
@@ -7531,7 +7546,7 @@ def _build_playlist_response(row: dict, video_count: int = 0, total_duration: fl
     )
 
 
-@app.get("/api/playlists")
+@v1_router.get("/playlists")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_playlists(
     request: Request,
@@ -7566,7 +7581,7 @@ async def list_playlists(
     return PlaylistListResponse(playlists=playlist_list, total_count=total_count or 0)
 
 
-@app.post("/api/playlists")
+@v1_router.post("/playlists")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_playlist(request: Request, data: PlaylistCreate) -> PlaylistResponse:
     """Create a new playlist."""
@@ -7623,7 +7638,7 @@ async def create_playlist(request: Request, data: PlaylistCreate) -> PlaylistRes
     )
 
 
-@app.get("/api/playlists/{playlist_id}")
+@v1_router.get("/playlists/{playlist_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_playlist(request: Request, playlist_id: int) -> PlaylistDetailResponse:
     """Get a playlist with its videos."""
@@ -7686,7 +7701,7 @@ async def get_playlist(request: Request, playlist_id: int) -> PlaylistDetailResp
     )
 
 
-@app.put("/api/playlists/{playlist_id}")
+@v1_router.put("/playlists/{playlist_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_playlist(request: Request, playlist_id: int, data: PlaylistUpdate) -> PlaylistResponse:
     """Update a playlist."""
@@ -7775,7 +7790,7 @@ async def update_playlist(request: Request, playlist_id: int, data: PlaylistUpda
     )
 
 
-@app.delete("/api/playlists/{playlist_id}")
+@v1_router.delete("/playlists/{playlist_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_playlist(request: Request, playlist_id: int):
     """Soft delete a playlist."""
@@ -7805,7 +7820,7 @@ async def delete_playlist(request: Request, playlist_id: int):
     return {"status": "ok"}
 
 
-@app.get("/api/playlists/{playlist_id}/videos")
+@v1_router.get("/playlists/{playlist_id}/videos")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_playlist_videos(request: Request, playlist_id: int) -> List[PlaylistVideoInfo]:
     """Get all videos in a playlist ordered by position."""
@@ -7842,7 +7857,7 @@ async def get_playlist_videos(request: Request, playlist_id: int) -> List[Playli
     ]
 
 
-@app.post("/api/playlists/{playlist_id}/videos")
+@v1_router.post("/playlists/{playlist_id}/videos")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def add_video_to_playlist(request: Request, playlist_id: int, data: AddVideoToPlaylistRequest):
     """Add a video to a playlist."""
@@ -7924,7 +7939,7 @@ async def add_video_to_playlist(request: Request, playlist_id: int, data: AddVid
     return {"status": "ok", "position": position}
 
 
-@app.delete("/api/playlists/{playlist_id}/videos/{video_id}")
+@v1_router.delete("/playlists/{playlist_id}/videos/{video_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def remove_video_from_playlist(request: Request, playlist_id: int, video_id: int):
     """Remove a video from a playlist."""
@@ -7982,7 +7997,7 @@ async def remove_video_from_playlist(request: Request, playlist_id: int, video_i
     return {"status": "ok"}
 
 
-@app.post("/api/playlists/{playlist_id}/reorder")
+@v1_router.post("/playlists/{playlist_id}/reorder")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def reorder_playlist(request: Request, playlist_id: int, data: ReorderPlaylistRequest):
     """Reorder videos in a playlist."""
@@ -8054,7 +8069,7 @@ async def reorder_playlist(request: Request, playlist_id: int, data: ReorderPlay
 # ============ Chapter Endpoints (Issue #413 Phase 7) ============
 
 
-@app.get("/api/videos/{video_id}/chapters")
+@v1_router.get("/videos/{video_id}/chapters")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_chapters(request: Request, video_id: int):
     """List all chapters for a video, ordered by position."""
@@ -8092,7 +8107,7 @@ async def list_chapters(request: Request, video_id: int):
     )
 
 
-@app.post("/api/videos/{video_id}/chapters")
+@v1_router.post("/videos/{video_id}/chapters")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_chapter(request: Request, video_id: int, data: ChapterCreate):
     """Create a new chapter for a video."""
@@ -8175,7 +8190,7 @@ async def create_chapter(request: Request, video_id: int, data: ChapterCreate):
     )
 
 
-@app.get("/api/videos/{video_id}/chapters/{chapter_id}")
+@v1_router.get("/videos/{video_id}/chapters/{chapter_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_chapter(request: Request, video_id: int, chapter_id: int):
     """Get a specific chapter."""
@@ -8198,7 +8213,7 @@ async def get_chapter(request: Request, video_id: int, chapter_id: int):
     )
 
 
-@app.put("/api/videos/{video_id}/chapters/{chapter_id}")
+@v1_router.put("/videos/{video_id}/chapters/{chapter_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_chapter(request: Request, video_id: int, chapter_id: int, data: ChapterUpdate):
     """Update an existing chapter."""
@@ -8261,7 +8276,7 @@ async def update_chapter(request: Request, video_id: int, chapter_id: int, data:
     )
 
 
-@app.delete("/api/videos/{video_id}/chapters/{chapter_id}")
+@v1_router.delete("/videos/{video_id}/chapters/{chapter_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_chapter(request: Request, video_id: int, chapter_id: int):
     """Delete a chapter and reorder remaining chapters."""
@@ -8311,7 +8326,7 @@ async def delete_chapter(request: Request, video_id: int, chapter_id: int):
     return {"status": "ok"}
 
 
-@app.post("/api/videos/{video_id}/chapters/reorder")
+@v1_router.post("/videos/{video_id}/chapters/reorder")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def reorder_chapters(request: Request, video_id: int, data: ReorderChaptersRequest):
     """Reorder chapters in a video."""
@@ -8388,7 +8403,7 @@ async def reorder_chapters(request: Request, video_id: int, data: ReorderChapter
     return {"status": "ok"}
 
 
-@app.post("/api/videos/{video_id}/chapters/auto-detect")
+@v1_router.post("/videos/{video_id}/chapters/auto-detect")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def auto_detect_chapters(
     request: Request, video_id: int, data: AutoDetectChaptersRequest
@@ -8622,7 +8637,7 @@ async def auto_detect_chapters(
 # =============================================================================
 
 
-@app.get("/api/sprites/status")
+@v1_router.get("/sprites/status")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_sprite_queue_status(request: Request) -> SpriteQueueStatusResponse:
     """
@@ -8656,7 +8671,7 @@ async def get_sprite_queue_status(request: Request) -> SpriteQueueStatusResponse
     return result
 
 
-@app.post("/api/videos/{video_id}/sprites/generate")
+@v1_router.post("/videos/{video_id}/sprites/generate")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def queue_sprite_generation(
     request: Request,
@@ -8731,7 +8746,7 @@ async def queue_sprite_generation(
     }
 
 
-@app.post("/api/sprites/queue-all")
+@v1_router.post("/sprites/queue-all")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def queue_all_for_sprites(
     request: Request,
@@ -8792,7 +8807,7 @@ async def queue_all_for_sprites(
     }
 
 
-@app.get("/api/sprites/jobs")
+@v1_router.get("/sprites/jobs")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_sprite_jobs(
     request: Request,
@@ -8867,7 +8882,7 @@ async def list_sprite_jobs(
     return SpriteQueueJobsResponse(jobs=jobs, count=len(jobs), total=total)
 
 
-@app.get("/api/videos/{video_id}/sprites")
+@v1_router.get("/videos/{video_id}/sprites")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_video_sprite_status(request: Request, video_id: int) -> SpriteStatusResponse:
     """
@@ -8892,7 +8907,7 @@ async def get_video_sprite_status(request: Request, video_id: int) -> SpriteStat
     )
 
 
-@app.delete("/api/sprites/jobs/{job_id}")
+@v1_router.delete("/sprites/jobs/{job_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def cancel_sprite_job(request: Request, job_id: int) -> dict:
     """
@@ -8931,7 +8946,7 @@ async def cancel_sprite_job(request: Request, job_id: int) -> dict:
 # =============================================================================
 
 
-@app.get("/api/admin/job-queue/dead-letter")
+@v1_router.get("/admin/job-queue/dead-letter")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_dead_letter_queue(
     request: Request,
@@ -9021,7 +9036,7 @@ async def get_dead_letter_queue(
         }
 
 
-@app.post("/api/admin/job-queue/dead-letter/{message_id}/reprocess")
+@v1_router.post("/admin/job-queue/dead-letter/{message_id}/reprocess")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def reprocess_dead_letter_job(
     request: Request,
@@ -9153,7 +9168,7 @@ async def reprocess_dead_letter_job(
         )
 
 
-@app.delete("/api/admin/job-queue/dead-letter/{message_id}")
+@v1_router.delete("/admin/job-queue/dead-letter/{message_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_dead_letter_entry(
     request: Request,
@@ -9202,7 +9217,7 @@ async def delete_dead_letter_entry(
         )
 
 
-@app.get("/api/admin/job-queue/stats")
+@v1_router.get("/admin/job-queue/stats")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_job_queue_stats(request: Request):
     """
@@ -9226,7 +9241,7 @@ async def get_job_queue_stats(request: Request):
 # ============ Webhook Management Endpoints (Issue #203) ============
 
 
-@app.get("/api/webhooks")
+@v1_router.get("/webhooks")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_webhooks(
     request: Request,
@@ -9287,7 +9302,7 @@ async def list_webhooks(
     return WebhookListResponse(webhooks=webhook_list, total_count=total_count)
 
 
-@app.get("/api/webhooks/stats")
+@v1_router.get("/webhooks/stats")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_webhook_stats(request: Request) -> WebhookStatsResponse:
     """
@@ -9336,7 +9351,7 @@ async def get_webhook_stats(request: Request) -> WebhookStatsResponse:
     )
 
 
-@app.post("/api/webhooks", status_code=201)
+@v1_router.post("/webhooks", status_code=201)
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def create_webhook(request: Request, data: WebhookCreate) -> WebhookResponse:
     """
@@ -9396,7 +9411,7 @@ async def create_webhook(request: Request, data: WebhookCreate) -> WebhookRespon
         )
 
 
-@app.get("/api/webhooks/{webhook_id}")
+@v1_router.get("/webhooks/{webhook_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_webhook(request: Request, webhook_id: int) -> WebhookResponse:
     """
@@ -9430,7 +9445,7 @@ async def get_webhook(request: Request, webhook_id: int) -> WebhookResponse:
     )
 
 
-@app.put("/api/webhooks/{webhook_id}")
+@v1_router.put("/webhooks/{webhook_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def update_webhook(request: Request, webhook_id: int, data: WebhookUpdate) -> WebhookResponse:
     """
@@ -9501,7 +9516,7 @@ async def update_webhook(request: Request, webhook_id: int, data: WebhookUpdate)
         )
 
 
-@app.delete("/api/webhooks/{webhook_id}")
+@v1_router.delete("/webhooks/{webhook_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def delete_webhook(request: Request, webhook_id: int):
     """
@@ -9536,7 +9551,7 @@ async def delete_webhook(request: Request, webhook_id: int):
         )
 
 
-@app.post("/api/webhooks/{webhook_id}/test")
+@v1_router.post("/webhooks/{webhook_id}/test")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def test_webhook(
     request: Request,
@@ -9567,7 +9582,7 @@ async def test_webhook(
     )
 
 
-@app.get("/api/webhooks/{webhook_id}/deliveries")
+@v1_router.get("/webhooks/{webhook_id}/deliveries")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def list_webhook_deliveries(
     request: Request,
@@ -9628,7 +9643,7 @@ async def list_webhook_deliveries(
     )
 
 
-@app.get("/api/webhooks/{webhook_id}/deliveries/{delivery_id}")
+@v1_router.get("/webhooks/{webhook_id}/deliveries/{delivery_id}")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def get_webhook_delivery(
     request: Request,
@@ -9672,7 +9687,7 @@ async def get_webhook_delivery(
     )
 
 
-@app.post("/api/webhooks/{webhook_id}/deliveries/{delivery_id}/retry")
+@v1_router.post("/webhooks/{webhook_id}/deliveries/{delivery_id}/retry")
 @limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
 async def retry_webhook_delivery(
     request: Request,
@@ -9725,6 +9740,29 @@ async def retry_webhook_delivery(
             status_code=500,
             detail=sanitize_error_message(str(e), context="retry_delivery"),
         )
+
+
+# =============================================================================
+# API Router Mounting (Issue #218)
+# Mount versioned routers and configure OpenAPI documentation
+# =============================================================================
+
+# Mount v1 router at /api/v1
+app.include_router(v1_router, prefix="/api/v1")
+logger.info("Mounted Admin API v1 at /api/v1")
+
+# Mount legacy routes at /api for backwards compatibility (if enabled)
+if API_INCLUDE_LEGACY_ROUTES:
+    app.include_router(v1_router, prefix="/api", include_in_schema=False)
+    logger.info("Mounted legacy admin routes at /api (aliased to v1)")
+
+
+# Configure custom OpenAPI schema
+def custom_openapi():
+    return configure_openapi_schema(app)
+
+
+app.openapi = custom_openapi
 
 
 if __name__ == "__main__":

--- a/api/public.py
+++ b/api/public.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 import sqlalchemy as sa
-from fastapi import Cookie, Depends, FastAPI, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Cookie, Depends, FastAPI, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -88,6 +88,8 @@ from api.schemas import (
     VideoTagInfo,
 )
 from config import (
+    API_INCLUDE_LEGACY_ROUTES,
+    API_VERSION,
     CORS_ALLOWED_ORIGINS,
     DOWNLOADS_ALLOW_ORIGINAL,
     DOWNLOADS_ALLOW_TRANSCODED,
@@ -95,6 +97,8 @@ from config import (
     DOWNLOADS_MAX_CONCURRENT,
     DOWNLOADS_RATE_LIMIT_PER_HOUR,
     NAS_STORAGE,
+    OPENAPI_DESCRIPTION,
+    OPENAPI_TITLE,
     PUBLIC_PORT,
     QUALITY_NAMES,
     RATE_LIMIT_ENABLED,
@@ -117,6 +121,7 @@ from config import (
     WATERMARK_TEXT_SIZE,
     WATERMARK_TYPE,
 )
+from api.versioning import VersionHeaderMiddleware, configure_openapi_schema
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +309,16 @@ async def lifespan(app: FastAPI):
     await database.disconnect()
 
 
-app = FastAPI(title="VLog", description="Self-hosted video platform", lifespan=lifespan)
+app = FastAPI(
+    title=OPENAPI_TITLE,
+    description=OPENAPI_DESCRIPTION,
+    version=API_VERSION,
+    lifespan=lifespan,
+)
+
+# Create versioned API router
+# All /api endpoints are registered on this router and mounted with version prefix
+v1_router = APIRouter(tags=["API v1"])
 
 # Register rate limiter with the app
 app.state.limiter = limiter
@@ -324,6 +338,7 @@ async def database_locked_handler(request: Request, exc: DatabaseLockedError):
 
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(RequestIDMiddleware)
+app.add_middleware(VersionHeaderMiddleware)
 
 # CORS middleware for HLS playback and analytics
 # If CORS_ALLOWED_ORIGINS is empty, allow same-origin only (no CORS headers)
@@ -913,7 +928,7 @@ def build_video_list_response(
     ]
 
 
-@app.get("/api/videos")
+@v1_router.get("/videos", summary="List videos", description="Get a paginated list of published videos with filtering and sorting options.")
 @limiter.limit(RATE_LIMIT_PUBLIC_VIDEOS_LIST)
 async def list_videos(
     request: Request,
@@ -1102,7 +1117,7 @@ async def list_videos(
 MAX_BULK_VIDEO_IDS = 20
 
 
-@app.get("/api/videos/bulk")
+@v1_router.get("/videos/bulk", summary="Bulk get videos", description="Get multiple videos by their slugs in a single request.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_videos_bulk(
     request: Request,
@@ -1204,7 +1219,7 @@ async def get_videos_bulk(
     return build_video_list_response(ordered_rows, video_tags_map)
 
 
-@app.get("/api/videos/{slug}")
+@v1_router.get("/videos/{slug}", summary="Get video", description="Get detailed information about a specific video by its slug.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_video(request: Request, slug: str) -> VideoResponse:
     """Get a single video by slug."""
@@ -1329,7 +1344,7 @@ async def get_video(request: Request, slug: str) -> VideoResponse:
     )
 
 
-@app.get("/api/videos/{slug}/progress")
+@v1_router.get("/videos/{slug}/progress", summary="Get video progress", description="Get transcoding progress for a video.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_video_progress(request: Request, slug: str) -> TranscodingProgressResponse:
     """Get transcoding progress for a video."""
@@ -1396,7 +1411,7 @@ async def get_video_progress(request: Request, slug: str) -> TranscodingProgress
     )
 
 
-@app.get("/api/videos/{slug}/transcript")
+@v1_router.get("/videos/{slug}/transcript", summary="Get video transcript", description="Get the transcription for a video if available.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_transcript(request: Request, slug: str) -> TranscriptionResponse:
     """Get transcription status and text for a video."""
@@ -1495,7 +1510,7 @@ async def _fetch_related_videos_tier(
     return await fetch_all_with_retry(query)
 
 
-@app.get("/api/videos/{slug}/related")
+@v1_router.get("/videos/{slug}/related", summary="Get related videos", description="Get videos related to the specified video based on tags and category.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_related_videos(
     request: Request,
@@ -1633,7 +1648,7 @@ async def get_related_videos(
     return result
 
 
-@app.get("/api/categories")
+@v1_router.get("/categories", summary="List categories", description="Get all video categories.")
 @limiter.limit(RATE_LIMIT_PUBLIC_VIDEOS_LIST)
 async def list_categories(request: Request) -> List[CategoryResponse]:
     """List all categories with video counts."""
@@ -1663,7 +1678,7 @@ async def list_categories(request: Request) -> List[CategoryResponse]:
     ]
 
 
-@app.get("/api/categories/{slug}")
+@v1_router.get("/categories/{slug}", summary="Get category", description="Get a category by its slug.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_category(request: Request, slug: str) -> CategoryResponse:
     """Get a single category by slug."""
@@ -1701,7 +1716,7 @@ async def get_category(request: Request, slug: str) -> CategoryResponse:
     )
 
 
-@app.get("/api/tags")
+@v1_router.get("/tags", summary="List tags", description="Get all video tags.")
 @limiter.limit(RATE_LIMIT_PUBLIC_VIDEOS_LIST)
 async def list_tags(request: Request) -> List[TagResponse]:
     """List all tags with video counts."""
@@ -1731,7 +1746,7 @@ async def list_tags(request: Request) -> List[TagResponse]:
     ]
 
 
-@app.get("/api/tags/{slug}")
+@v1_router.get("/tags/{slug}", summary="Get tag", description="Get a tag by its slug.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_tag(request: Request, slug: str) -> TagResponse:
     """Get a single tag by slug."""
@@ -1778,7 +1793,7 @@ def _get_video_url_prefix() -> str:
 VALID_PLAYLIST_TYPES = {"playlist", "collection", "series", "course"}
 
 
-@app.get("/api/playlists")
+@v1_router.get("/playlists", summary="List playlists", description="Get all public playlists.")
 @limiter.limit(RATE_LIMIT_PUBLIC_VIDEOS_LIST)
 async def list_public_playlists(
     request: Request,
@@ -1865,7 +1880,7 @@ async def list_public_playlists(
     return PlaylistListResponse(playlists=playlist_list, total_count=total_count or 0)
 
 
-@app.get("/api/playlists/{slug}")
+@v1_router.get("/playlists/{slug}", summary="Get playlist", description="Get a playlist by its slug.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_public_playlist(request: Request, slug: str) -> PlaylistDetailResponse:
     """Get a public playlist by slug with its videos."""
@@ -1937,7 +1952,7 @@ async def get_public_playlist(request: Request, slug: str) -> PlaylistDetailResp
     )
 
 
-@app.get("/api/playlists/{slug}/videos")
+@v1_router.get("/playlists/{slug}/videos", summary="Get playlist videos", description="Get videos in a playlist.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_public_playlist_videos(request: Request, slug: str) -> List[PlaylistVideoInfo]:
     """Get videos in a public playlist."""
@@ -1989,7 +2004,7 @@ async def get_public_playlist_videos(request: Request, slug: str) -> List[Playli
 # ============================================================================
 
 
-@app.get("/api/config/watermark")
+@v1_router.get("/config/watermark", summary="Get watermark config", description="Get watermark configuration for video overlay.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_watermark_config(request: Request):
     """
@@ -2130,7 +2145,7 @@ async def get_display_settings() -> Dict[str, Any]:
     return _cached_display_settings
 
 
-@app.get("/api/config/display")
+@v1_router.get("/config/display", summary="Get display config", description="Get display configuration for the video player.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_display_config(request: Request):
     """
@@ -2255,7 +2270,7 @@ def reset_download_settings_cache() -> None:
     _cached_download_settings_time = 0
 
 
-@app.get("/api/config/downloads")
+@v1_router.get("/config/downloads", summary="Get downloads config", description="Get download configuration and availability.")
 @limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
 async def get_download_config(request: Request):
     """
@@ -2369,7 +2384,7 @@ async def _release_download_slot(client_ip: str) -> None:
             _active_downloads_per_ip[client_ip] = current - 1
 
 
-@app.get("/api/videos/{slug}/download/original")
+@v1_router.get("/videos/{slug}/download/original", summary="Download original video", description="Download the original video file if downloads are enabled.")
 @limiter.limit(
     # Note: This rate limit is configured at startup from env vars.
     # Changing the database setting requires a restart to take effect.
@@ -2518,7 +2533,7 @@ async def download_original(
 # ============================================================================
 
 
-@app.post("/api/analytics/session")
+@v1_router.post("/analytics/session", summary="Create analytics session", description="Start a new playback analytics session.")
 @limiter.limit(RATE_LIMIT_PUBLIC_ANALYTICS)
 async def start_analytics_session(
     request: Request,
@@ -2591,7 +2606,7 @@ async def start_analytics_session(
     return PlaybackSessionResponse(session_token=session_token)
 
 
-@app.post("/api/analytics/heartbeat")
+@v1_router.post("/analytics/heartbeat", summary="Send analytics heartbeat", description="Send periodic heartbeat during video playback.")
 @limiter.limit(RATE_LIMIT_PUBLIC_ANALYTICS)
 async def analytics_heartbeat(request: Request, data: PlaybackHeartbeat):
     """Update playback session with current progress."""
@@ -2628,7 +2643,7 @@ async def analytics_heartbeat(request: Request, data: PlaybackHeartbeat):
     return {"status": "ok"}
 
 
-@app.post("/api/analytics/end")
+@v1_router.post("/analytics/end", summary="End analytics session", description="End a playback analytics session.")
 @limiter.limit(RATE_LIMIT_PUBLIC_ANALYTICS)
 async def end_analytics_session(request: Request, data: PlaybackEnd):
     """End a playback session."""
@@ -2669,6 +2684,29 @@ async def end_analytics_session(request: Request, data: PlaybackEnd):
         VIDEOS_WATCH_TIME_SECONDS_TOTAL.inc(duration_watched)
 
     return {"status": "ok"}
+
+
+# =============================================================================
+# API Router Mounting (Issue #218)
+# Mount versioned routers and configure OpenAPI documentation
+# =============================================================================
+
+# Mount v1 router at /api/v1
+app.include_router(v1_router, prefix="/api/v1")
+logger.info("Mounted API v1 at /api/v1")
+
+# Mount legacy routes at /api for backwards compatibility (if enabled)
+if API_INCLUDE_LEGACY_ROUTES:
+    app.include_router(v1_router, prefix="/api", include_in_schema=False)
+    logger.info("Mounted legacy routes at /api (aliased to v1)")
+
+
+# Configure custom OpenAPI schema
+def custom_openapi():
+    return configure_openapi_schema(app)
+
+
+app.openapi = custom_openapi
 
 
 if __name__ == "__main__":

--- a/api/versioning.py
+++ b/api/versioning.py
@@ -203,9 +203,8 @@ class DeprecationHeadersRoute(APIRoute):
                             self.version_info.sunset_date
                         )
 
-                    # Link to current version documentation
-                    current_docs_url = f"/api/{API_VERSION}/docs"
-                    response.headers["Link"] = f'<{current_docs_url}>; rel="successor-version"'
+                    # Link to API documentation (FastAPI serves docs at /docs by default)
+                    response.headers["Link"] = '</docs>; rel="successor-version"'
                 except Exception as e:
                     # Don't fail the response if deprecation headers can't be added
                     logger.warning(f"Failed to add deprecation headers: {e}")

--- a/api/versioning.py
+++ b/api/versioning.py
@@ -1,0 +1,375 @@
+"""
+API Versioning Infrastructure (Issue #218)
+
+Provides utilities for versioned API routes, deprecation headers,
+and enhanced OpenAPI documentation.
+
+Usage:
+    from api.versioning import create_versioned_router, VersionInfo
+
+    # Create a versioned router
+    v1_router = create_versioned_router("v1")
+
+    # Add routes to the versioned router
+    @v1_router.get("/videos")
+    async def list_videos():
+        ...
+
+    # Include in app with version prefix
+    app.include_router(v1_router, prefix="/api/v1")
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from fastapi import APIRouter, Request, Response
+from fastapi.routing import APIRoute
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from config import (
+    API_DEPRECATION_NOTICE,
+    API_DEPRECATION_SUNSET,
+    API_INCLUDE_LEGACY_ROUTES,
+    API_SUPPORTED_VERSIONS,
+    API_VERSION,
+    OPENAPI_CONTACT_EMAIL,
+    OPENAPI_CONTACT_NAME,
+    OPENAPI_DESCRIPTION,
+    OPENAPI_LICENSE_NAME,
+    OPENAPI_LICENSE_URL,
+    OPENAPI_TERMS_OF_SERVICE,
+    OPENAPI_TITLE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VersionInfo:
+    """Information about an API version."""
+
+    version: str
+    is_current: bool = False
+    is_deprecated: bool = False
+    sunset_date: Optional[str] = None
+    description: Optional[str] = None
+
+    @property
+    def prefix(self) -> str:
+        """Return the URL prefix for this version (e.g., '/api/v1')."""
+        return f"/api/{self.version}"
+
+
+def get_version_info(version: str) -> VersionInfo:
+    """Get version information for a specific API version."""
+    is_current = version == API_VERSION
+    is_deprecated = not is_current and API_DEPRECATION_NOTICE
+    sunset_date = API_DEPRECATION_SUNSET if is_deprecated else None
+
+    return VersionInfo(
+        version=version,
+        is_current=is_current,
+        is_deprecated=is_deprecated,
+        sunset_date=sunset_date,
+        description=f"API version {version}" + (" (current)" if is_current else ""),
+    )
+
+
+def get_all_versions() -> List[VersionInfo]:
+    """Get information about all supported API versions."""
+    return [get_version_info(v) for v in API_SUPPORTED_VERSIONS]
+
+
+class DeprecationHeadersRoute(APIRoute):
+    """
+    Custom route class that adds deprecation headers to responses.
+
+    Adds the following headers for deprecated versions:
+    - Deprecation: true
+    - Sunset: <date> (if configured)
+    - Link: <docs-url>; rel="successor-version"
+    """
+
+    def __init__(self, *args, version_info: Optional[VersionInfo] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.version_info = version_info
+
+    def get_route_handler(self) -> Callable:
+        original_handler = super().get_route_handler()
+
+        async def custom_handler(request: Request) -> Response:
+            response: Response = await original_handler(request)
+
+            if self.version_info and self.version_info.is_deprecated:
+                response.headers["Deprecation"] = "true"
+
+                if self.version_info.sunset_date:
+                    response.headers["Sunset"] = self.version_info.sunset_date
+
+                # Link to current version documentation
+                current_docs_url = f"/api/{API_VERSION}/docs"
+                response.headers["Link"] = f'<{current_docs_url}>; rel="successor-version"'
+
+            return response
+
+        return custom_handler
+
+
+def create_versioned_router(
+    version: str,
+    *,
+    tags: Optional[List[str]] = None,
+    deprecated: Optional[bool] = None,
+) -> APIRouter:
+    """
+    Create an APIRouter configured for a specific API version.
+
+    Args:
+        version: Version string (e.g., "v1", "v2")
+        tags: Optional list of tags for OpenAPI documentation
+        deprecated: Override deprecation status (auto-detected if None)
+
+    Returns:
+        APIRouter configured with version-specific settings
+    """
+    version_info = get_version_info(version)
+
+    # Allow override of deprecation status
+    if deprecated is not None:
+        version_info = VersionInfo(
+            version=version_info.version,
+            is_current=version_info.is_current,
+            is_deprecated=deprecated,
+            sunset_date=version_info.sunset_date if deprecated else None,
+            description=version_info.description,
+        )
+
+    # Create router with deprecation-aware route class for deprecated versions
+    if version_info.is_deprecated:
+
+        class VersionedDeprecationRoute(DeprecationHeadersRoute):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, version_info=version_info, **kwargs)
+
+        route_class = VersionedDeprecationRoute
+    else:
+        route_class = APIRoute
+
+    router = APIRouter(
+        tags=tags or [f"API {version}"],
+        route_class=route_class,
+    )
+
+    return router
+
+
+class VersionHeaderMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that adds API version information to response headers.
+
+    Headers added:
+    - X-API-Version: Current API version
+    - X-API-Supported-Versions: Comma-separated list of supported versions
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+
+        # Only add version headers to API responses
+        if request.url.path.startswith("/api"):
+            response.headers["X-API-Version"] = API_VERSION
+            response.headers["X-API-Supported-Versions"] = ",".join(API_SUPPORTED_VERSIONS)
+
+        return response
+
+
+def configure_openapi_schema(
+    app,
+    *,
+    title: Optional[str] = None,
+    version: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Configure and return an enhanced OpenAPI schema for the application.
+
+    This function customizes the auto-generated OpenAPI schema with:
+    - Custom title, description, and version
+    - Contact and license information
+    - Version-specific server entries
+    - Enhanced endpoint descriptions
+
+    Args:
+        app: FastAPI application instance
+        title: Override title (uses OPENAPI_TITLE if not provided)
+        version: Override version (uses API_VERSION if not provided)
+        description: Override description (uses OPENAPI_DESCRIPTION if not provided)
+
+    Returns:
+        Dict containing the OpenAPI schema
+    """
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    from fastapi.openapi.utils import get_openapi
+
+    # Build info object
+    info: Dict[str, Any] = {
+        "title": title or OPENAPI_TITLE,
+        "version": version or API_VERSION,
+        "description": description or OPENAPI_DESCRIPTION,
+    }
+
+    if OPENAPI_TERMS_OF_SERVICE:
+        info["termsOfService"] = OPENAPI_TERMS_OF_SERVICE
+
+    if OPENAPI_CONTACT_NAME or OPENAPI_CONTACT_EMAIL:
+        info["contact"] = {}
+        if OPENAPI_CONTACT_NAME:
+            info["contact"]["name"] = OPENAPI_CONTACT_NAME
+        if OPENAPI_CONTACT_EMAIL:
+            info["contact"]["email"] = OPENAPI_CONTACT_EMAIL
+
+    if OPENAPI_LICENSE_NAME:
+        info["license"] = {"name": OPENAPI_LICENSE_NAME}
+        if OPENAPI_LICENSE_URL:
+            info["license"]["url"] = OPENAPI_LICENSE_URL
+
+    openapi_schema = get_openapi(
+        title=info["title"],
+        version=info["version"],
+        description=info["description"],
+        routes=app.routes,
+    )
+
+    # Add additional info fields
+    if "termsOfService" in info:
+        openapi_schema["info"]["termsOfService"] = info["termsOfService"]
+    if "contact" in info:
+        openapi_schema["info"]["contact"] = info["contact"]
+    if "license" in info:
+        openapi_schema["info"]["license"] = info["license"]
+
+    # Add version information to description
+    version_info_text = "\n\n## API Versions\n\n"
+    for v_info in get_all_versions():
+        status = "**Current**" if v_info.is_current else "Deprecated" if v_info.is_deprecated else "Supported"
+        version_info_text += f"- `{v_info.version}`: {status}\n"
+        if v_info.is_deprecated and v_info.sunset_date:
+            version_info_text += f"  - Sunset date: {v_info.sunset_date}\n"
+
+    openapi_schema["info"]["description"] = (openapi_schema["info"].get("description", "") + version_info_text).strip()
+
+    # Add servers for each version
+    openapi_schema["servers"] = [{"url": f"/api/{API_VERSION}", "description": f"Current API ({API_VERSION})"}]
+
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+def setup_versioned_api(app, routers: Dict[str, APIRouter]) -> None:
+    """
+    Set up versioned API routes on a FastAPI application.
+
+    This function:
+    1. Mounts versioned routers at their respective prefixes
+    2. Optionally adds legacy unversioned routes that alias to the current version
+    3. Adds version header middleware
+    4. Configures the OpenAPI schema
+
+    Args:
+        app: FastAPI application instance
+        routers: Dict mapping version strings to APIRouter instances
+            Example: {"v1": v1_router, "v2": v2_router}
+    """
+    # Add version header middleware
+    app.add_middleware(VersionHeaderMiddleware)
+
+    # Mount versioned routers
+    for version, router in routers.items():
+        app.include_router(router, prefix=f"/api/{version}")
+        logger.info(f"Mounted API {version} at /api/{version}")
+
+    # Add legacy routes if configured
+    if API_INCLUDE_LEGACY_ROUTES and API_VERSION in routers:
+        # Mount current version router without version prefix for backwards compatibility
+        app.include_router(
+            routers[API_VERSION],
+            prefix="/api",
+            include_in_schema=False,  # Don't duplicate in OpenAPI docs
+        )
+        logger.info(f"Mounted legacy routes at /api (aliased to {API_VERSION})")
+
+    # Configure OpenAPI schema
+    def custom_openapi():
+        return configure_openapi_schema(app)
+
+    app.openapi = custom_openapi
+
+
+# Response examples for common endpoints (for OpenAPI documentation)
+RESPONSE_EXAMPLES = {
+    "video_list": {
+        "description": "List of videos with pagination",
+        "content": {
+            "application/json": {
+                "example": {
+                    "videos": [
+                        {
+                            "id": 1,
+                            "slug": "example-video",
+                            "title": "Example Video",
+                            "status": "published",
+                            "duration": 120.5,
+                            "created_at": "2025-01-01T00:00:00Z",
+                        }
+                    ],
+                    "total": 1,
+                    "page": 1,
+                    "per_page": 20,
+                }
+            }
+        },
+    },
+    "video_detail": {
+        "description": "Video details",
+        "content": {
+            "application/json": {
+                "example": {
+                    "id": 1,
+                    "slug": "example-video",
+                    "title": "Example Video",
+                    "description": "A sample video",
+                    "status": "published",
+                    "duration": 120.5,
+                    "qualities": ["1080p", "720p", "480p"],
+                    "created_at": "2025-01-01T00:00:00Z",
+                }
+            }
+        },
+    },
+    "error_not_found": {
+        "description": "Resource not found",
+        "content": {"application/json": {"example": {"detail": "Video not found"}}},
+    },
+    "error_validation": {
+        "description": "Validation error",
+        "content": {
+            "application/json": {
+                "example": {
+                    "detail": [{"loc": ["query", "page"], "msg": "value must be greater than 0", "type": "value_error"}]
+                }
+            }
+        },
+    },
+    "error_rate_limit": {
+        "description": "Rate limit exceeded",
+        "content": {
+            "application/json": {
+                "example": {"error": "Rate limit exceeded", "retry_after": 60}
+            }
+        },
+    },
+}

--- a/api/versioning.py
+++ b/api/versioning.py
@@ -20,8 +20,8 @@ Usage:
 """
 
 import logging
+import re
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import APIRouter, Request, Response
@@ -44,6 +44,93 @@ from config import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Regex pattern for valid API version format (e.g., "v1", "v2", "v10")
+API_VERSION_PATTERN = re.compile(r"^v\d+$")
+
+
+def sanitize_header_value(value: str) -> str:
+    """
+    Sanitize a string for use in HTTP headers.
+
+    Removes carriage return and newline characters to prevent
+    HTTP header injection (CRLF injection) attacks.
+
+    Args:
+        value: The string to sanitize
+
+    Returns:
+        Sanitized string safe for use in HTTP headers
+    """
+    if not value:
+        return value
+    return value.replace("\r", "").replace("\n", "")
+
+
+def validate_config() -> None:
+    """
+    Validate API versioning configuration at startup.
+
+    Raises:
+        ValueError: If configuration is invalid
+
+    This function is called at module load to fail fast on
+    misconfiguration rather than causing runtime errors.
+    """
+    # Validate API_VERSION is set and non-empty
+    if not API_VERSION:
+        raise ValueError(
+            "VLOG_API_VERSION must be set and non-empty. "
+            "Example: VLOG_API_VERSION=v1"
+        )
+
+    # Validate API_VERSION matches expected format
+    if not API_VERSION_PATTERN.match(API_VERSION):
+        raise ValueError(
+            f"VLOG_API_VERSION '{API_VERSION}' has invalid format. "
+            f"Must match pattern 'v' followed by a number (e.g., 'v1', 'v2'). "
+            f"This prevents path injection vulnerabilities."
+        )
+
+    # Validate API_SUPPORTED_VERSIONS is set and non-empty
+    if not API_SUPPORTED_VERSIONS:
+        raise ValueError(
+            "API_SUPPORTED_VERSIONS must contain at least one version. "
+            "Check config.py to ensure API_SUPPORTED_VERSIONS is properly defined."
+        )
+
+    # Validate all supported versions match the expected format
+    for version in API_SUPPORTED_VERSIONS:
+        if not API_VERSION_PATTERN.match(version):
+            raise ValueError(
+                f"API_SUPPORTED_VERSIONS contains invalid version '{version}'. "
+                f"All versions must match pattern 'v' followed by a number."
+            )
+
+    # Warn if current version is not in supported versions
+    if API_VERSION not in API_SUPPORTED_VERSIONS:
+        logger.warning(
+            f"API_VERSION '{API_VERSION}' is not in API_SUPPORTED_VERSIONS "
+            f"{API_SUPPORTED_VERSIONS}. This may cause unexpected behavior."
+        )
+
+    # Validate deprecation sunset date format if set
+    if API_DEPRECATION_SUNSET:
+        # Check for CRLF injection attempts
+        if "\r" in API_DEPRECATION_SUNSET or "\n" in API_DEPRECATION_SUNSET:
+            raise ValueError(
+                "VLOG_API_DEPRECATION_SUNSET contains invalid characters (CR/LF). "
+                "This could enable HTTP header injection attacks."
+            )
+
+    logger.debug(
+        f"API versioning config validated: version={API_VERSION}, "
+        f"supported={API_SUPPORTED_VERSIONS}"
+    )
+
+
+# Validate configuration at module load (fail fast)
+validate_config()
 
 
 @dataclass
@@ -100,17 +187,28 @@ class DeprecationHeadersRoute(APIRoute):
         original_handler = super().get_route_handler()
 
         async def custom_handler(request: Request) -> Response:
-            response: Response = await original_handler(request)
+            try:
+                response: Response = await original_handler(request)
+            except Exception:
+                # Let exception propagate - deprecation headers aren't critical for errors
+                raise
 
             if self.version_info and self.version_info.is_deprecated:
-                response.headers["Deprecation"] = "true"
+                try:
+                    response.headers["Deprecation"] = "true"
 
-                if self.version_info.sunset_date:
-                    response.headers["Sunset"] = self.version_info.sunset_date
+                    if self.version_info.sunset_date:
+                        # Sanitize to prevent header injection
+                        response.headers["Sunset"] = sanitize_header_value(
+                            self.version_info.sunset_date
+                        )
 
-                # Link to current version documentation
-                current_docs_url = f"/api/{API_VERSION}/docs"
-                response.headers["Link"] = f'<{current_docs_url}>; rel="successor-version"'
+                    # Link to current version documentation
+                    current_docs_url = f"/api/{API_VERSION}/docs"
+                    response.headers["Link"] = f'<{current_docs_url}>; rel="successor-version"'
+                except Exception as e:
+                    # Don't fail the response if deprecation headers can't be added
+                    logger.warning(f"Failed to add deprecation headers: {e}")
 
             return response
 
@@ -172,15 +270,29 @@ class VersionHeaderMiddleware(BaseHTTPMiddleware):
     Headers added:
     - X-API-Version: Current API version
     - X-API-Supported-Versions: Comma-separated list of supported versions
+
+    This middleware includes error handling to ensure version header
+    failures don't crash the API or prevent responses from being sent.
     """
 
     async def dispatch(self, request: Request, call_next):
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception as e:
+            # Log that versioning failed on this request, then re-raise
+            logger.debug(f"Request failed before version headers could be added: {e}")
+            raise
 
-        # Only add version headers to API responses
-        if request.url.path.startswith("/api"):
-            response.headers["X-API-Version"] = API_VERSION
-            response.headers["X-API-Supported-Versions"] = ",".join(API_SUPPORTED_VERSIONS)
+        # Only add version headers to API responses (precise matching)
+        if request.url.path.startswith("/api/") or request.url.path == "/api":
+            try:
+                response.headers["X-API-Version"] = API_VERSION
+                response.headers["X-API-Supported-Versions"] = ",".join(
+                    API_SUPPORTED_VERSIONS
+                )
+            except Exception as e:
+                # Don't fail the request if header setting fails
+                logger.warning(f"Failed to add version headers: {e}")
 
         return response
 
@@ -201,6 +313,9 @@ def configure_openapi_schema(
     - Version-specific server entries
     - Enhanced endpoint descriptions
 
+    Includes error handling to return a minimal valid schema on failure,
+    ensuring the /docs endpoint remains functional.
+
     Args:
         app: FastAPI application instance
         title: Override title (uses OPENAPI_TITLE if not provided)
@@ -210,63 +325,93 @@ def configure_openapi_schema(
     Returns:
         Dict containing the OpenAPI schema
     """
+    # Return cached schema if available
     if app.openapi_schema:
         return app.openapi_schema
 
-    from fastapi.openapi.utils import get_openapi
+    try:
+        from fastapi.openapi.utils import get_openapi
 
-    # Build info object
-    info: Dict[str, Any] = {
-        "title": title or OPENAPI_TITLE,
-        "version": version or API_VERSION,
-        "description": description or OPENAPI_DESCRIPTION,
-    }
+        # Build info object
+        info: Dict[str, Any] = {
+            "title": title or OPENAPI_TITLE,
+            "version": version or API_VERSION,
+            "description": description or OPENAPI_DESCRIPTION,
+        }
 
-    if OPENAPI_TERMS_OF_SERVICE:
-        info["termsOfService"] = OPENAPI_TERMS_OF_SERVICE
+        if OPENAPI_TERMS_OF_SERVICE:
+            info["termsOfService"] = OPENAPI_TERMS_OF_SERVICE
 
-    if OPENAPI_CONTACT_NAME or OPENAPI_CONTACT_EMAIL:
-        info["contact"] = {}
-        if OPENAPI_CONTACT_NAME:
-            info["contact"]["name"] = OPENAPI_CONTACT_NAME
-        if OPENAPI_CONTACT_EMAIL:
-            info["contact"]["email"] = OPENAPI_CONTACT_EMAIL
+        if OPENAPI_CONTACT_NAME or OPENAPI_CONTACT_EMAIL:
+            info["contact"] = {}
+            if OPENAPI_CONTACT_NAME:
+                info["contact"]["name"] = OPENAPI_CONTACT_NAME
+            if OPENAPI_CONTACT_EMAIL:
+                info["contact"]["email"] = OPENAPI_CONTACT_EMAIL
 
-    if OPENAPI_LICENSE_NAME:
-        info["license"] = {"name": OPENAPI_LICENSE_NAME}
-        if OPENAPI_LICENSE_URL:
-            info["license"]["url"] = OPENAPI_LICENSE_URL
+        if OPENAPI_LICENSE_NAME:
+            info["license"] = {"name": OPENAPI_LICENSE_NAME}
+            if OPENAPI_LICENSE_URL:
+                info["license"]["url"] = OPENAPI_LICENSE_URL
 
-    openapi_schema = get_openapi(
-        title=info["title"],
-        version=info["version"],
-        description=info["description"],
-        routes=app.routes,
-    )
+        openapi_schema = get_openapi(
+            title=info["title"],
+            version=info["version"],
+            description=info["description"],
+            routes=app.routes,
+        )
 
-    # Add additional info fields
-    if "termsOfService" in info:
-        openapi_schema["info"]["termsOfService"] = info["termsOfService"]
-    if "contact" in info:
-        openapi_schema["info"]["contact"] = info["contact"]
-    if "license" in info:
-        openapi_schema["info"]["license"] = info["license"]
+        # Add additional info fields
+        if "termsOfService" in info:
+            openapi_schema["info"]["termsOfService"] = info["termsOfService"]
+        if "contact" in info:
+            openapi_schema["info"]["contact"] = info["contact"]
+        if "license" in info:
+            openapi_schema["info"]["license"] = info["license"]
 
-    # Add version information to description
-    version_info_text = "\n\n## API Versions\n\n"
-    for v_info in get_all_versions():
-        status = "**Current**" if v_info.is_current else "Deprecated" if v_info.is_deprecated else "Supported"
-        version_info_text += f"- `{v_info.version}`: {status}\n"
-        if v_info.is_deprecated and v_info.sunset_date:
-            version_info_text += f"  - Sunset date: {v_info.sunset_date}\n"
+        # Add version information to description
+        version_info_text = "\n\n## API Versions\n\n"
+        for v_info in get_all_versions():
+            status = (
+                "**Current**"
+                if v_info.is_current
+                else "Deprecated"
+                if v_info.is_deprecated
+                else "Supported"
+            )
+            version_info_text += f"- `{v_info.version}`: {status}\n"
+            if v_info.is_deprecated and v_info.sunset_date:
+                version_info_text += f"  - Sunset date: {v_info.sunset_date}\n"
 
-    openapi_schema["info"]["description"] = (openapi_schema["info"].get("description", "") + version_info_text).strip()
+        openapi_schema["info"]["description"] = (
+            openapi_schema["info"].get("description", "") + version_info_text
+        ).strip()
 
-    # Add servers for each version
-    openapi_schema["servers"] = [{"url": f"/api/{API_VERSION}", "description": f"Current API ({API_VERSION})"}]
+        # Add servers for each version
+        openapi_schema["servers"] = [
+            {"url": f"/api/{API_VERSION}", "description": f"Current API ({API_VERSION})"}
+        ]
 
-    app.openapi_schema = openapi_schema
-    return app.openapi_schema
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    except Exception as e:
+        # Log the error and return a minimal valid schema
+        logger.error(f"OpenAPI schema generation failed: {e}", exc_info=True)
+
+        # Return minimal valid OpenAPI schema so /docs still works
+        minimal_schema = {
+            "openapi": "3.1.0",
+            "info": {
+                "title": title or OPENAPI_TITLE or "API",
+                "version": version or API_VERSION or "1.0.0",
+                "description": f"OpenAPI schema generation encountered an error: {str(e)}",
+            },
+            "paths": {},
+        }
+
+        # Don't cache the error schema - allow retry on next request
+        return minimal_schema
 
 
 def setup_versioned_api(app, routers: Dict[str, APIRouter]) -> None:
@@ -307,69 +452,3 @@ def setup_versioned_api(app, routers: Dict[str, APIRouter]) -> None:
         return configure_openapi_schema(app)
 
     app.openapi = custom_openapi
-
-
-# Response examples for common endpoints (for OpenAPI documentation)
-RESPONSE_EXAMPLES = {
-    "video_list": {
-        "description": "List of videos with pagination",
-        "content": {
-            "application/json": {
-                "example": {
-                    "videos": [
-                        {
-                            "id": 1,
-                            "slug": "example-video",
-                            "title": "Example Video",
-                            "status": "published",
-                            "duration": 120.5,
-                            "created_at": "2025-01-01T00:00:00Z",
-                        }
-                    ],
-                    "total": 1,
-                    "page": 1,
-                    "per_page": 20,
-                }
-            }
-        },
-    },
-    "video_detail": {
-        "description": "Video details",
-        "content": {
-            "application/json": {
-                "example": {
-                    "id": 1,
-                    "slug": "example-video",
-                    "title": "Example Video",
-                    "description": "A sample video",
-                    "status": "published",
-                    "duration": 120.5,
-                    "qualities": ["1080p", "720p", "480p"],
-                    "created_at": "2025-01-01T00:00:00Z",
-                }
-            }
-        },
-    },
-    "error_not_found": {
-        "description": "Resource not found",
-        "content": {"application/json": {"example": {"detail": "Video not found"}}},
-    },
-    "error_validation": {
-        "description": "Validation error",
-        "content": {
-            "application/json": {
-                "example": {
-                    "detail": [{"loc": ["query", "page"], "msg": "value must be greater than 0", "type": "value_error"}]
-                }
-            }
-        },
-    },
-    "error_rate_limit": {
-        "description": "Rate limit exceeded",
-        "content": {
-            "application/json": {
-                "example": {"error": "Rate limit exceeded", "retry_after": 60}
-            }
-        },
-    },
-}

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -72,7 +72,7 @@ from pathlib import Path
 from typing import Optional
 
 import sqlalchemy as sa
-from fastapi import Depends, FastAPI, File, Header, HTTPException, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, FastAPI, File, Header, HTTPException, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from slowapi import Limiter
@@ -136,6 +136,10 @@ from api.worker_schemas import (
     WorkerStatusResponse,
 )
 from config import (
+    API_INCLUDE_LEGACY_ROUTES,
+    API_VERSION,
+    OPENAPI_DESCRIPTION,
+    OPENAPI_TITLE,
     MAX_HLS_ARCHIVE_FILES,
     MAX_HLS_ARCHIVE_SIZE,
     MAX_HLS_SINGLE_FILE_SIZE,
@@ -161,6 +165,8 @@ from config import (
     WORKER_HEARTBEAT_INTERVAL,
     WORKER_OFFLINE_THRESHOLD_MINUTES,
 )
+
+from api.versioning import VersionHeaderMiddleware, configure_openapi_schema
 
 logger = logging.getLogger(__name__)
 security_logger = logging.getLogger("security.worker_auth")
@@ -1069,14 +1075,18 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="VLog Worker API",
-    description="API for distributed transcoding workers",
-    version="1.0.0",
+    title=f"{OPENAPI_TITLE} Worker",
+    description=f"{OPENAPI_DESCRIPTION} - Worker API for distributed transcoding",
+    version=API_VERSION,
     lifespan=lifespan,
 )
 
+# Create versioned API router for worker endpoints
+v1_router = APIRouter(tags=["Worker API v1"])
+
 # Request ID middleware for tracing
 app.add_middleware(RequestIDMiddleware)
+app.add_middleware(VersionHeaderMiddleware)
 
 # CORS - allow all origins since workers use API key auth (not cookies)
 # Note: allow_credentials must be False with wildcard origins per CORS spec
@@ -1103,7 +1113,7 @@ app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 # =============================================================================
 
 
-@app.post("/api/worker/register", response_model=WorkerRegisterResponse)
+@v1_router.post("/worker/register", response_model=WorkerRegisterResponse)
 @limiter.limit(RATE_LIMIT_WORKER_REGISTER)
 async def register_worker(
     request: Request,
@@ -1216,7 +1226,7 @@ async def register_worker(
 # =============================================================================
 
 
-@app.post("/api/worker/heartbeat", response_model=HeartbeatResponse)
+@v1_router.post("/worker/heartbeat", response_model=HeartbeatResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def worker_heartbeat(
     request: Request,
@@ -1371,7 +1381,7 @@ def worker_has_gpu(worker: dict) -> bool:
     return False
 
 
-@app.post("/api/worker/claim", response_model=ClaimJobResponse)
+@v1_router.post("/worker/claim", response_model=ClaimJobResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def claim_job(
     request: Request,
@@ -1744,7 +1754,7 @@ async def claim_job(
 # =============================================================================
 
 
-@app.post("/api/worker/{job_id}/progress", response_model=ProgressUpdateResponse)
+@v1_router.post("/worker/{job_id}/progress", response_model=ProgressUpdateResponse)
 @limiter.limit(RATE_LIMIT_WORKER_PROGRESS)
 async def update_progress(
     request: Request,
@@ -1861,7 +1871,7 @@ async def update_progress(
 # =============================================================================
 
 
-@app.post("/api/worker/{job_id}/complete", response_model=CompleteJobResponse)
+@v1_router.post("/worker/{job_id}/complete", response_model=CompleteJobResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def complete_job(
     request: Request,
@@ -2071,7 +2081,7 @@ async def complete_job(
 # =============================================================================
 
 
-@app.post("/api/worker/{job_id}/fail", response_model=FailJobResponse)
+@v1_router.post("/worker/{job_id}/fail", response_model=FailJobResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def fail_job(
     request: Request,
@@ -2190,7 +2200,7 @@ async def fail_job(
 # =============================================================================
 
 
-@app.get("/api/worker/source/{video_id}")
+@v1_router.get("/worker/source/{video_id}")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def download_source(
     request: Request,
@@ -2237,7 +2247,7 @@ async def download_source(
     )
 
 
-@app.post("/api/worker/upload/{video_id}/quality/{quality_name}", response_model=StatusResponse)
+@v1_router.post("/worker/upload/{video_id}/quality/{quality_name}", response_model=StatusResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def upload_quality(
     request: Request,
@@ -2333,7 +2343,7 @@ async def upload_quality(
     return StatusResponse(status="ok", message=f"Quality {quality_name} uploaded successfully")
 
 
-@app.post("/api/worker/upload/{video_id}/finalize", response_model=StatusResponse)
+@v1_router.post("/worker/upload/{video_id}/finalize", response_model=StatusResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def upload_finalize(
     request: Request,
@@ -2411,7 +2421,7 @@ async def upload_finalize(
     return StatusResponse(status="ok", message="Finalize files uploaded successfully")
 
 
-@app.post("/api/worker/upload/{video_id}", response_model=StatusResponse)
+@v1_router.post("/worker/upload/{video_id}", response_model=StatusResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def upload_hls(
     request: Request,
@@ -2931,7 +2941,7 @@ async def finalize_segment_upload(
 # =============================================================================
 
 
-@app.get("/api/workers", response_model=WorkerListResponse)
+@v1_router.get("/workers", response_model=WorkerListResponse)
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def list_workers(
     request: Request,
@@ -3003,7 +3013,7 @@ async def list_workers(
     )
 
 
-@app.post("/api/workers/{worker_id}/revoke", response_model=StatusResponse)
+@v1_router.post("/workers/{worker_id}/revoke", response_model=StatusResponse)
 @limiter.limit(RATE_LIMIT_WORKER_REGISTER)
 async def revoke_worker(
     request: Request,
@@ -3036,7 +3046,7 @@ async def revoke_worker(
     return StatusResponse(status="ok", message=f"Worker {worker_id} has been revoked")
 
 
-@app.get("/api/health")
+@v1_router.get("/health")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def health_check(request: Request):
     """
@@ -3119,7 +3129,7 @@ async def metrics_endpoint(request: Request):
 # =============================================================================
 
 
-@app.post("/api/reencode/claim")
+@v1_router.post("/reencode/claim")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def claim_reencode_job(
     request: Request,
@@ -3176,7 +3186,7 @@ async def claim_reencode_job(
     }
 
 
-@app.get("/api/reencode/{job_id}/download")
+@v1_router.get("/reencode/{job_id}/download")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def download_reencode_source(
     request: Request,
@@ -3249,7 +3259,7 @@ async def download_reencode_source(
         raise HTTPException(status_code=500, detail=f"Failed to package files: {e}")
 
 
-@app.post("/api/reencode/{job_id}/upload")
+@v1_router.post("/reencode/{job_id}/upload")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def upload_reencode_result(
     request: Request,
@@ -3348,7 +3358,7 @@ async def upload_reencode_result(
         raise HTTPException(status_code=500, detail=f"Upload failed: {e}")
 
 
-@app.patch("/api/reencode/{job_id}")
+@v1_router.patch("/reencode/{job_id}")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def update_reencode_job(
     request: Request,
@@ -3393,7 +3403,7 @@ async def update_reencode_job(
 # =============================================================================
 
 
-@app.get("/api/worker/{job_id}/verify-complete")
+@v1_router.get("/worker/{job_id}/verify-complete")
 @limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
 async def verify_job_completion(
     request: Request,
@@ -3505,6 +3515,29 @@ async def verify_job_completion(
     )
 
     return result
+
+
+# =============================================================================
+# API Router Mounting (Issue #218)
+# Mount versioned routers and configure OpenAPI documentation
+# =============================================================================
+
+# Mount v1 router at /api/v1
+app.include_router(v1_router, prefix="/api/v1")
+logger.info("Mounted Worker API v1 at /api/v1")
+
+# Mount legacy routes at /api for backwards compatibility (if enabled)
+if API_INCLUDE_LEGACY_ROUTES:
+    app.include_router(v1_router, prefix="/api", include_in_schema=False)
+    logger.info("Mounted legacy worker routes at /api (aliased to v1)")
+
+
+# Configure custom OpenAPI schema
+def custom_openapi():
+    return configure_openapi_schema(app)
+
+
+app.openapi = custom_openapi
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -217,6 +217,43 @@ ARCHIVE_RETENTION_DAYS = get_int_env("VLOG_ARCHIVE_RETENTION_DAYS", 30, min_val=
 PUBLIC_PORT = get_int_env("VLOG_PUBLIC_PORT", 9000, min_val=1, max_val=65535)
 ADMIN_PORT = get_int_env("VLOG_ADMIN_PORT", 9001, min_val=1, max_val=65535)
 
+# =============================================================================
+# API Versioning Configuration (Issue #218)
+# Supports versioned API routes (e.g., /api/v1/videos) and OpenAPI documentation
+# =============================================================================
+
+# Current API version (used in route prefixes and documentation)
+# Changing this does NOT affect existing routes - it only sets the "current" version marker
+API_VERSION = os.getenv("VLOG_API_VERSION", "v1")
+
+# List of supported API versions (for documentation and deprecation notices)
+# Versions listed here will have routes registered and documentation generated
+API_SUPPORTED_VERSIONS = ["v1"]
+
+# Enable deprecation notices for older API versions
+# When True, deprecated versions include Deprecation and Sunset headers
+API_DEPRECATION_NOTICE = os.getenv("VLOG_API_DEPRECATION_NOTICE", "true").lower() in ("true", "1", "yes")
+
+# Sunset date for deprecated API versions (ISO 8601 format)
+# Leave empty to not include Sunset header
+API_DEPRECATION_SUNSET = os.getenv("VLOG_API_DEPRECATION_SUNSET", "")
+
+# Include legacy unversioned routes (/api/videos) that alias to current version
+# Set to false to require explicit version in all API requests
+API_INCLUDE_LEGACY_ROUTES = os.getenv("VLOG_API_INCLUDE_LEGACY_ROUTES", "true").lower() in ("true", "1", "yes")
+
+# OpenAPI documentation customization
+OPENAPI_TITLE = os.getenv("VLOG_OPENAPI_TITLE", "VLog API")
+OPENAPI_DESCRIPTION = os.getenv(
+    "VLOG_OPENAPI_DESCRIPTION",
+    "Self-hosted video platform API with versioned endpoints",
+)
+OPENAPI_TERMS_OF_SERVICE = os.getenv("VLOG_OPENAPI_TERMS_OF_SERVICE", "")
+OPENAPI_CONTACT_NAME = os.getenv("VLOG_OPENAPI_CONTACT_NAME", "")
+OPENAPI_CONTACT_EMAIL = os.getenv("VLOG_OPENAPI_CONTACT_EMAIL", "")
+OPENAPI_LICENSE_NAME = os.getenv("VLOG_OPENAPI_LICENSE_NAME", "")
+OPENAPI_LICENSE_URL = os.getenv("VLOG_OPENAPI_LICENSE_URL", "")
+
 # Transcoding quality presets (YouTube-style)
 QUALITY_PRESETS = [
     {"name": "2160p", "height": 2160, "bitrate": "15000k", "audio_bitrate": "192k"},

--- a/tests/test_api_versioning.py
+++ b/tests/test_api_versioning.py
@@ -1,0 +1,186 @@
+"""
+Tests for API versioning functionality (Issue #218).
+
+Tests cover:
+- Versioned endpoints at /api/v1/* work correctly
+- X-API-Version and X-API-Supported-Versions headers are present
+- Deprecation headers for deprecated versions
+- Configuration validation
+- Legacy route behavior
+"""
+
+import pytest
+
+
+class TestVersionHeaders:
+    """Test API version headers are present in responses."""
+
+    def test_version_header_on_versioned_endpoint(self, public_client):
+        """Test X-API-Version header is present on /api/v1/* endpoints."""
+        response = public_client.get("/api/v1/videos")
+        assert response.status_code == 200
+        assert "X-API-Version" in response.headers
+        assert response.headers["X-API-Version"] == "v1"
+
+    def test_supported_versions_header(self, public_client):
+        """Test X-API-Supported-Versions header is present."""
+        response = public_client.get("/api/v1/videos")
+        assert response.status_code == 200
+        assert "X-API-Supported-Versions" in response.headers
+        assert "v1" in response.headers["X-API-Supported-Versions"]
+
+    def test_version_headers_on_admin_api(self, admin_client):
+        """Test version headers are present on admin API."""
+        response = admin_client.get("/api/v1/videos")
+        assert response.status_code == 200
+        assert "X-API-Version" in response.headers
+        assert "X-API-Supported-Versions" in response.headers
+
+    def test_no_version_headers_on_non_api_endpoints(self, public_client):
+        """Test version headers are NOT added to non-API endpoints."""
+        response = public_client.get("/health")
+        # Health endpoint should not have version headers
+        assert "X-API-Version" not in response.headers
+
+
+class TestVersionedEndpoints:
+    """Test versioned API endpoints work correctly."""
+
+    def test_v1_videos_endpoint(self, public_client):
+        """Test /api/v1/videos endpoint works."""
+        response = public_client.get("/api/v1/videos")
+        assert response.status_code == 200
+        data = response.json()
+        assert "videos" in data
+
+    def test_v1_categories_endpoint(self, public_client):
+        """Test /api/v1/categories endpoint works."""
+        response = public_client.get("/api/v1/categories")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+
+    def test_admin_v1_videos_endpoint(self, admin_client):
+        """Test admin /api/v1/videos endpoint works."""
+        response = admin_client.get("/api/v1/videos")
+        assert response.status_code == 200
+
+
+class TestLegacyRoutes:
+    """Test legacy unversioned routes behavior."""
+
+    def test_legacy_videos_endpoint(self, public_client):
+        """Test legacy /api/videos endpoint works (aliases to v1)."""
+        response = public_client.get("/api/videos")
+        assert response.status_code == 200
+        data = response.json()
+        assert "videos" in data
+
+    def test_legacy_and_versioned_return_same_data(self, public_client):
+        """Test legacy and versioned endpoints return the same data."""
+        legacy_response = public_client.get("/api/videos")
+        versioned_response = public_client.get("/api/v1/videos")
+
+        assert legacy_response.status_code == versioned_response.status_code
+        assert legacy_response.json() == versioned_response.json()
+
+
+class TestConfigValidation:
+    """Test API versioning configuration validation."""
+
+    def test_validate_config_accepts_valid_version(self):
+        """Test validate_config accepts valid version formats."""
+        from api.versioning import API_VERSION_PATTERN
+
+        assert API_VERSION_PATTERN.match("v1")
+        assert API_VERSION_PATTERN.match("v2")
+        assert API_VERSION_PATTERN.match("v10")
+        assert API_VERSION_PATTERN.match("v123")
+
+    def test_validate_config_rejects_invalid_version(self):
+        """Test validate_config rejects invalid version formats."""
+        from api.versioning import API_VERSION_PATTERN
+
+        assert not API_VERSION_PATTERN.match("1")
+        assert not API_VERSION_PATTERN.match("version1")
+        assert not API_VERSION_PATTERN.match("v")
+        assert not API_VERSION_PATTERN.match("V1")
+        assert not API_VERSION_PATTERN.match("v1.0")
+        assert not API_VERSION_PATTERN.match("v1/../../etc")
+
+
+class TestHeaderSanitization:
+    """Test header sanitization for security."""
+
+    def test_sanitize_header_value_removes_crlf(self):
+        """Test sanitize_header_value removes CR/LF characters."""
+        from api.versioning import sanitize_header_value
+
+        assert sanitize_header_value("normal value") == "normal value"
+        assert sanitize_header_value("value\r\ninjection") == "valueinjection"
+        assert sanitize_header_value("value\rinjection") == "valueinjection"
+        assert sanitize_header_value("value\ninjection") == "valueinjection"
+        assert sanitize_header_value("") == ""
+        assert sanitize_header_value(None) is None
+
+    def test_sanitize_header_preserves_valid_content(self):
+        """Test sanitize_header_value preserves valid header content."""
+        from api.versioning import sanitize_header_value
+
+        # RFC 5322 date format
+        date = "Sat, 01 Jan 2028 00:00:00 GMT"
+        assert sanitize_header_value(date) == date
+
+
+class TestVersionInfo:
+    """Test VersionInfo dataclass functionality."""
+
+    def test_version_info_prefix(self):
+        """Test VersionInfo.prefix property returns correct URL prefix."""
+        from api.versioning import VersionInfo
+
+        info = VersionInfo(version="v1")
+        assert info.prefix == "/api/v1"
+
+        info = VersionInfo(version="v2")
+        assert info.prefix == "/api/v2"
+
+    def test_get_version_info(self):
+        """Test get_version_info returns correct information."""
+        from api.versioning import get_version_info
+
+        info = get_version_info("v1")
+        assert info.version == "v1"
+        assert info.is_current is True  # v1 is the current version
+
+    def test_get_all_versions(self):
+        """Test get_all_versions returns all supported versions."""
+        from api.versioning import get_all_versions
+
+        versions = get_all_versions()
+        assert len(versions) >= 1
+        assert any(v.version == "v1" for v in versions)
+
+
+class TestOpenAPISchema:
+    """Test OpenAPI schema configuration."""
+
+    def test_openapi_schema_includes_version_info(self, public_client):
+        """Test OpenAPI schema includes version information."""
+        response = public_client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+
+        assert "info" in schema
+        assert "version" in schema["info"]
+        assert schema["info"]["version"] == "v1"
+
+    def test_openapi_schema_has_description(self, public_client):
+        """Test OpenAPI schema has description with version info."""
+        response = public_client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+
+        assert "description" in schema["info"]
+        # Description should mention API versions
+        assert "v1" in schema["info"]["description"]


### PR DESCRIPTION
## Summary

This PR implements API versioning and improves OpenAPI documentation as requested in #218.

### Changes

- **Versioned API Routes**: All three APIs (public, admin, worker) now support versioned routes:
  - `/api/v1/videos` (new versioned endpoint)
  - `/api/videos` (legacy endpoint, aliased to v1 for backwards compatibility)

- **New Versioning Module** (`api/versioning.py`):
  - `create_versioned_router()` - Create routers with version-specific settings
  - `VersionHeaderMiddleware` - Adds `X-API-Version` and `X-API-Supported-Versions` headers
  - `configure_openapi_schema()` - Enhanced OpenAPI documentation with version info
  - `DeprecationHeadersRoute` - Automatic deprecation headers for deprecated versions

- **Configuration Options** (in `config.py`):
  - `VLOG_API_VERSION` - Current API version (default: `v1`)
  - `VLOG_API_DEPRECATION_NOTICE` - Enable deprecation notices
  - `VLOG_API_DEPRECATION_SUNSET` - Sunset date for deprecated versions
  - `VLOG_API_INCLUDE_LEGACY_ROUTES` - Enable backwards-compatible legacy routes
  - `VLOG_OPENAPI_*` - OpenAPI documentation customization

- **Enhanced OpenAPI Documentation**:
  - Added summaries and descriptions to all public API endpoints
  - Version information included in OpenAPI schema
  - Contact and license info support

### URL Structure

```
/api/v1/videos           # Versioned API (current)
/api/videos              # Legacy alias (backwards compatible)
```

### Response Headers

All API responses now include:
```
X-API-Version: v1
X-API-Supported-Versions: v1
```

### Backwards Compatibility

- All existing `/api/*` routes continue to work
- Legacy routes are aliased to the current version
- Can be disabled with `VLOG_API_INCLUDE_LEGACY_ROUTES=false`

## Test plan

- [x] Verify public API tests pass
- [x] Verify admin API tests pass  
- [x] Verify all APIs can be imported correctly
- [x] Verify versioning module works correctly
- [ ] Manual testing of versioned endpoints

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)