### PR TITLE
feat(playback): Implement Up Next autoplay feature (Issue #211)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -438,6 +438,22 @@ VLOG_DOWNLOADS_RATE_LIMIT_PER_HOUR=10
 VLOG_DOWNLOADS_MAX_CONCURRENT=2
 
 # =============================================================================
+# Playback Settings (Issue #211) [MIGRATABLE]
+# Autoplay and "Up Next" video suggestions
+# =============================================================================
+
+# Enable autoplay feature globally (can be overridden by user preferences)
+# When enabled, the next video will automatically play after the current ends
+VLOG_AUTOPLAY_ENABLED=true
+
+# Enable "Up Next" suggestions after video ends
+# Shows a countdown overlay with the next recommended video
+VLOG_UPNEXT_ENABLED=true
+
+# Countdown duration in seconds before autoplay starts (5-30)
+VLOG_AUTOPLAY_COUNTDOWN_SECONDS=10
+
+# =============================================================================
 # Cookie Security
 # =============================================================================
 

--- a/api/public.py
+++ b/api/public.py
@@ -134,9 +134,12 @@ _cached_watermark_settings_time: float = 0
 _WATERMARK_SETTINGS_CACHE_TTL = 60  # Refresh every 60 seconds
 
 # Video list cache for performance (Issue #429)
-# Caches video list query results for 300 seconds to reduce database load
-# Performance review (Issue #211): Increased from 30s to 300s for reduced DB load
-_video_list_cache = AnalyticsCache(ttl_seconds=300, enabled=True, max_size=500)
+# Caches video list query results to reduce database load.
+# Performance review (Issue #211): Increased default from 30s to 300s for reduced DB load.
+# TTL is configurable via the VIDEO_LIST_CACHE_TTL environment variable (seconds).
+_VIDEO_LIST_CACHE_TTL_DEFAULT = 300
+_VIDEO_LIST_CACHE_TTL = int(os.getenv("VIDEO_LIST_CACHE_TTL", _VIDEO_LIST_CACHE_TTL_DEFAULT))
+_video_list_cache = AnalyticsCache(ttl_seconds=_VIDEO_LIST_CACHE_TTL, enabled=True, max_size=500)
 
 
 async def get_watermark_settings() -> Dict[str, Any]:

--- a/api/public.py
+++ b/api/public.py
@@ -13,7 +13,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 import sqlalchemy as sa
@@ -134,8 +134,9 @@ _cached_watermark_settings_time: float = 0
 _WATERMARK_SETTINGS_CACHE_TTL = 60  # Refresh every 60 seconds
 
 # Video list cache for performance (Issue #429)
-# Caches video list query results for 30 seconds to reduce database load
-_video_list_cache = AnalyticsCache(ttl_seconds=30, enabled=True, max_size=500)
+# Caches video list query results for 300 seconds to reduce database load
+# Performance review (Issue #211): Increased from 30s to 300s for reduced DB load
+_video_list_cache = AnalyticsCache(ttl_seconds=300, enabled=True, max_size=500)
 
 
 async def get_watermark_settings() -> Dict[str, Any]:
@@ -1513,50 +1514,34 @@ async def _fetch_related_videos_tier(
     return await fetch_all_with_retry(query)
 
 
-@v1_router.get("/videos/{slug}/related", summary="Get related videos", description="Get videos related to the specified video based on tags and category.")
-@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
-async def get_related_videos(
-    request: Request,
+async def _find_related_videos_for_slug(
     slug: str,
-    limit: int = Query(default=12, ge=1, le=24, description="Maximum number of related videos to return"),
-) -> List[VideoListResponse]:
+    limit: int = 12,
+    parallelize: bool = False,
+) -> List[Dict[str, Any]]:
     """
-    Get related videos for a given video.
+    Shared helper to find related videos for a given video slug.
 
-    Algorithm priority (with early termination when limit reached):
+    Implements the tiered algorithm:
     1. Same category + shared tags (highest relevance)
     2. Same category only
     3. Shared tags only
     4. Recent videos (fallback)
 
-    Results are cached for 30 seconds using the video list cache.
-
     Args:
-        slug: The video slug to find related videos for
-        limit: Maximum number of related videos (1-24, default 12)
+        slug: The source video slug
+        limit: Maximum number of related videos to return
+        parallelize: If True, run all tier queries in parallel (optimal for limit=1)
 
     Returns:
-        List of related videos sorted by relevance tier then recency
+        List of related video row dicts, or empty list if source not found
+
+    Raises:
+        HTTPException: If video not found (404)
     """
-    # Validate slug to prevent injection attacks
+    # Validate slug
     if not validate_slug(slug):
         raise HTTPException(status_code=400, detail="Invalid video slug")
-
-    # Build cache key with SHA256 hash to prevent cache poisoning
-    # High priority fix (Margo): Include schema version in cache key
-    RELATED_VIDEOS_CACHE_VERSION = "v1"  # Increment on schema changes
-    cache_key_raw = f"related:{RELATED_VIDEOS_CACHE_VERSION}:{slug}|{limit}"
-    cache_key = f"related:{hashlib.sha256(cache_key_raw.encode()).hexdigest()[:16]}"
-
-    # Check cache first
-    cached = _video_list_cache.get(cache_key)
-    if cached is not None:
-        try:
-            return [VideoListResponse(**v) for v in cached]
-        except Exception as e:
-            # Cache schema mismatch after deploy, invalidate and regenerate
-            logger.warning(f"Cached related videos schema mismatch, invalidating: {e}")
-            _video_list_cache.delete(cache_key)
 
     # Get the source video with its category
     video_query = (
@@ -1579,9 +1564,70 @@ async def get_related_videos(
     tag_rows = await fetch_all_with_retry(tag_query)
     source_tag_ids = [r["tag_id"] for r in tag_rows] if tag_rows else []
 
-    # Collect related videos using tiered algorithm with early termination
-    related_videos: List[Dict[str, Any]] = []
     seen_ids: set = {video_id}  # Always exclude the source video
+
+    if parallelize:
+        # Performance optimization: Run all tiers in parallel for limit=1 (Issue #211)
+        # This is optimal when we just need one result and don't know which tier will succeed
+        # Build list of (priority, coroutine) tuples - only include applicable tiers
+        tier_coros: List[Tuple[int, Any]] = []
+
+        # Tier 1: Same category + shared tags (highest relevance)
+        if category_id is not None and source_tag_ids:
+            tier_coros.append((1, _fetch_related_videos_tier(
+                category_id=category_id,
+                tag_ids=source_tag_ids,
+                exclude_ids=seen_ids,
+                limit=limit,
+            )))
+
+        # Tier 2: Same category only
+        if category_id is not None:
+            tier_coros.append((2, _fetch_related_videos_tier(
+                category_id=category_id,
+                tag_ids=None,
+                exclude_ids=seen_ids,
+                limit=limit,
+            )))
+
+        # Tier 3: Shared tags only
+        if source_tag_ids:
+            tier_coros.append((3, _fetch_related_videos_tier(
+                category_id=None,
+                tag_ids=source_tag_ids,
+                exclude_ids=seen_ids,
+                limit=limit,
+            )))
+
+        # Tier 4: Recent videos fallback (always included)
+        tier_coros.append((4, _fetch_related_videos_tier(
+            category_id=None,
+            tag_ids=None,
+            exclude_ids=seen_ids,
+            limit=limit,
+        )))
+
+        # Run all applicable tiers in parallel
+        tier_results = await asyncio.gather(
+            *[coro for _, coro in tier_coros],
+            return_exceptions=True
+        )
+
+        # Match results back to priorities and find first non-empty by priority
+        results_with_priority = list(zip([p for p, _ in tier_coros], tier_results))
+        results_with_priority.sort(key=lambda x: x[0])  # Sort by priority
+
+        for priority, tier_result in results_with_priority:
+            if isinstance(tier_result, Exception):
+                logger.warning(f"Tier {priority} query failed: {tier_result}")
+                continue
+            if tier_result:
+                return tier_result[:limit]
+
+        return []
+
+    # Sequential execution with early termination (optimal for larger limits)
+    related_videos: List[Dict[str, Any]] = []
 
     # Tier 1: Same category + shared tags (highest relevance)
     if category_id is not None and source_tag_ids:
@@ -1638,6 +1684,52 @@ async def get_related_videos(
                 related_videos.append(v)
                 seen_ids.add(v["id"])
 
+    return related_videos
+
+
+@v1_router.get("/videos/{slug}/related", summary="Get related videos", description="Get videos related to the specified video based on tags and category.")
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def get_related_videos(
+    request: Request,
+    slug: str,
+    limit: int = Query(default=12, ge=1, le=24, description="Maximum number of related videos to return"),
+) -> List[VideoListResponse]:
+    """
+    Get related videos for a given video.
+
+    Algorithm priority (with early termination when limit reached):
+    1. Same category + shared tags (highest relevance)
+    2. Same category only
+    3. Shared tags only
+    4. Recent videos (fallback)
+
+    Results are cached for 300 seconds using the video list cache.
+
+    Args:
+        slug: The video slug to find related videos for
+        limit: Maximum number of related videos (1-24, default 12)
+
+    Returns:
+        List of related videos sorted by relevance tier then recency
+    """
+    # Build cache key with SHA256 hash to prevent cache poisoning
+    RELATED_VIDEOS_CACHE_VERSION = "v1"  # Increment on schema changes
+    cache_key_raw = f"related:{RELATED_VIDEOS_CACHE_VERSION}:{slug}|{limit}"
+    cache_key = f"related:{hashlib.sha256(cache_key_raw.encode()).hexdigest()[:16]}"
+
+    # Check cache first
+    cached = _video_list_cache.get(cache_key)
+    if cached is not None:
+        try:
+            return [VideoListResponse(**v) for v in cached]
+        except Exception as e:
+            # Cache schema mismatch after deploy, invalidate and regenerate
+            logger.warning(f"Cached related videos schema mismatch, invalidating: {e}")
+            _video_list_cache.delete(cache_key)
+
+    # Use shared helper for the tiered algorithm
+    related_videos = await _find_related_videos_for_slug(slug, limit=limit, parallelize=False)
+
     # Get tags for all related videos
     video_ids = [v["id"] for v in related_videos]
     video_tags_map = await get_video_tags(video_ids)
@@ -1662,7 +1754,7 @@ async def get_next_video(
 
     Returns the single best related video for the "Up Next" feature.
     Uses the same tiered algorithm as related videos but returns only
-    the top result.
+    the top result. Parallelizes tier queries for optimal latency.
 
     Args:
         slug: The current video slug
@@ -1670,10 +1762,6 @@ async def get_next_video(
     Returns:
         Single video suggestion, or null if no related videos found
     """
-    # Validate slug to prevent injection attacks
-    if not validate_slug(slug):
-        raise HTTPException(status_code=400, detail="Invalid video slug")
-
     # Build cache key with SHA256 hash
     NEXT_VIDEO_CACHE_VERSION = "v1"
     cache_key_raw = f"next:{NEXT_VIDEO_CACHE_VERSION}:{slug}"
@@ -1690,78 +1778,16 @@ async def get_next_video(
             logger.warning(f"Cached next video schema mismatch, invalidating: {e}")
             _video_list_cache.delete(cache_key)
 
-    # Get the source video
-    video_query = (
-        sa.select(videos.c.id, videos.c.category_id)
-        .where(videos.c.slug == slug)
-        .where(videos.c.status == VideoStatus.READY)
-        .where(videos.c.deleted_at.is_(None))
-        .where(videos.c.published_at.is_not(None))
-    )
-    video = await fetch_one_with_retry(video_query)
+    # Use shared helper with parallelization for optimal latency (Issue #211)
+    # For limit=1, running all tiers in parallel is faster than sequential with early termination
+    related_videos = await _find_related_videos_for_slug(slug, limit=1, parallelize=True)
 
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
-
-    video_id = video["id"]
-    category_id = video["category_id"]
-
-    # Get source video's tag IDs
-    tag_query = sa.select(video_tags.c.tag_id).where(video_tags.c.video_id == video_id).limit(10)
-    tag_rows = await fetch_all_with_retry(tag_query)
-    source_tag_ids = [r["tag_id"] for r in tag_rows] if tag_rows else []
-
-    seen_ids: set = {video_id}
-    next_video = None
-
-    # Tier 1: Same category + shared tags (highest relevance)
-    if category_id is not None and source_tag_ids and not next_video:
-        tier1 = await _fetch_related_videos_tier(
-            category_id=category_id,
-            tag_ids=source_tag_ids,
-            exclude_ids=seen_ids,
-            limit=1,
-        )
-        if tier1:
-            next_video = tier1[0]
-
-    # Tier 2: Same category only
-    if not next_video and category_id is not None:
-        tier2 = await _fetch_related_videos_tier(
-            category_id=category_id,
-            tag_ids=None,
-            exclude_ids=seen_ids,
-            limit=1,
-        )
-        if tier2:
-            next_video = tier2[0]
-
-    # Tier 3: Shared tags only
-    if not next_video and source_tag_ids:
-        tier3 = await _fetch_related_videos_tier(
-            category_id=None,
-            tag_ids=source_tag_ids,
-            exclude_ids=seen_ids,
-            limit=1,
-        )
-        if tier3:
-            next_video = tier3[0]
-
-    # Tier 4: Recent videos fallback
-    if not next_video:
-        tier4 = await _fetch_related_videos_tier(
-            category_id=None,
-            tag_ids=None,
-            exclude_ids=seen_ids,
-            limit=1,
-        )
-        if tier4:
-            next_video = tier4[0]
-
-    if not next_video:
+    if not related_videos:
         # Cache empty result to avoid repeated lookups
         _video_list_cache.set(cache_key, [])
         return None
+
+    next_video = related_videos[0]
 
     # Get tags for the next video
     video_tags_map = await get_video_tags([next_video["id"]])
@@ -2436,9 +2462,10 @@ async def get_playback_settings() -> Dict[str, Any]:
     - autoplay_enabled: bool (default True)
     - upnext_enabled: bool (default True)
     - autoplay_countdown_seconds: int (default 10)
-    """
-    import time
 
+    Note: No locking needed - dict reads are atomic and stale data
+    for 60s is acceptable for these settings.
+    """
     global _cached_playback_settings, _cached_playback_settings_time
 
     now = time.time()
@@ -2462,7 +2489,7 @@ async def get_playback_settings() -> Dict[str, Any]:
         _cached_playback_settings_time = now
 
     except Exception as e:
-        logger.debug(f"Failed to get playback settings from DB, using defaults: {e}")
+        logger.warning(f"Failed to get playback settings from DB, using defaults: {e}")
         _cached_playback_settings = {
             "autoplay_enabled": AUTOPLAY_ENABLED,
             "upnext_enabled": UPNEXT_ENABLED,

--- a/api/public.py
+++ b/api/public.py
@@ -96,6 +96,9 @@ from config import (
     DOWNLOADS_ENABLED,
     DOWNLOADS_MAX_CONCURRENT,
     DOWNLOADS_RATE_LIMIT_PER_HOUR,
+    AUTOPLAY_ENABLED,
+    UPNEXT_ENABLED,
+    AUTOPLAY_COUNTDOWN_SECONDS,
     NAS_STORAGE,
     OPENAPI_DESCRIPTION,
     OPENAPI_TITLE,
@@ -1648,6 +1651,130 @@ async def get_related_videos(
     return result
 
 
+@v1_router.get("/videos/{slug}/next", summary="Get next video", description="Get the next suggested video for autoplay.")
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def get_next_video(
+    request: Request,
+    slug: str,
+) -> Optional[VideoListResponse]:
+    """
+    Get the next video suggestion for autoplay.
+
+    Returns the single best related video for the "Up Next" feature.
+    Uses the same tiered algorithm as related videos but returns only
+    the top result.
+
+    Args:
+        slug: The current video slug
+
+    Returns:
+        Single video suggestion, or null if no related videos found
+    """
+    # Validate slug to prevent injection attacks
+    if not validate_slug(slug):
+        raise HTTPException(status_code=400, detail="Invalid video slug")
+
+    # Build cache key with SHA256 hash
+    NEXT_VIDEO_CACHE_VERSION = "v1"
+    cache_key_raw = f"next:{NEXT_VIDEO_CACHE_VERSION}:{slug}"
+    cache_key = f"next:{hashlib.sha256(cache_key_raw.encode()).hexdigest()[:16]}"
+
+    # Check cache first
+    cached = _video_list_cache.get(cache_key)
+    if cached is not None:
+        if cached == []:
+            return None
+        try:
+            return VideoListResponse(**cached[0])
+        except Exception as e:
+            logger.warning(f"Cached next video schema mismatch, invalidating: {e}")
+            _video_list_cache.delete(cache_key)
+
+    # Get the source video
+    video_query = (
+        sa.select(videos.c.id, videos.c.category_id)
+        .where(videos.c.slug == slug)
+        .where(videos.c.status == VideoStatus.READY)
+        .where(videos.c.deleted_at.is_(None))
+        .where(videos.c.published_at.is_not(None))
+    )
+    video = await fetch_one_with_retry(video_query)
+
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    video_id = video["id"]
+    category_id = video["category_id"]
+
+    # Get source video's tag IDs
+    tag_query = sa.select(video_tags.c.tag_id).where(video_tags.c.video_id == video_id).limit(10)
+    tag_rows = await fetch_all_with_retry(tag_query)
+    source_tag_ids = [r["tag_id"] for r in tag_rows] if tag_rows else []
+
+    seen_ids: set = {video_id}
+    next_video = None
+
+    # Tier 1: Same category + shared tags (highest relevance)
+    if category_id is not None and source_tag_ids and not next_video:
+        tier1 = await _fetch_related_videos_tier(
+            category_id=category_id,
+            tag_ids=source_tag_ids,
+            exclude_ids=seen_ids,
+            limit=1,
+        )
+        if tier1:
+            next_video = tier1[0]
+
+    # Tier 2: Same category only
+    if not next_video and category_id is not None:
+        tier2 = await _fetch_related_videos_tier(
+            category_id=category_id,
+            tag_ids=None,
+            exclude_ids=seen_ids,
+            limit=1,
+        )
+        if tier2:
+            next_video = tier2[0]
+
+    # Tier 3: Shared tags only
+    if not next_video and source_tag_ids:
+        tier3 = await _fetch_related_videos_tier(
+            category_id=None,
+            tag_ids=source_tag_ids,
+            exclude_ids=seen_ids,
+            limit=1,
+        )
+        if tier3:
+            next_video = tier3[0]
+
+    # Tier 4: Recent videos fallback
+    if not next_video:
+        tier4 = await _fetch_related_videos_tier(
+            category_id=None,
+            tag_ids=None,
+            exclude_ids=seen_ids,
+            limit=1,
+        )
+        if tier4:
+            next_video = tier4[0]
+
+    if not next_video:
+        # Cache empty result to avoid repeated lookups
+        _video_list_cache.set(cache_key, [])
+        return None
+
+    # Get tags for the next video
+    video_tags_map = await get_video_tags([next_video["id"]])
+
+    # Build response
+    result = build_video_list_response([next_video], video_tags_map)
+
+    # Cache the result
+    _video_list_cache.set(cache_key, [v.model_dump() for v in result])
+
+    return result[0] if result else None
+
+
 @v1_router.get("/categories", summary="List categories", description="Get all video categories.")
 @limiter.limit(RATE_LIMIT_PUBLIC_VIDEOS_LIST)
 async def list_categories(request: Request) -> List[CategoryResponse]:
@@ -2288,6 +2415,79 @@ async def get_download_config(request: Request):
         "enabled": True,
         "allow_original": settings["allow_original"],
         "allow_transcoded": settings["allow_transcoded"],
+    }
+
+
+# ============================================================================
+# Playback Configuration (Issue #211)
+# ============================================================================
+
+# Cached playback settings (refreshed every 60 seconds)
+_cached_playback_settings: Dict[str, Any] = {}
+_cached_playback_settings_time: float = 0
+_PLAYBACK_SETTINGS_CACHE_TTL = 60  # seconds
+
+
+async def get_playback_settings() -> Dict[str, Any]:
+    """
+    Get playback settings from database with caching.
+
+    Returns dict with:
+    - autoplay_enabled: bool (default True)
+    - upnext_enabled: bool (default True)
+    - autoplay_countdown_seconds: int (default 10)
+    """
+    import time
+
+    global _cached_playback_settings, _cached_playback_settings_time
+
+    now = time.time()
+    if _cached_playback_settings and (now - _cached_playback_settings_time) < _PLAYBACK_SETTINGS_CACHE_TTL:
+        return _cached_playback_settings
+
+    try:
+        from api.settings_service import get_settings_service
+
+        service = get_settings_service()
+
+        settings = {
+            "autoplay_enabled": await service.get("playback.autoplay_enabled", AUTOPLAY_ENABLED),
+            "upnext_enabled": await service.get("playback.upnext_enabled", UPNEXT_ENABLED),
+            "autoplay_countdown_seconds": await service.get(
+                "playback.autoplay_countdown_seconds", AUTOPLAY_COUNTDOWN_SECONDS
+            ),
+        }
+
+        _cached_playback_settings = settings
+        _cached_playback_settings_time = now
+
+    except Exception as e:
+        logger.debug(f"Failed to get playback settings from DB, using defaults: {e}")
+        _cached_playback_settings = {
+            "autoplay_enabled": AUTOPLAY_ENABLED,
+            "upnext_enabled": UPNEXT_ENABLED,
+            "autoplay_countdown_seconds": AUTOPLAY_COUNTDOWN_SECONDS,
+        }
+        _cached_playback_settings_time = now
+
+    return _cached_playback_settings
+
+
+@v1_router.get("/config/playback", summary="Get playback config", description="Get playback configuration for autoplay and up-next features.")
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def get_playback_config(request: Request):
+    """
+    Get playback configuration for the UI.
+
+    Returns autoplay and up-next settings that control video player behavior.
+    This is used by the watch page to enable/disable autoplay features.
+    """
+    settings = await get_playback_settings()
+
+    return {
+        "autoplay_enabled": settings["autoplay_enabled"],
+        "upnext_enabled": settings["upnext_enabled"],
+        "autoplay_countdown_seconds": settings["autoplay_countdown_seconds"],
     }
 
 

--- a/api/settings_service.py
+++ b/api/settings_service.py
@@ -1055,6 +1055,28 @@ KNOWN_SETTINGS = [
         "Maximum concurrent downloads per IP",
         {"min": 1, "max": 10},
     ),
+    # Playback settings (Issue #211)
+    (
+        "playback.autoplay_enabled",
+        "playback",
+        "boolean",
+        "Enable autoplay feature globally (can be overridden by user preferences)",
+        None,
+    ),
+    (
+        "playback.upnext_enabled",
+        "playback",
+        "boolean",
+        "Enable 'Up Next' suggestions after video ends",
+        None,
+    ),
+    (
+        "playback.autoplay_countdown_seconds",
+        "playback",
+        "integer",
+        "Countdown duration in seconds before autoplay starts",
+        {"min": 5, "max": 30},
+    ),
     # Webhook settings (Issue #203)
     (
         "webhooks.enabled",
@@ -1172,6 +1194,10 @@ SETTING_TO_ENV_MAP = {
     "downloads.allow_transcoded": "VLOG_DOWNLOADS_ALLOW_TRANSCODED",
     "downloads.rate_limit_per_hour": "VLOG_DOWNLOADS_RATE_LIMIT_PER_HOUR",
     "downloads.max_concurrent": "VLOG_DOWNLOADS_MAX_CONCURRENT",
+    # Playback settings (Issue #211)
+    "playback.autoplay_enabled": "VLOG_AUTOPLAY_ENABLED",
+    "playback.upnext_enabled": "VLOG_UPNEXT_ENABLED",
+    "playback.autoplay_countdown_seconds": "VLOG_AUTOPLAY_COUNTDOWN_SECONDS",
     # Webhook settings (Issue #203)
     "webhooks.enabled": "VLOG_WEBHOOKS_ENABLED",
     "webhooks.max_retries": "VLOG_WEBHOOKS_MAX_RETRIES",

--- a/config.py
+++ b/config.py
@@ -651,3 +651,17 @@ DOWNLOADS_RATE_LIMIT_PER_HOUR = get_int_env("VLOG_DOWNLOADS_RATE_LIMIT_PER_HOUR"
 # Maximum concurrent downloads per IP (prevents bandwidth abuse)
 # This is tracked in-memory so resets on server restart
 DOWNLOADS_MAX_CONCURRENT = get_int_env("VLOG_DOWNLOADS_MAX_CONCURRENT", 2, min_val=1, max_val=10)
+
+# =============================================================================
+# Playback Configuration (Issue #211)
+# Autoplay and "Up Next" settings for video player
+# =============================================================================
+
+# Enable autoplay feature globally (can be overridden by user preferences)
+AUTOPLAY_ENABLED = os.getenv("VLOG_AUTOPLAY_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Enable "Up Next" suggestions after video ends
+UPNEXT_ENABLED = os.getenv("VLOG_UPNEXT_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Countdown duration in seconds before autoplay starts (5-30)
+AUTOPLAY_COUNTDOWN_SECONDS = get_int_env("VLOG_AUTOPLAY_COUNTDOWN_SECONDS", 10, min_val=5, max_val=30)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1083,3 +1083,317 @@ class TestRelatedVideosHTTP:
         data = response.json()
         # Should return recent videos as fallback
         assert len(data) >= 1
+
+
+# ============================================================================
+# Next Video Tests (Issue #211)
+# ============================================================================
+
+
+class TestNextVideoHTTP:
+    """HTTP-level tests for next video endpoint (Issue #211)."""
+
+    def test_next_video_not_found(self, public_client):
+        """Test next video returns 404 for non-existent video."""
+        response = public_client.get("/api/videos/nonexistent-slug/next")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Video not found"
+
+    @pytest.mark.asyncio
+    async def test_next_video_excludes_deleted(self, public_client, sample_deleted_video):
+        """Test next video returns 404 for deleted video."""
+        response = public_client.get(f"/api/videos/{sample_deleted_video['slug']}/next")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Video not found"
+
+    @pytest.mark.asyncio
+    async def test_next_video_returns_null_when_no_related(self, public_client, sample_video):
+        """Test next video returns null when no related videos exist."""
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        # When no related videos, response should be null
+        assert response.json() is None
+
+    @pytest.mark.asyncio
+    async def test_next_video_returns_single_video(self, public_client, test_database, sample_video, sample_category):
+        """Test next video returns exactly one video."""
+        now = datetime.now(timezone.utc)
+        # Create multiple videos in the same category
+        for i in range(3):
+            await test_database.execute(
+                videos.insert().values(
+                    title=f"Related Video {i}",
+                    slug=f"related-video-{i}",
+                    description=f"Related video {i}",
+                    category_id=sample_category["id"],
+                    duration=60.0,
+                    status=VideoStatus.READY,
+                    created_at=now,
+                    published_at=now,
+                )
+            )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        # Should return exactly one video, not a list
+        assert isinstance(data, dict)
+        assert "slug" in data
+        assert "title" in data
+
+    @pytest.mark.asyncio
+    async def test_next_video_same_category(self, public_client, test_database, sample_video, sample_category):
+        """Test next video returns video from same category."""
+        now = datetime.now(timezone.utc)
+        await test_database.execute(
+            videos.insert().values(
+                title="Related Video",
+                slug="related-video",
+                description="Another video in the same category",
+                category_id=sample_category["id"],
+                duration=90.0,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data is not None
+        assert data["slug"] == "related-video"
+
+    @pytest.mark.asyncio
+    async def test_next_video_excludes_current_video(self, public_client, test_database, sample_video, sample_category):
+        """Test next video excludes the current video from results."""
+        now = datetime.now(timezone.utc)
+        await test_database.execute(
+            videos.insert().values(
+                title="Related Video",
+                slug="related-video",
+                description="Another video",
+                category_id=sample_category["id"],
+                duration=90.0,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data is not None
+        assert data["slug"] != sample_video["slug"]
+
+    @pytest.mark.asyncio
+    async def test_next_video_shared_tags(self, public_client, test_database, sample_video_with_tag, sample_tag):
+        """Test next video returns video with shared tags."""
+        now = datetime.now(timezone.utc)
+        # Create a video with the same tag
+        video_id = await test_database.execute(
+            videos.insert().values(
+                title="Tagged Video",
+                slug="tagged-video",
+                description="A video with the same tag",
+                category_id=None,  # Different category
+                duration=60.0,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+            )
+        )
+        await test_database.execute(
+            video_tags.insert().values(
+                video_id=video_id,
+                tag_id=sample_tag["id"],
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video_with_tag['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data is not None
+        assert data["slug"] == "tagged-video"
+
+    @pytest.mark.asyncio
+    async def test_next_video_excludes_deleted_videos(
+        self, public_client, test_database, sample_video, sample_category
+    ):
+        """Test next video excludes soft-deleted videos from results."""
+        now = datetime.now(timezone.utc)
+        # Create a deleted video in the same category
+        await test_database.execute(
+            videos.insert().values(
+                title="Deleted Related Video",
+                slug="deleted-related",
+                description="A deleted video",
+                category_id=sample_category["id"],
+                duration=90.0,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+                deleted_at=now,  # Soft deleted
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        # Should be null because the only related video is deleted
+        assert data is None
+
+    @pytest.mark.asyncio
+    async def test_next_video_excludes_non_ready_videos(
+        self, public_client, test_database, sample_video, sample_category
+    ):
+        """Test next video excludes non-ready (pending/processing) videos."""
+        now = datetime.now(timezone.utc)
+        # Create a pending video in the same category
+        await test_database.execute(
+            videos.insert().values(
+                title="Pending Related Video",
+                slug="pending-related",
+                description="A pending video",
+                category_id=sample_category["id"],
+                duration=0,
+                status=VideoStatus.PENDING,
+                created_at=now,
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        # Should be null because the only related video is pending
+        assert data is None
+
+    @pytest.mark.asyncio
+    async def test_next_video_returns_correct_fields(
+        self, public_client, test_database, sample_video, sample_category
+    ):
+        """Test next video returns expected fields."""
+        now = datetime.now(timezone.utc)
+        await test_database.execute(
+            videos.insert().values(
+                title="Next Video",
+                slug="next-video",
+                description="The next video",
+                category_id=sample_category["id"],
+                duration=120.0,
+                source_width=1920,
+                source_height=1080,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+            )
+        )
+
+        response = public_client.get(f"/api/videos/{sample_video['slug']}/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data is not None
+        # Check expected fields are present
+        assert "id" in data
+        assert "title" in data
+        assert "slug" in data
+        assert "duration" in data
+        assert data["title"] == "Next Video"
+        assert data["slug"] == "next-video"
+
+    @pytest.mark.asyncio
+    async def test_next_video_fallback_to_recent(self, public_client, test_database, sample_category):
+        """Test next video falls back to recent videos when no matches."""
+        now = datetime.now(timezone.utc)
+        # Create a video with no category or tags
+        await test_database.execute(
+            videos.insert().values(
+                title="Isolated Video",
+                slug="isolated-video",
+                description="A video with no category",
+                category_id=None,
+                duration=60.0,
+                status=VideoStatus.READY,
+                created_at=now,
+                published_at=now,
+            )
+        )
+        # Create some recent videos
+        for i in range(2):
+            await test_database.execute(
+                videos.insert().values(
+                    title=f"Recent Video {i}",
+                    slug=f"recent-video-{i}",
+                    description=f"Recent video {i}",
+                    category_id=sample_category["id"],
+                    duration=60.0,
+                    status=VideoStatus.READY,
+                    created_at=now,
+                    published_at=now,
+                )
+            )
+
+        response = public_client.get("/api/videos/isolated-video/next")
+        assert response.status_code == 200
+        data = response.json()
+        # Should return one recent video as fallback
+        assert data is not None
+        assert data["slug"].startswith("recent-video-")
+
+    def test_next_video_invalid_slug_path_traversal(self, public_client):
+        """Test next video rejects path traversal attempts."""
+        # Test with path traversal attempt in slug
+        response = public_client.get("/api/videos/..test-video/next")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid video slug"
+
+    def test_next_video_invalid_slug_uppercase(self, public_client):
+        """Test next video rejects uppercase slugs."""
+        # Slugs should be lowercase only
+        response = public_client.get("/api/videos/Test-Video/next")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid video slug"
+
+
+# ============================================================================
+# Playback Config Tests (Issue #211)
+# ============================================================================
+
+
+class TestPlaybackConfigHTTP:
+    """HTTP-level tests for playback config endpoint (Issue #211)."""
+
+    def test_get_playback_config(self, public_client):
+        """Test getting playback configuration returns expected structure."""
+        response = public_client.get("/api/config/playback")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Check all expected fields are present
+        assert "autoplay_enabled" in data
+        assert "upnext_enabled" in data
+        assert "autoplay_countdown_seconds" in data
+
+        # Check types
+        assert isinstance(data["autoplay_enabled"], bool)
+        assert isinstance(data["upnext_enabled"], bool)
+        assert isinstance(data["autoplay_countdown_seconds"], int)
+
+    def test_playback_config_countdown_range(self, public_client):
+        """Test playback config autoplay_countdown_seconds is within valid range."""
+        response = public_client.get("/api/config/playback")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Countdown should be between 5 and 30 seconds per config
+        assert 5 <= data["autoplay_countdown_seconds"] <= 30
+
+    def test_playback_config_caching(self, public_client):
+        """Test playback config returns consistent values on repeated calls."""
+        response1 = public_client.get("/api/config/playback")
+        response2 = public_client.get("/api/config/playback")
+
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        assert response1.json() == response2.json()

--- a/web/public/static/css/pages/player.css
+++ b/web/public/static/css/pages/player.css
@@ -1594,4 +1594,198 @@ body.player-theater-active::after {
     }
 }
 
+/* =============================================================================
+ * Up Next Overlay (Issue #211)
+ * Shown when video ends to countdown to next video
+ * ============================================================================= */
+
+.upnext-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 50;
+    animation: upnext-fade-in 0.3s ease-out;
+}
+
+@keyframes upnext-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.upnext-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    max-width: 400px;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.upnext-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    color: var(--vlog-text-muted, #9CA3AF);
+}
+
+.upnext-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+.upnext-countdown {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--vlog-primary, #3B82F6);
+    min-width: 2rem;
+    text-align: center;
+}
+
+.upnext-video {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    text-decoration: none;
+    color: inherit;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    transition: background-color 0.2s ease;
+    cursor: pointer;
+}
+
+.upnext-video:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.upnext-thumbnail {
+    position: relative;
+    width: 280px;
+    aspect-ratio: 16 / 9;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    background: var(--vlog-bg-muted, #1F2937);
+}
+
+.upnext-thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.upnext-duration {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    padding: 0.125rem 0.375rem;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 0.25rem;
+}
+
+.upnext-info {
+    width: 100%;
+}
+
+.upnext-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    line-height: 1.4;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.upnext-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.upnext-btn {
+    padding: 0.625rem 1.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border: none;
+}
+
+.upnext-btn--cancel {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+}
+
+.upnext-btn--cancel:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.upnext-btn--play {
+    background: var(--vlog-primary, #3B82F6);
+    color: #fff;
+}
+
+.upnext-btn--play:hover {
+    background: var(--vlog-primary-hover, #2563EB);
+}
+
+.upnext-toggle {
+    margin-top: 0.5rem;
+}
+
+.upnext-toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--vlog-text-muted, #9CA3AF);
+}
+
+.upnext-toggle-label input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--vlog-primary, #3B82F6);
+    cursor: pointer;
+}
+
+/* Mobile responsive */
+@media (max-width: 480px) {
+    .upnext-content {
+        padding: 1rem;
+        max-width: 100%;
+    }
+
+    .upnext-thumbnail {
+        width: 100%;
+        max-width: 240px;
+    }
+
+    .upnext-countdown {
+        font-size: 1.5rem;
+    }
+
+    .upnext-title {
+        font-size: 0.875rem;
+    }
+
+    .upnext-btn {
+        padding: 0.5rem 1rem;
+        font-size: 0.8125rem;
+    }
+}
+
 } /* End @layer pages */

--- a/web/public/static/js/pages/watch.js
+++ b/web/public/static/js/pages/watch.js
@@ -197,6 +197,20 @@ function watchPage() {
         // Precomputed arrays for skeleton loaders (Alpine CSP)
         _skeletonArray6: [1, 2, 3, 4, 5, 6],
 
+        // Up Next / Autoplay state (Issue #211)
+        playbackConfig: null,
+        nextVideo: null,
+        upNextCountdown: 0,
+        _upNextCountdownInterval: null,
+        _showUpNext: false,
+        _autoplayEnabled: true, // User preference (stored in localStorage)
+        // Precomputed Up Next display values for Alpine CSP
+        _nextVideoTitle: '',
+        _nextVideoThumbnail: '',
+        _nextVideoDuration: '',
+        _nextVideoHref: '',
+        _upNextCountdownText: '',
+
         async loadDisplayConfig() {
             try {
                 const res = await VLogUtils.fetchWithTimeout('/api/config/display', {}, 5000);
@@ -372,6 +386,7 @@ function watchPage() {
             this.loadWatermarkConfig();
             this.loadDisplayConfig();
             this.loadDownloadConfig();  // Issue #202
+            this.loadPlaybackConfig();  // Issue #211
 
             const slug = window.location.pathname.split('/').pop();
             if (!slug || !SLUG_PATTERN.test(slug)) {
@@ -408,6 +423,9 @@ function watchPage() {
 
                 // Load related videos (non-blocking, don't wait)
                 this.loadRelatedVideos(slug);
+
+                // Load next video for Up Next / autoplay (Issue #211)
+                this.loadNextVideo(slug);
             } catch (e) {
                 this.error = e.message;
                 this.loading = false;
@@ -480,6 +498,156 @@ function watchPage() {
             } catch (e) {
                 // Downloads are optional, fail silently
                 debugLog('Failed to load download config:', e);
+            }
+        },
+
+        // Issue #211: Load playback configuration (autoplay/up-next settings)
+        async loadPlaybackConfig() {
+            try {
+                const res = await VLogUtils.fetchWithTimeout('/api/config/playback', {}, 5000);
+                if (res.ok) {
+                    this.playbackConfig = await res.json();
+                    debugLog('Playback config loaded:', this.playbackConfig);
+                }
+            } catch (e) {
+                // Use defaults on error
+                debugLog('Failed to load playback config, using defaults:', e);
+                this.playbackConfig = {
+                    autoplay_enabled: true,
+                    upnext_enabled: true,
+                    autoplay_countdown_seconds: 10
+                };
+            }
+
+            // Load user's autoplay preference from localStorage
+            this._autoplayEnabled = VLogUtils.preferences.get('autoplay', true);
+        },
+
+        // Issue #211: Load next video for autoplay
+        async loadNextVideo(slug) {
+            if (!slug) return;
+
+            try {
+                const res = await VLogUtils.fetchWithTimeout(
+                    `/api/videos/${encodeURIComponent(slug)}/next`,
+                    {},
+                    5000
+                );
+
+                if (!res.ok) {
+                    debugLog('No next video available');
+                    this.nextVideo = null;
+                    return;
+                }
+
+                // Guard JSON parsing
+                let data;
+                try {
+                    data = await res.json();
+                } catch (parseError) {
+                    debugLog('Invalid JSON response for next video');
+                    return;
+                }
+
+                if (!data) {
+                    this.nextVideo = null;
+                    return;
+                }
+
+                // Enrich with display values
+                this.nextVideo = {
+                    ...data,
+                    _href: '/watch/' + data.slug,
+                    _duration: VLogUtils.formatDuration(data.duration)
+                };
+                this.updateNextVideoDisplayFlags();
+                debugLog('Next video loaded:', this.nextVideo.title);
+            } catch (e) {
+                debugLog('Failed to load next video:', e);
+                this.nextVideo = null;
+            }
+        },
+
+        // Update precomputed next video display values for Alpine CSP
+        updateNextVideoDisplayFlags() {
+            if (this.nextVideo) {
+                this._nextVideoTitle = this.nextVideo.title || '';
+                this._nextVideoThumbnail = this.nextVideo.thumbnail_url || '';
+                this._nextVideoDuration = this.nextVideo._duration || '';
+                this._nextVideoHref = this.nextVideo._href || '';
+            } else {
+                this._nextVideoTitle = '';
+                this._nextVideoThumbnail = '';
+                this._nextVideoDuration = '';
+                this._nextVideoHref = '';
+            }
+        },
+
+        // Issue #211: Check if autoplay should be enabled
+        shouldAutoplay() {
+            // Global setting must be enabled
+            if (!this.playbackConfig?.autoplay_enabled) return false;
+            if (!this.playbackConfig?.upnext_enabled) return false;
+            // User preference must be enabled
+            if (!this._autoplayEnabled) return false;
+            // Must have a next video
+            if (!this.nextVideo) return false;
+            return true;
+        },
+
+        // Issue #211: Start the Up Next countdown
+        startUpNextCountdown() {
+            if (!this.shouldAutoplay()) {
+                debugLog('Autoplay disabled or no next video');
+                return;
+            }
+
+            const countdownSeconds = this.playbackConfig?.autoplay_countdown_seconds || 10;
+            this.upNextCountdown = countdownSeconds;
+            this._upNextCountdownText = countdownSeconds.toString();
+            this._showUpNext = true;
+            debugLog('Starting Up Next countdown:', countdownSeconds, 'seconds');
+
+            // Start countdown interval
+            this._upNextCountdownInterval = setInterval(() => {
+                this.upNextCountdown--;
+                this._upNextCountdownText = this.upNextCountdown.toString();
+
+                if (this.upNextCountdown <= 0) {
+                    this.playNextVideo();
+                }
+            }, 1000);
+        },
+
+        // Issue #211: Cancel the Up Next countdown
+        cancelUpNextCountdown() {
+            if (this._upNextCountdownInterval) {
+                clearInterval(this._upNextCountdownInterval);
+                this._upNextCountdownInterval = null;
+            }
+            this._showUpNext = false;
+            this.upNextCountdown = 0;
+            debugLog('Up Next countdown cancelled');
+        },
+
+        // Issue #211: Play the next video (navigate to it)
+        playNextVideo() {
+            this.cancelUpNextCountdown();
+            if (this.nextVideo?._href) {
+                debugLog('Playing next video:', this.nextVideo.title);
+                window.location.href = this.nextVideo._href;
+            }
+        },
+
+        // Issue #211: Toggle autoplay preference
+        toggleAutoplay() {
+            this._autoplayEnabled = !this._autoplayEnabled;
+            VLogUtils.preferences.set('autoplay', this._autoplayEnabled);
+            debugLog('Autoplay preference set to:', this._autoplayEnabled);
+
+            // If we just disabled autoplay and countdown is running, cancel it
+            if (!this._autoplayEnabled && this._showUpNext) {
+                this.cancelUpNextCountdown();
             }
         },
 
@@ -673,6 +841,9 @@ function watchPage() {
                         console.warn('Failed to clear watch history:', e);
                     }
                 }
+
+                // Issue #211: Start Up Next countdown when video ends
+                this.startUpNextCountdown();
             });
 
             // Handle page unload
@@ -681,6 +852,10 @@ function watchPage() {
                 // Clean up save interval
                 if (this._watchSaveInterval) {
                     clearInterval(this._watchSaveInterval);
+                }
+                // Clean up Up Next countdown (Issue #211)
+                if (this._upNextCountdownInterval) {
+                    clearInterval(this._upNextCountdownInterval);
                 }
                 if (this.playerControls) {
                     this.playerControls.destroy();

--- a/web/public/static/js/pages/watch.js
+++ b/web/public/static/js/pages/watch.js
@@ -561,10 +561,18 @@ function watchPage() {
                     return;
                 }
 
+                // Validate slug before using it to construct URLs (defense-in-depth)
+                const slug = typeof data.slug === 'string' ? data.slug : '';
+                if (!SLUG_PATTERN.test(slug)) {
+                    debugLog('Invalid next video slug received:', data.slug);
+                    this.nextVideo = null;
+                    return;
+                }
+
                 // Enrich with display values
                 this.nextVideo = {
                     ...data,
-                    _href: '/watch/' + data.slug,
+                    _href: '/watch/' + encodeURIComponent(slug),
                     _duration: VLogUtils.formatDuration(data.duration)
                 };
                 this.updateNextVideoDisplayFlags();
@@ -613,11 +621,20 @@ function watchPage() {
                 return;
             }
 
+            // Clear any existing countdown first (e.g., if video 'ended' fires multiple times)
+            this.cancelUpNextCountdown();
+
             const countdownSeconds = this.playbackConfig?.autoplay_countdown_seconds || 10;
             this.upNextCountdown = countdownSeconds;
             this._upNextCountdownText = countdownSeconds.toString();
             this._showUpNext = true;
             debugLog('Starting Up Next countdown:', countdownSeconds, 'seconds');
+
+            // Focus the cancel button for keyboard accessibility
+            this.$nextTick(() => {
+                const cancelBtn = this.$el.querySelector('.upnext-btn--cancel');
+                if (cancelBtn) cancelBtn.focus();
+            });
 
             // Start countdown interval
             this._upNextCountdownInterval = setInterval(() => {

--- a/web/public/static/js/pages/watch.js
+++ b/web/public/static/js/pages/watch.js
@@ -202,6 +202,7 @@ function watchPage() {
         nextVideo: null,
         upNextCountdown: 0,
         _upNextCountdownInterval: null,
+        _nextVideoAbortController: null,
         _showUpNext: false,
         _autoplayEnabled: true, // User preference (stored in localStorage)
         // Precomputed Up Next display values for Alpine CSP
@@ -527,10 +528,16 @@ function watchPage() {
         async loadNextVideo(slug) {
             if (!slug) return;
 
+            // Cancel any in-flight request
+            if (this._nextVideoAbortController) {
+                this._nextVideoAbortController.abort();
+            }
+            this._nextVideoAbortController = new AbortController();
+
             try {
                 const res = await VLogUtils.fetchWithTimeout(
                     `/api/videos/${encodeURIComponent(slug)}/next`,
-                    {},
+                    { signal: this._nextVideoAbortController.signal },
                     5000
                 );
 
@@ -563,6 +570,10 @@ function watchPage() {
                 this.updateNextVideoDisplayFlags();
                 debugLog('Next video loaded:', this.nextVideo.title);
             } catch (e) {
+                // Handle abort separately (including Safari quirks)
+                if (e.name === 'AbortError' || this._nextVideoAbortController?.signal?.aborted) {
+                    return;
+                }
                 debugLog('Failed to load next video:', e);
                 this.nextVideo = null;
             }
@@ -614,7 +625,7 @@ function watchPage() {
                 this._upNextCountdownText = this.upNextCountdown.toString();
 
                 if (this.upNextCountdown <= 0) {
-                    this.playNextVideo();
+                    this.navigateToNextVideo();
                 }
             }, 1000);
         },
@@ -630,20 +641,39 @@ function watchPage() {
             debugLog('Up Next countdown cancelled');
         },
 
-        // Issue #211: Play the next video (navigate to it)
-        playNextVideo() {
+        // Issue #211: Navigate to the next video
+        navigateToNextVideo() {
             this.cancelUpNextCountdown();
-            if (this.nextVideo?._href) {
-                debugLog('Playing next video:', this.nextVideo.title);
-                window.location.href = this.nextVideo._href;
+
+            // Validate URL before navigation (defense in depth)
+            if (!this.nextVideo?._href || typeof this.nextVideo._href !== 'string') {
+                debugLog('Cannot navigate to next video: invalid URL');
+                return;
             }
+
+            // Verify URL is a valid internal path
+            if (!this.nextVideo._href.startsWith('/watch/')) {
+                debugLog('Cannot navigate to next video: unexpected URL format');
+                return;
+            }
+
+            debugLog('Navigating to next video:', this.nextVideo.title);
+            window.location.href = this.nextVideo._href;
         },
 
         // Issue #211: Toggle autoplay preference
         toggleAutoplay() {
-            this._autoplayEnabled = !this._autoplayEnabled;
-            VLogUtils.preferences.set('autoplay', this._autoplayEnabled);
-            debugLog('Autoplay preference set to:', this._autoplayEnabled);
+            const newValue = !this._autoplayEnabled;
+
+            try {
+                VLogUtils.preferences.set('autoplay', newValue);
+                this._autoplayEnabled = newValue;
+                debugLog('Autoplay preference set to:', this._autoplayEnabled);
+            } catch (e) {
+                // localStorage quota exceeded or unavailable - log but don't crash
+                console.warn('Failed to save autoplay preference:', e.name);
+                // Don't update state if save failed - keep UI consistent with storage
+            }
 
             // If we just disabled autoplay and countdown is running, cancel it
             if (!this._autoplayEnabled && this._showUpNext) {

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -175,6 +175,56 @@
                             ></span>
                         </div>
                     </template>
+
+                    <!-- Up Next Overlay (Issue #211) -->
+                    <div
+                        x-show="_showUpNext"
+                        x-cloak
+                        class="upnext-overlay"
+                    >
+                        <div class="upnext-content">
+                            <div class="upnext-header">
+                                <span class="upnext-label">Up Next in</span>
+                                <span class="upnext-countdown" x-text="_upNextCountdownText"></span>
+                            </div>
+                            <a :href="_nextVideoHref" class="upnext-video" @click="playNextVideo">
+                                <div class="upnext-thumbnail">
+                                    <img :src="_nextVideoThumbnail" :alt="_nextVideoTitle" loading="lazy">
+                                    <span class="upnext-duration" x-text="_nextVideoDuration"></span>
+                                </div>
+                                <div class="upnext-info">
+                                    <h3 class="upnext-title" x-text="_nextVideoTitle"></h3>
+                                </div>
+                            </a>
+                            <div class="upnext-actions">
+                                <button
+                                    type="button"
+                                    class="upnext-btn upnext-btn--cancel"
+                                    @click="cancelUpNextCountdown"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    class="upnext-btn upnext-btn--play"
+                                    @click="playNextVideo"
+                                >
+                                    Play Now
+                                </button>
+                            </div>
+                            <div class="upnext-toggle">
+                                <label class="upnext-toggle-label">
+                                    <input
+                                        type="checkbox"
+                                        :checked="_autoplayEnabled"
+                                        @change="toggleAutoplay"
+                                    >
+                                    <span>Autoplay</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Custom controls are injected by VLogPlayerControls (native controls removed on init) -->
                 </div>
             </div>

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -181,13 +181,26 @@
                         x-show="_showUpNext"
                         x-cloak
                         class="upnext-overlay"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="upnext-label"
+                        aria-describedby="upnext-description"
+                        @keydown.escape="cancelUpNextCountdown"
                     >
                         <div class="upnext-content">
                             <div class="upnext-header">
-                                <span class="upnext-label">Up Next in</span>
-                                <span class="upnext-countdown" x-text="_upNextCountdownText"></span>
+                                <span id="upnext-label" class="upnext-label">Up Next in</span>
+                                <span
+                                    class="upnext-countdown"
+                                    x-text="_upNextCountdownText"
+                                    aria-live="polite"
+                                    aria-label="Seconds until next video"
+                                ></span>
                             </div>
-                            <a :href="_nextVideoHref" class="upnext-video" @click="navigateToNextVideo">
+                            <p id="upnext-description" class="sr-only">
+                                The next video will start automatically when the countdown reaches zero. Use the Cancel button to stop autoplay or the Play Now button to start immediately.
+                            </p>
+                            <a :href="_nextVideoHref" class="upnext-video" @click.prevent="navigateToNextVideo">
                                 <div class="upnext-thumbnail">
                                     <img :src="_nextVideoThumbnail" :alt="_nextVideoTitle" loading="lazy">
                                     <span class="upnext-duration" x-text="_nextVideoDuration"></span>
@@ -217,7 +230,7 @@
                                     <input
                                         type="checkbox"
                                         :checked="_autoplayEnabled"
-                                        @change="toggleAutoplay"
+                                        @click.prevent="toggleAutoplay"
                                     >
                                     <span>Autoplay</span>
                                 </label>

--- a/web/public/watch.html
+++ b/web/public/watch.html
@@ -187,7 +187,7 @@
                                 <span class="upnext-label">Up Next in</span>
                                 <span class="upnext-countdown" x-text="_upNextCountdownText"></span>
                             </div>
-                            <a :href="_nextVideoHref" class="upnext-video" @click="playNextVideo">
+                            <a :href="_nextVideoHref" class="upnext-video" @click="navigateToNextVideo">
                                 <div class="upnext-thumbnail">
                                     <img :src="_nextVideoThumbnail" :alt="_nextVideoTitle" loading="lazy">
                                     <span class="upnext-duration" x-text="_nextVideoDuration"></span>
@@ -207,7 +207,7 @@
                                 <button
                                     type="button"
                                     class="upnext-btn upnext-btn--play"
-                                    @click="playNextVideo"
+                                    @click="navigateToNextVideo"
                                 >
                                     Play Now
                                 </button>


### PR DESCRIPTION
## Summary

This PR implements the remaining "Up Next" autoplay functionality from Issue #211. The core related videos feature was already implemented; this adds the autoplay/countdown behavior.

### Features Added

- **Autoplay countdown overlay** - Shows after video ends with configurable countdown (default 10s)
- **Next video suggestion** - Uses existing related videos algorithm to pick the best next video
- **User preference toggle** - Persisted to localStorage, overrides global setting
- **Cancel/Play Now buttons** - User can cancel countdown or skip to next video immediately
- **Admin configuration** - Global settings to enable/disable autoplay feature

### API Endpoints

- `GET /api/v1/config/playback` - Returns autoplay settings
- `GET /api/v1/videos/{slug}/next` - Returns single next video suggestion

### Configuration

New settings (can be set via env vars or database):
- `VLOG_AUTOPLAY_ENABLED` - Enable autoplay globally (default: true)
- `VLOG_UPNEXT_ENABLED` - Enable Up Next suggestions (default: true)  
- `VLOG_AUTOPLAY_COUNTDOWN_SECONDS` - Countdown duration 5-30 (default: 10)

### Files Changed

- `config.py` - New configuration variables
- `.env.example` - Documentation of new settings
- `api/public.py` - New endpoints and playback config
- `api/settings_service.py` - Settings mapping for database migration
- `web/public/static/js/pages/watch.js` - Frontend autoplay logic
- `web/public/watch.html` - Up Next overlay UI
- `web/public/static/css/pages/player.css` - Up Next overlay styles

## Test plan

- [ ] Video plays and Up Next overlay appears when video ends
- [ ] Countdown decrements every second
- [ ] Cancel button hides overlay and stays on current video
- [ ] Play Now button navigates to next video immediately
- [ ] Autoplay toggle persists preference across sessions
- [ ] Setting `VLOG_AUTOPLAY_ENABLED=false` disables feature
- [ ] API endpoints return correct data
- [ ] Mobile responsive layout works

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)