### PR TITLE
feat(live): Implement live streaming via HTTP segment push

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -10042,7 +10042,19 @@ async def end_live_stream(request: Request, slug: str) -> LiveStreamResponse:
     # Trigger VOD recording if auto_record_vod is enabled
     if row["auto_record_vod"]:
         from api.live_vod import trigger_vod_recording
-        asyncio.create_task(trigger_vod_recording(row["id"]))
+
+        def _log_vod_task_result(task: asyncio.Task) -> None:
+            """Log errors from fire-and-forget VOD recording task."""
+            try:
+                exc = task.exception()
+            except asyncio.CancelledError:
+                logger.info(f"VOD recording task was cancelled for stream {slug}")
+                return
+            if exc is not None:
+                logger.error(f"VOD recording failed for stream {slug}: {exc}")
+
+        vod_task = asyncio.create_task(trigger_vod_recording(row["id"]))
+        vod_task.add_done_callback(_log_vod_task_result)
         logger.info(f"Triggered VOD recording for stream {slug}")
 
     return _build_live_stream_response(dict(updated_row))

--- a/api/admin.py
+++ b/api/admin.py
@@ -55,6 +55,8 @@ from api.database import (
     create_tables,
     custom_field_definitions,
     database,
+    live_stream_segments,
+    live_streams,
     playback_sessions,
     playlist_items,
     playlists,
@@ -205,6 +207,16 @@ from api.settings_service import (
     get_setting as get_db_setting,
 )
 from api.worker_auth import authenticate_api_key
+from api.live_auth import generate_stream_key, get_key_prefix, hash_stream_key, revoke_stream_key
+from api.live_schemas import (
+    LiveStreamCreate,
+    LiveStreamCreatedResponse,
+    LiveStreamKeyRegenerateResponse,
+    LiveStreamListResponse,
+    LiveStreamResponse,
+    LiveStreamStatus,
+    LiveStreamUpdate,
+)
 from config import (
     API_INCLUDE_LEGACY_ROUTES,
     API_VERSION,
@@ -243,6 +255,9 @@ from config import (
     VIDEOS_DIR,
     WORKER_OFFLINE_THRESHOLD_MINUTES,
     check_deprecated_env_vars,
+    LIVE_ENABLED,
+    LIVE_STORAGE_PATH,
+    LIVE_MAX_CONCURRENT_STREAMS,
 )
 from worker.transcoder import generate_thumbnail, get_video_info
 
@@ -9740,6 +9755,343 @@ async def retry_webhook_delivery(
             status_code=500,
             detail=sanitize_error_message(str(e), context="retry_delivery"),
         )
+
+
+# =============================================================================
+# Live Streaming Admin API
+# HTTP segment push for live streaming without RTMP/SRT servers
+# =============================================================================
+
+
+def _parse_qualities_json(qualities_str: Optional[str]) -> List[str]:
+    """Parse qualities JSON string to list."""
+    if not qualities_str:
+        return []
+    try:
+        return json.loads(qualities_str)
+    except json.JSONDecodeError:
+        return []
+
+
+def _build_live_stream_response(row: dict) -> LiveStreamResponse:
+    """Build LiveStreamResponse from database row."""
+    return LiveStreamResponse(
+        id=row["id"],
+        title=row["title"],
+        slug=row["slug"],
+        description=row["description"] or "",
+        status=LiveStreamStatus(row["status"]),
+        qualities=_parse_qualities_json(row["qualities"]),
+        category_id=row["category_id"],
+        dvr_enabled=row["dvr_enabled"],
+        dvr_window_seconds=row["dvr_window_seconds"],
+        auto_record_vod=row["auto_record_vod"],
+        segment_count=row["segment_count"],
+        vod_video_id=row["vod_video_id"],
+        created_at=row["created_at"],
+        started_at=row["started_at"],
+        ended_at=row["ended_at"],
+        last_segment_at=row["last_segment_at"],
+    )
+
+
+@v1_router.get("/live/streams")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def list_live_streams(
+    request: Request,
+    status: Optional[str] = Query(None, description="Filter by status (idle, live, ending, ended)"),
+) -> LiveStreamListResponse:
+    """List all live streams."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    query = live_streams.select().order_by(live_streams.c.created_at.desc())
+
+    if status:
+        valid_statuses = ["idle", "live", "ending", "ended"]
+        if status not in valid_statuses:
+            raise HTTPException(status_code=400, detail=f"Invalid status. Must be one of: {', '.join(valid_statuses)}")
+        query = query.where(live_streams.c.status == status)
+
+    rows = await fetch_all_with_retry(query)
+
+    return LiveStreamListResponse(
+        streams=[_build_live_stream_response(dict(row)) for row in rows],
+        total=len(rows),
+    )
+
+
+@v1_router.post("/live/streams", status_code=201)
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def create_live_stream(request: Request, data: LiveStreamCreate) -> LiveStreamCreatedResponse:
+    """Create a new live stream. Returns the stream key (shown once)."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    # Check concurrent stream limit
+    active_count = await database.fetch_val(
+        sa.select(sa.func.count()).select_from(live_streams).where(
+            live_streams.c.status.in_(["idle", "live", "ending"])
+        )
+    )
+    if active_count >= LIVE_MAX_CONCURRENT_STREAMS:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Maximum concurrent streams ({LIVE_MAX_CONCURRENT_STREAMS}) reached",
+        )
+
+    # Generate slug
+    slug = slugify(data.title)
+
+    # Check for duplicate slug
+    existing = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if existing:
+        # Append random suffix
+        slug = f"{slug}-{secrets.token_hex(4)}"
+
+    # Generate stream key
+    stream_key = generate_stream_key()
+    key_hash = hash_stream_key(stream_key)
+    key_prefix = get_key_prefix(stream_key)
+
+    now = datetime.now(timezone.utc)
+
+    # Insert stream
+    query = live_streams.insert().values(
+        title=data.title,
+        slug=slug,
+        description=data.description,
+        stream_key_hash=key_hash,
+        stream_key_prefix=key_prefix,
+        hash_version=2,  # argon2id
+        status="idle",
+        category_id=data.category_id,
+        dvr_enabled=data.dvr_enabled,
+        dvr_window_seconds=data.dvr_window_seconds,
+        auto_record_vod=data.auto_record_vod,
+        created_at=now,
+    )
+    stream_id = await db_execute_with_retry(query)
+
+    # Create storage directory
+    stream_dir = LIVE_STORAGE_PATH / slug
+    try:
+        stream_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error(f"Failed to create live stream directory {stream_dir}: {e}")
+
+    # Audit log
+    log_audit(
+        AuditAction.CREATE,
+        client_ip=get_real_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        resource_type="live_stream",
+        resource_id=stream_id,
+        resource_name=slug,
+        details={"title": data.title},
+    )
+
+    return LiveStreamCreatedResponse(
+        id=stream_id,
+        title=data.title,
+        slug=slug,
+        description=data.description,
+        status=LiveStreamStatus.IDLE,
+        stream_key=stream_key,  # Only shown once
+        category_id=data.category_id,
+        dvr_enabled=data.dvr_enabled,
+        dvr_window_seconds=data.dvr_window_seconds,
+        auto_record_vod=data.auto_record_vod,
+        created_at=now,
+    )
+
+
+@v1_router.get("/live/streams/{slug}")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def get_live_stream(request: Request, slug: str) -> LiveStreamResponse:
+    """Get details of a live stream."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if not row:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    return _build_live_stream_response(dict(row))
+
+
+@v1_router.patch("/live/streams/{slug}")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def update_live_stream(request: Request, slug: str, data: LiveStreamUpdate) -> LiveStreamResponse:
+    """Update a live stream."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if not row:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    # Build update values
+    update_values = {}
+    if data.title is not None:
+        update_values["title"] = data.title
+    if data.description is not None:
+        update_values["description"] = data.description
+    if data.category_id is not None:
+        update_values["category_id"] = data.category_id
+    if data.dvr_enabled is not None:
+        update_values["dvr_enabled"] = data.dvr_enabled
+    if data.dvr_window_seconds is not None:
+        update_values["dvr_window_seconds"] = data.dvr_window_seconds
+    if data.auto_record_vod is not None:
+        update_values["auto_record_vod"] = data.auto_record_vod
+
+    if update_values:
+        await db_execute_with_retry(
+            live_streams.update().where(live_streams.c.slug == slug).values(**update_values)
+        )
+
+    # Fetch updated row
+    updated_row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+
+    # Audit log
+    log_audit(
+        AuditAction.UPDATE,
+        client_ip=get_real_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        resource_type="live_stream",
+        resource_id=row["id"],
+        resource_name=slug,
+        details=update_values,
+    )
+
+    return _build_live_stream_response(dict(updated_row))
+
+
+@v1_router.post("/live/streams/{slug}/regenerate-key")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def regenerate_stream_key(request: Request, slug: str) -> LiveStreamKeyRegenerateResponse:
+    """Regenerate the stream key for a live stream."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if not row:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    # Cannot regenerate key for live stream
+    if row["status"] == "live":
+        raise HTTPException(status_code=400, detail="Cannot regenerate key while stream is live")
+
+    # Generate new key
+    new_key = generate_stream_key()
+    new_hash = hash_stream_key(new_key)
+    new_prefix = get_key_prefix(new_key)
+
+    await db_execute_with_retry(
+        live_streams.update()
+        .where(live_streams.c.slug == slug)
+        .values(stream_key_hash=new_hash, stream_key_prefix=new_prefix)
+    )
+
+    # Audit log
+    log_audit(
+        AuditAction.UPDATE,
+        client_ip=get_real_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        resource_type="live_stream",
+        resource_id=row["id"],
+        resource_name=slug,
+        details={"action": "regenerate_key"},
+    )
+
+    return LiveStreamKeyRegenerateResponse(stream_key=new_key)
+
+
+@v1_router.post("/live/streams/{slug}/end")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def end_live_stream(request: Request, slug: str) -> LiveStreamResponse:
+    """End a live stream. This triggers VOD recording if enabled."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if not row:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    if row["status"] == "ended":
+        raise HTTPException(status_code=400, detail="Stream has already ended")
+
+    # Revoke the stream key atomically
+    await revoke_stream_key(row["id"])
+
+    # Fetch updated row
+    updated_row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+
+    # Audit log
+    log_audit(
+        AuditAction.UPDATE,
+        client_ip=get_real_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        resource_type="live_stream",
+        resource_id=row["id"],
+        resource_name=slug,
+        details={"action": "end_stream"},
+    )
+
+    # Trigger VOD recording if auto_record_vod is enabled
+    if row["auto_record_vod"]:
+        from api.live_vod import trigger_vod_recording
+        asyncio.create_task(trigger_vod_recording(row["id"]))
+        logger.info(f"Triggered VOD recording for stream {slug}")
+
+    return _build_live_stream_response(dict(updated_row))
+
+
+@v1_router.delete("/live/streams/{slug}")
+@limiter.limit(RATE_LIMIT_ADMIN_DEFAULT)
+async def delete_live_stream(request: Request, slug: str):
+    """Delete a live stream and its segments."""
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(live_streams.select().where(live_streams.c.slug == slug))
+    if not row:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    # Cannot delete live stream
+    if row["status"] == "live":
+        raise HTTPException(status_code=400, detail="Cannot delete while stream is live. End it first.")
+
+    stream_id = row["id"]
+
+    # Delete segments from database (CASCADE should handle this, but be explicit)
+    await db_execute_with_retry(
+        live_stream_segments.delete().where(live_stream_segments.c.stream_id == stream_id)
+    )
+
+    # Delete stream from database
+    await db_execute_with_retry(live_streams.delete().where(live_streams.c.id == stream_id))
+
+    # Delete storage directory
+    stream_dir = LIVE_STORAGE_PATH / slug
+    if stream_dir.exists():
+        try:
+            shutil.rmtree(stream_dir)
+        except OSError as e:
+            logger.error(f"Failed to delete live stream directory {stream_dir}: {e}")
+
+    # Audit log
+    log_audit(
+        AuditAction.DELETE,
+        client_ip=get_real_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        resource_type="live_stream",
+        resource_id=stream_id,
+        resource_name=slug,
+    )
+
+    return {"status": "ok", "message": f"Stream '{slug}' deleted"}
 
 
 # =============================================================================

--- a/api/database.py
+++ b/api/database.py
@@ -926,6 +926,123 @@ webhook_deliveries = sa.Table(
     sa.Index("ix_webhook_deliveries_status_next_retry", "status", "next_retry_at"),
 )
 
+# Live streaming via HTTP segment push
+#
+# STREAM STATES:
+# --------------
+# - idle: Stream created but not yet started (no segments received)
+# - live: Actively receiving segments
+# - ending: No segments received for threshold period (grace period)
+# - ended: Stream explicitly ended or stale timeout exceeded
+#
+# ARCHITECTURE:
+# -------------
+# - Client (FFmpeg) encodes locally into HLS/CMAF segments
+# - Client pushes segments to VLog API via HTTP PUT
+# - VLog stores segments, writes playlists to disk on each segment
+# - Viewers watch via standard HLS playback (static file serving)
+# - On stream end, segments become a VOD recording
+#
+# AUTH:
+# -----
+# - Stream keys follow worker API key pattern (argon2id hashed)
+# - Keys are prefixed with "sk_live_" for easy identification
+# - Prefix lookup for fast authentication
+#
+# See: https://github.com/filthyrake/vlog/issues/XXX
+live_streams = sa.Table(
+    "live_streams",
+    metadata,
+    sa.Column("id", sa.Integer, primary_key=True),
+    sa.Column("title", sa.String(255), nullable=False),
+    sa.Column("slug", sa.String(255), unique=True, nullable=False),
+    sa.Column("description", sa.Text, default=""),
+    # Auth (argon2id hashed like worker API keys)
+    sa.Column("stream_key_hash", sa.Text, nullable=False),
+    sa.Column("stream_key_prefix", sa.String(8), nullable=False),
+    sa.Column("hash_version", sa.Integer, nullable=False, server_default="2"),
+    # Status
+    sa.Column(
+        "status",
+        sa.String(20),
+        sa.CheckConstraint(
+            "status IN ('idle', 'live', 'ending', 'ended')",
+            name="ck_live_streams_status",
+        ),
+        default="idle",
+    ),
+    sa.Column("qualities", sa.Text, nullable=True),  # JSON: ["720p", "480p"]
+    # Timestamps
+    sa.Column("created_at", sa.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)),
+    sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+    sa.Column("last_segment_at", sa.DateTime(timezone=True), nullable=True),
+    # Metrics
+    sa.Column("segment_count", sa.Integer, default=0),
+    # DVR/VOD
+    sa.Column("dvr_enabled", sa.Boolean, default=True),
+    sa.Column("dvr_window_seconds", sa.Integer, default=7200),  # 2 hours
+    sa.Column("auto_record_vod", sa.Boolean, default=True),
+    sa.Column(
+        "vod_video_id",
+        sa.Integer,
+        sa.ForeignKey("videos.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
+    sa.Column(
+        "category_id",
+        sa.Integer,
+        sa.ForeignKey("categories.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
+    sa.Index("ix_live_streams_slug", "slug"),
+    sa.Index("ix_live_streams_status", "status"),
+    sa.Index("ix_live_streams_stream_key_prefix", "stream_key_prefix"),
+    sa.Index("ix_live_streams_created_at", "created_at"),
+)
+
+# Live stream segment tracking for DVR and VOD recording
+#
+# SEGMENT SEMANTICS:
+# ------------------
+# - Each segment is a single HLS/CMAF fragment
+# - Segments are stored on disk at: live/{slug}/{quality}/seg_{sequence}.m4s
+# - Init segments stored at: live/{slug}/{quality}/init.mp4
+# - Playlists generated dynamically from database records
+#
+# DVR CLEANUP:
+# ------------
+# - Background task deletes segments older than dvr_window_seconds
+# - Batched DELETEs (10 at a time) to reduce lock contention
+# - Async file deletion to avoid blocking segment uploads
+#
+# VOD RECORDING:
+# --------------
+# - On stream end, segments are hardlinked to videos directory
+# - Fallback to copy if hardlinks fail (different filesystems)
+live_stream_segments = sa.Table(
+    "live_stream_segments",
+    metadata,
+    sa.Column("id", sa.Integer, primary_key=True),
+    sa.Column(
+        "stream_id",
+        sa.Integer,
+        sa.ForeignKey("live_streams.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    sa.Column("quality", sa.String(10), nullable=False),
+    sa.Column("filename", sa.String(255), nullable=False),
+    sa.Column("sequence_number", sa.Integer, nullable=False),
+    sa.Column("duration_ms", sa.Integer, nullable=True),
+    sa.Column("size_bytes", sa.Integer, nullable=False),
+    sa.Column("received_at", sa.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)),
+    sa.UniqueConstraint("stream_id", "quality", "sequence_number", name="uq_live_segment_stream_quality_seq"),
+    # Critical indexes for performance (from Brendan's review)
+    sa.Index("ix_live_segments_stream_quality_seq", "stream_id", "quality", "sequence_number"),
+    sa.Index("ix_live_segments_received_at", "received_at"),
+    sa.Index("ix_live_segments_cleanup", "stream_id", "received_at"),
+)
+
 
 def create_tables():
     """

--- a/api/live_auth.py
+++ b/api/live_auth.py
@@ -1,0 +1,302 @@
+"""Authentication for live stream ingest API.
+
+Follows the worker_auth.py pattern for API key management:
+- argon2id hashing for secure storage
+- Prefix-based lookup for efficient authentication
+- Security event logging for monitoring/SIEM integration
+"""
+
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Optional
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
+from fastapi import HTTPException, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from api.database import database, live_streams
+from config import TRUSTED_PROXIES
+
+# Security event logger - separate from regular application logging
+security_logger = logging.getLogger("security.live")
+
+# Standard logger for general operations
+logger = logging.getLogger(__name__)
+
+# Bearer token auth
+bearer_scheme = HTTPBearer(auto_error=False)
+
+# Stream key prefix for easy identification
+STREAM_KEY_PREFIX = "sk_live_"
+
+# Hash version constants (same as worker_auth.py)
+HASH_VERSION_ARGON2 = 2
+
+# Explicit argon2 parameters (OWASP recommended minimums)
+_password_hasher = PasswordHasher(
+    time_cost=3,  # iterations
+    memory_cost=65536,  # 64MB memory
+    parallelism=4,  # threads
+)
+
+
+def generate_stream_key() -> str:
+    """
+    Generate a secure stream key.
+
+    Format: sk_live_{random_32_bytes_base64}
+    The prefix makes it easy to identify stream keys in logs/configs.
+    """
+    return f"{STREAM_KEY_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def hash_stream_key(key: str) -> str:
+    """
+    Hash a stream key using argon2id.
+
+    Returns the argon2id hash with embedded salt and parameters.
+    """
+    return _password_hasher.hash(key)
+
+
+def get_key_prefix(key: str) -> str:
+    """Get the first 8 characters of a stream key for efficient lookup."""
+    return key[:8]
+
+
+def verify_stream_key_hash(key: str, stored_hash: str, key_prefix: Optional[str] = None) -> bool:
+    """
+    Verify a stream key against a stored hash using argon2id.
+
+    Args:
+        key: The plaintext stream key to verify
+        stored_hash: The hash stored in the database
+        key_prefix: Optional key prefix for error logging context
+
+    Returns:
+        True if the key matches the hash, False otherwise
+    """
+    try:
+        _password_hasher.verify(stored_hash, key)
+        return True
+    except VerifyMismatchError:
+        return False
+    except InvalidHashError:
+        # Malformed hash in database - log and fail
+        security_logger.error(
+            "Invalid argon2 hash format in database for stream key",
+            extra={
+                "event": "live_auth_error",
+                "reason": "invalid_hash_format",
+                "key_prefix": key_prefix,
+            },
+        )
+        return False
+
+
+def _get_request_context(request: Optional[Request]) -> dict:
+    """
+    Extract security-relevant context from request for logging.
+
+    Returns both the direct client IP and any X-Forwarded-For value separately.
+    The X-Forwarded-For header is only trusted if the direct client IP is in
+    TRUSTED_PROXIES to prevent header spoofing attacks.
+    """
+    if request is None:
+        return {
+            "ip_address": "unknown",
+            "direct_ip": "unknown",
+            "forwarded_for": None,
+            "user_agent": "unknown",
+        }
+
+    # Always get the direct connection IP
+    direct_ip = request.client.host if request.client else "unknown"
+
+    # Get X-Forwarded-For header if present (may be spoofed if not behind trusted proxy)
+    forwarded_for_header = request.headers.get("x-forwarded-for")
+    forwarded_for_ip = None
+    if forwarded_for_header:
+        # Take the first IP in the chain (claimed original client)
+        forwarded_for_ip = forwarded_for_header.split(",")[0].strip()
+
+    # Determine the effective IP address for logging
+    # Only trust X-Forwarded-For if request comes from a trusted proxy
+    if forwarded_for_ip and direct_ip in TRUSTED_PROXIES:
+        effective_ip = forwarded_for_ip
+    else:
+        effective_ip = direct_ip
+
+    user_agent = request.headers.get("user-agent", "unknown")
+
+    return {
+        "ip_address": effective_ip,
+        "direct_ip": direct_ip,
+        "forwarded_for": forwarded_for_ip,
+        "user_agent": user_agent,
+    }
+
+
+async def authenticate_stream_key(stream_key: str, request: Optional[Request] = None) -> dict:
+    """
+    Authenticate a stream key and return the stream record.
+
+    Args:
+        stream_key: The plaintext stream key from the Authorization header
+        request: Optional request for logging context
+
+    Returns:
+        The stream record as a dict on success
+
+    Raises:
+        HTTPException(401) if key is invalid or stream is not in valid state
+        HTTPException(403) if stream has ended
+    """
+    ctx = _get_request_context(request)
+
+    # Validate stream key format
+    if not stream_key or len(stream_key) < 8:
+        security_logger.warning(
+            "Live auth failed: invalid stream key format",
+            extra={
+                "event": "live_auth_failure",
+                "reason": "invalid_key_format",
+                "key_length": len(stream_key) if stream_key else 0,
+                **ctx,
+            },
+        )
+        raise HTTPException(status_code=401, detail="Invalid stream key")
+
+    prefix = get_key_prefix(stream_key)
+
+    # Query database for matching streams by prefix (non-ended streams only)
+    # We accept both 'idle' and 'live' status for segment uploads
+    # 'ending' status also accepted (grace period for network hiccups)
+    stream_records = await database.fetch_all(
+        live_streams.select()
+        .where(live_streams.c.stream_key_prefix == prefix)
+        .where(live_streams.c.status.in_(["idle", "live", "ending"]))
+    )
+
+    if not stream_records:
+        # Check if stream exists but has ended
+        ended_stream = await database.fetch_one(
+            live_streams.select()
+            .where(live_streams.c.stream_key_prefix == prefix)
+            .where(live_streams.c.status == "ended")
+        )
+        if ended_stream:
+            security_logger.warning(
+                "Live auth failed: stream has ended",
+                extra={
+                    "event": "live_auth_failure",
+                    "reason": "stream_ended",
+                    "key_prefix": prefix,
+                    "stream_id": ended_stream["id"],
+                    **ctx,
+                },
+            )
+            raise HTTPException(status_code=403, detail="Stream has ended")
+
+        security_logger.warning(
+            "Live auth failed: invalid stream key",
+            extra={
+                "event": "live_auth_failure",
+                "reason": "invalid_key",
+                "key_prefix": prefix,
+                **ctx,
+            },
+        )
+        raise HTTPException(status_code=401, detail="Invalid stream key")
+
+    # Try each candidate stream with matching prefix
+    for stream_record in stream_records:
+        if verify_stream_key_hash(stream_key, stream_record["stream_key_hash"], key_prefix=prefix):
+            # Found matching stream
+            security_logger.info(
+                "Live auth successful",
+                extra={
+                    "event": "live_auth_success",
+                    "stream_id": stream_record["id"],
+                    "stream_slug": stream_record["slug"],
+                    **ctx,
+                },
+            )
+            return dict(stream_record)
+
+    # None of the candidates matched
+    security_logger.warning(
+        "Live auth failed: key hash mismatch",
+        extra={
+            "event": "live_auth_failure",
+            "reason": "hash_mismatch",
+            "key_prefix": prefix,
+            "candidates_checked": len(stream_records),
+            **ctx,
+        },
+    )
+    raise HTTPException(status_code=401, detail="Invalid stream key")
+
+
+async def verify_stream_key(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(bearer_scheme),
+) -> dict:
+    """
+    FastAPI dependency for stream key verification.
+
+    Expects Authorization: Bearer <stream_key>
+
+    Returns the stream record as a dict on success.
+    Raises HTTPException if authentication fails.
+    """
+    ctx = _get_request_context(request)
+
+    if not credentials:
+        security_logger.warning(
+            "Live auth failed: missing Authorization header",
+            extra={
+                "event": "live_auth_failure",
+                "reason": "missing_header",
+                **ctx,
+            },
+        )
+        raise HTTPException(
+            status_code=401,
+            detail="Missing Authorization header. Use: Authorization: Bearer <stream_key>",
+        )
+
+    return await authenticate_stream_key(credentials.credentials, request)
+
+
+async def revoke_stream_key(stream_id: int) -> bool:
+    """
+    Atomically revoke a stream key by setting status to 'ended'.
+
+    This prevents race conditions where segments could be uploaded
+    during VOD creation.
+
+    Args:
+        stream_id: The ID of the stream to revoke
+
+    Returns:
+        True if revoked successfully, False if stream was already ended
+    """
+    now = datetime.now(timezone.utc)
+
+    # Atomically update status to 'ended' if not already ended
+    result = await database.execute(
+        live_streams.update()
+        .where(live_streams.c.id == stream_id)
+        .where(live_streams.c.status != "ended")
+        .values(status="ended", ended_at=now)
+    )
+
+    if result > 0:
+        logger.info(f"Revoked stream key for stream {stream_id}")
+        return True
+    else:
+        logger.debug(f"Stream {stream_id} was already ended")
+        return False

--- a/api/live_ingest.py
+++ b/api/live_ingest.py
@@ -26,13 +26,14 @@ from typing import Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from slowapi import Limiter
-from slowapi.errors import RateLimitExceeded
+from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
 
 from api.common import get_real_ip
-from api.database import database, live_stream_segments, live_streams
-from api.db_retry import db_execute_with_retry, fetch_one_with_retry
+from api.database import live_stream_segments, live_streams
+from api.db_retry import db_execute_with_retry
 from api.live_auth import verify_stream_key
+from api.live_playlist import update_master_playlist, update_variant_playlist
 from api.live_schemas import IngestStatusResponse, SegmentUploadResponse
 
 from config import (
@@ -130,8 +131,17 @@ def validate_path_containment(path: Path, base_dir: Path) -> bool:
         resolved_path = path.resolve()
         resolved_base = base_dir.resolve()
 
-        # Check if resolved path starts with the base directory
-        return str(resolved_path).startswith(str(resolved_base) + os.sep) or resolved_path == resolved_base
+        # Use pathlib's semantic containment check (Python 3.9+)
+        try:
+            return resolved_path.is_relative_to(resolved_base)
+        except AttributeError:
+            # Fallback for older Python versions: use normalized string comparison
+            resolved_path_str = os.path.normcase(str(resolved_path))
+            resolved_base_str = os.path.normcase(str(resolved_base))
+            return (
+                resolved_path_str == resolved_base_str
+                or resolved_path_str.startswith(resolved_base_str + os.sep)
+            )
     except (OSError, ValueError):
         # Any error during resolution means the path is suspicious
         return False
@@ -212,7 +222,9 @@ def prepare_stream_update_values(stream: dict, quality: str, now: datetime) -> d
         try:
             current_qualities = json.loads(stream["qualities"])
         except json.JSONDecodeError:
-            pass
+            # Invalid JSON in qualities field; treat as empty and continue
+            logger.warning("Invalid JSON in stream qualities; treating as empty")
+            current_qualities = []
 
     if quality not in current_qualities:
         current_qualities.append(quality)
@@ -264,9 +276,9 @@ async def put_init_segment(
                 detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
             )
 
-    # Read request body with timeout (50MB at 100KB/s = 500s, with 50% margin = 720s)
+    # Read request body with timeout (50MB at 125KB/s ≈ 400s, with 50% margin ≈ 600s)
     try:
-        data = await asyncio.wait_for(request.body(), timeout=720.0)
+        data = await asyncio.wait_for(request.body(), timeout=600.0)
     except asyncio.TimeoutError:
         raise HTTPException(status_code=408, detail="Upload timeout - slow connection")
 
@@ -302,6 +314,21 @@ async def put_init_segment(
     _active_uploads.add(upload_key)
     try:
         await write_segment_atomic(dest_path, data)
+
+        # Update stream status to indicate ingest has started (without incrementing segment count)
+        if stream["status"] == "idle":
+            try:
+                await db_execute_with_retry(
+                    live_streams.update()
+                    .where(live_streams.c.id == stream["id"])
+                    .values(
+                        status="live",
+                        started_at=datetime.now(timezone.utc),
+                    )
+                )
+            except Exception as e:
+                # Log but don't fail; init upload should succeed even if metadata update fails
+                logger.warning(f"Failed to update stream status after init segment for {slug}: {e}")
     finally:
         _active_uploads.discard(upload_key)
 
@@ -365,9 +392,9 @@ async def put_media_segment(
                 detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
             )
 
-    # Read request body with timeout (50MB at 100KB/s = 500s, with 50% margin = 720s)
+    # Read request body with timeout (50MB at 125KB/s ≈ 400s, with 50% margin ≈ 600s)
     try:
-        data = await asyncio.wait_for(request.body(), timeout=720.0)
+        data = await asyncio.wait_for(request.body(), timeout=600.0)
     except asyncio.TimeoutError:
         raise HTTPException(status_code=408, detail="Upload timeout - slow connection")
 
@@ -398,6 +425,7 @@ async def put_media_segment(
         try:
             duration_ms = int(x_segment_duration)
         except ValueError:
+            # Invalid duration header; ignore and use default segment duration
             pass
 
     now = datetime.now(timezone.utc)
@@ -433,9 +461,11 @@ async def put_media_segment(
                     received_at=now,
                 )
             )
-        except Exception as e:
+        except IntegrityError as e:
             # Unique constraint violation = segment already exists (idempotent)
-            if "uq_live_segment_stream_quality_seq" in str(e).lower() or "unique" in str(e).lower():
+            # Check constraint name or generic "unique" for database compatibility
+            error_msg = str(e).lower()
+            if "uq_live_segment_stream_quality_seq" in error_msg or "unique" in error_msg:
                 logger.debug(f"Segment {safe_filename} already exists for {slug}/{quality}")
                 segment_is_duplicate = True
             else:
@@ -450,6 +480,16 @@ async def put_media_segment(
                 .where(live_streams.c.id == stream_id)
                 .values(**update_values)
             )
+
+            # Update playlists after successful segment upload
+            try:
+                await update_variant_playlist(
+                    stream_id, slug, quality, stream["dvr_window_seconds"]
+                )
+                await update_master_playlist(stream_id, slug)
+            except Exception as playlist_error:
+                # Log but don't fail the upload if playlist update fails
+                logger.warning(f"Failed to update playlists for {slug}/{quality}: {playlist_error}")
 
     except Exception as e:
         # Clean up orphaned file if DB operations failed after file write
@@ -501,7 +541,9 @@ async def get_ingest_status(
         try:
             qualities = json.loads(stream["qualities"])
         except json.JSONDecodeError:
-            pass
+            # Malformed qualities JSON; log and return empty list
+            logger.warning(f"Invalid qualities JSON for stream {slug}")
+            qualities = []
 
     return IngestStatusResponse(
         stream_id=stream["id"],

--- a/api/live_ingest.py
+++ b/api/live_ingest.py
@@ -1,0 +1,547 @@
+"""Live stream ingest API for segment push.
+
+This module handles the HTTP segment push from FFmpeg:
+- PUT /api/live/ingest/{slug}/{quality}/init.mp4 - Push init segment
+- PUT /api/live/ingest/{slug}/{quality}/seg_{seq}.m4s - Push media segment
+- GET /api/live/ingest/{slug}/status - Get ingest status
+
+Security:
+- All endpoints require Bearer token authentication with stream key
+- Path validation prevents directory traversal
+- Magic byte validation ensures file format
+- Rate limiting prevents DoS attacks
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Set
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from starlette.responses import Response
+
+from api.common import get_real_ip
+from api.database import database, live_stream_segments, live_streams
+from api.db_retry import db_execute_with_retry, fetch_one_with_retry
+from api.live_auth import verify_stream_key
+from api.live_schemas import IngestStatusResponse, SegmentUploadResponse
+
+from config import (
+    LIVE_ALLOWED_QUALITIES,
+    LIVE_ENABLED,
+    LIVE_MAX_SEGMENT_SIZE,
+    LIVE_STORAGE_PATH,
+    RATE_LIMIT_ENABLED,
+    RATE_LIMIT_LIVE_GLOBAL,
+    RATE_LIMIT_LIVE_SEGMENT,
+    RATE_LIMIT_STORAGE_URL,
+)
+
+logger = logging.getLogger(__name__)
+
+# Create router for ingest API
+router = APIRouter(prefix="/api/live/ingest", tags=["Live Ingest"])
+
+# Initialize rate limiter for ingest API
+# Uses same storage backend as other APIs for consistency
+limiter = Limiter(
+    key_func=get_real_ip,
+    storage_uri=RATE_LIMIT_STORAGE_URL if RATE_LIMIT_ENABLED else None,
+    enabled=RATE_LIMIT_ENABLED,
+)
+
+# Thread pool for file I/O (prevents blocking event loop)
+# 16 workers to handle concurrent segment uploads without blocking
+_io_executor = ThreadPoolExecutor(max_workers=16, thread_name_prefix="live_io")
+
+# Track active segment uploads for graceful shutdown
+_active_uploads: Set[str] = set()
+_accepting_uploads = True
+
+# Magic bytes for segment validation (same as worker_api.py)
+TS_MAGIC_BYTE = b"\x47"
+FTYP_MAGIC = b"ftyp"
+MOOF_MAGIC = b"moof"
+STYP_MAGIC = b"styp"
+SIDX_MAGIC = b"sidx"
+EMSG_MAGIC = b"emsg"
+
+# Regex for segment filename validation
+SEGMENT_FILENAME_RE = re.compile(r"^seg_(\d{4,6})\.m4s$")
+
+
+def validate_segment_magic_bytes(data: bytes, filename: str) -> bool:
+    """
+    Validate segment file magic bytes.
+
+    Verifies that the file content matches expected format based on extension:
+    - .ts files start with MPEG-TS sync byte (0x47)
+    - .m4s files start with 'ftyp', 'moof', 'styp', 'sidx', or 'emsg' box
+    - .mp4 files start with 'ftyp' box
+    """
+    if len(data) < 8:
+        return False
+
+    if filename.endswith(".ts"):
+        return data[0:1] == TS_MAGIC_BYTE
+
+    if filename.endswith(".m4s"):
+        box_type = data[4:8]
+        return box_type in (FTYP_MAGIC, MOOF_MAGIC, STYP_MAGIC, SIDX_MAGIC, EMSG_MAGIC)
+
+    if filename.endswith(".mp4"):
+        box_type = data[4:8]
+        return box_type == FTYP_MAGIC
+
+    return False
+
+
+def validate_quality(quality: str) -> bool:
+    """Validate quality name against allowed values."""
+    return quality in LIVE_ALLOWED_QUALITIES
+
+
+def validate_path_containment(path: Path, base_dir: Path) -> bool:
+    """
+    Validate that a path stays within its base directory.
+
+    This is defense-in-depth against path traversal attacks.
+    Even though inputs are validated, this ensures the resolved
+    path cannot escape the intended directory.
+
+    Args:
+        path: The path to validate (will be resolved)
+        base_dir: The base directory the path must stay within
+
+    Returns:
+        True if path is safely contained within base_dir
+    """
+    try:
+        # Resolve both paths to their absolute, canonical forms
+        resolved_path = path.resolve()
+        resolved_base = base_dir.resolve()
+
+        # Check if resolved path starts with the base directory
+        return str(resolved_path).startswith(str(resolved_base) + os.sep) or resolved_path == resolved_base
+    except (OSError, ValueError):
+        # Any error during resolution means the path is suspicious
+        return False
+
+
+def validate_segment_filename(filename: str) -> Optional[int]:
+    """
+    Validate segment filename and extract sequence number.
+
+    Returns sequence number if valid, None otherwise.
+    Only allows: seg_NNNN.m4s format
+    """
+    match = SEGMENT_FILENAME_RE.match(filename)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+async def write_segment_atomic(dest_path: Path, data: bytes) -> None:
+    """
+    Write segment data atomically using tempfile and rename.
+
+    This ensures readers never see partial files.
+    """
+    loop = asyncio.get_event_loop()
+
+    def _write():
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write to temp file in same directory
+        fd, temp_path = tempfile.mkstemp(dir=str(dest_path.parent), suffix=".tmp")
+        fd_closed = False
+        try:
+            os.write(fd, data)
+            os.fsync(fd)
+            os.close(fd)
+            fd_closed = True
+            # Atomic rename
+            os.rename(temp_path, str(dest_path))
+        except Exception:
+            if not fd_closed:
+                os.close(fd)
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            raise
+
+    await loop.run_in_executor(_io_executor, _write)
+
+
+def prepare_stream_update_values(stream: dict, quality: str, now: datetime) -> dict:
+    """
+    Prepare update values for stream record based on current state.
+
+    This function uses the already-fetched stream data to avoid an extra query.
+
+    Args:
+        stream: Stream record dict from verify_stream_key
+        quality: Quality being uploaded
+        now: Current timestamp
+
+    Returns:
+        Dict of values to update on the stream record
+    """
+    update_values = {
+        "last_segment_at": now,
+        "segment_count": live_streams.c.segment_count + 1,
+    }
+
+    # Update status to live if currently idle or ending
+    if stream["status"] in ("idle", "ending"):
+        update_values["status"] = "live"
+        if stream["status"] == "idle":
+            update_values["started_at"] = now
+
+    # Update qualities list if this is a new quality
+    current_qualities = []
+    if stream["qualities"]:
+        try:
+            current_qualities = json.loads(stream["qualities"])
+        except json.JSONDecodeError:
+            pass
+
+    if quality not in current_qualities:
+        current_qualities.append(quality)
+        current_qualities.sort()
+        update_values["qualities"] = json.dumps(current_qualities)
+
+    return update_values
+
+
+@router.put("/{slug}/{quality}/init.mp4")
+@limiter.limit(RATE_LIMIT_LIVE_GLOBAL)  # Global per-IP limit (prevents flood via multiple streams)
+@limiter.limit(RATE_LIMIT_LIVE_SEGMENT)  # Additional per-IP limit for segment uploads
+async def put_init_segment(
+    request: Request,
+    slug: str,
+    quality: str,
+    stream: dict = Depends(verify_stream_key),
+) -> Response:
+    """
+    Push init segment for a quality variant.
+
+    The init segment contains the initialization data needed to decode
+    subsequent media segments.
+    """
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    if not _accepting_uploads:
+        raise HTTPException(status_code=503, detail="Server is shutting down")
+
+    # Validate quality
+    if not validate_quality(quality):
+        raise HTTPException(status_code=400, detail=f"Invalid quality: {quality}")
+
+    # Verify slug matches authenticated stream
+    if stream["slug"] != slug:
+        raise HTTPException(status_code=403, detail="Stream key does not match slug")
+
+    # Validate Content-Length header if present
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            length = int(content_length)
+        except (ValueError, OverflowError):
+            raise HTTPException(status_code=400, detail="Invalid Content-Length header")
+        if length > LIVE_MAX_SEGMENT_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
+            )
+
+    # Read request body with timeout (50MB at 100KB/s = 500s, with 50% margin = 720s)
+    try:
+        data = await asyncio.wait_for(request.body(), timeout=720.0)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=408, detail="Upload timeout - slow connection")
+
+    if len(data) > LIVE_MAX_SEGMENT_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
+        )
+
+    # Validate magic bytes
+    if not validate_segment_magic_bytes(data, "init.mp4"):
+        raise HTTPException(status_code=400, detail="Invalid init segment format")
+
+    # Validate checksum if provided
+    x_content_sha256 = request.headers.get("x-content-sha256")
+    if x_content_sha256:
+        checksum = x_content_sha256.lower()
+        if checksum.startswith("sha256:"):
+            checksum = checksum[7:]
+        computed = hashlib.sha256(data).hexdigest()
+        if checksum != computed:
+            raise HTTPException(status_code=400, detail="Checksum mismatch")
+
+    # Write init segment
+    dest_path = LIVE_STORAGE_PATH / slug / quality / "init.mp4"
+
+    # Defense-in-depth: verify path stays within live storage
+    if not validate_path_containment(dest_path, LIVE_STORAGE_PATH):
+        logger.warning(f"Path containment violation for init segment: {dest_path}")
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    upload_key = f"{slug}/{quality}/init"
+    _active_uploads.add(upload_key)
+    try:
+        await write_segment_atomic(dest_path, data)
+    finally:
+        _active_uploads.discard(upload_key)
+
+    logger.debug(f"Received init segment for {slug}/{quality}")
+
+    return Response(status_code=204)
+
+
+@router.put("/{slug}/{quality}/{filename}")
+@limiter.limit(RATE_LIMIT_LIVE_GLOBAL)  # Global per-IP limit (prevents flood via multiple streams)
+@limiter.limit(RATE_LIMIT_LIVE_SEGMENT)  # Additional per-IP limit for segment uploads
+async def put_media_segment(
+    request: Request,
+    slug: str,
+    quality: str,
+    filename: str,
+    stream: dict = Depends(verify_stream_key),
+) -> SegmentUploadResponse:
+    """
+    Push a media segment.
+
+    Segment filenames must match pattern: seg_NNNN.m4s
+    where NNNN is a 4-6 digit sequence number.
+    """
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    if not _accepting_uploads:
+        raise HTTPException(status_code=503, detail="Server is shutting down")
+
+    # Validate quality
+    if not validate_quality(quality):
+        raise HTTPException(status_code=400, detail=f"Invalid quality: {quality}")
+
+    # Verify slug matches authenticated stream
+    if stream["slug"] != slug:
+        raise HTTPException(status_code=403, detail="Stream key does not match slug")
+
+    # Validate and extract sequence number
+    # Server generates the actual filename for security
+    sequence_number = validate_segment_filename(filename)
+    if sequence_number is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid segment filename. Must be seg_NNNN.m4s",
+        )
+
+    # Generate server-controlled filename
+    safe_filename = f"seg_{sequence_number:04d}.m4s"
+
+    # Validate Content-Length header if present
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            length = int(content_length)
+        except (ValueError, OverflowError):
+            raise HTTPException(status_code=400, detail="Invalid Content-Length header")
+        if length > LIVE_MAX_SEGMENT_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
+            )
+
+    # Read request body with timeout (50MB at 100KB/s = 500s, with 50% margin = 720s)
+    try:
+        data = await asyncio.wait_for(request.body(), timeout=720.0)
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=408, detail="Upload timeout - slow connection")
+
+    if len(data) > LIVE_MAX_SEGMENT_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Segment too large. Max: {LIVE_MAX_SEGMENT_SIZE} bytes",
+        )
+
+    # Validate magic bytes
+    if not validate_segment_magic_bytes(data, safe_filename):
+        raise HTTPException(status_code=400, detail="Invalid segment format")
+
+    # Validate checksum if provided
+    x_content_sha256 = request.headers.get("x-content-sha256")
+    if x_content_sha256:
+        checksum = x_content_sha256.lower()
+        if checksum.startswith("sha256:"):
+            checksum = checksum[7:]
+        computed = hashlib.sha256(data).hexdigest()
+        if checksum != computed:
+            raise HTTPException(status_code=400, detail="Checksum mismatch")
+
+    # Parse segment duration from header (optional)
+    duration_ms = None
+    x_segment_duration = request.headers.get("x-segment-duration-ms")
+    if x_segment_duration:
+        try:
+            duration_ms = int(x_segment_duration)
+        except ValueError:
+            pass
+
+    now = datetime.now(timezone.utc)
+    stream_id = stream["id"]
+    dest_path = LIVE_STORAGE_PATH / slug / quality / safe_filename
+
+    # Defense-in-depth: verify path stays within live storage
+    if not validate_path_containment(dest_path, LIVE_STORAGE_PATH):
+        logger.warning(f"Path containment violation for segment: {dest_path}")
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    upload_key = f"{slug}/{quality}/{sequence_number}"
+    _active_uploads.add(upload_key)
+    file_written = False
+
+    try:
+        # Write segment to disk first
+        await write_segment_atomic(dest_path, data)
+        file_written = True
+
+        # Batch database operations: insert segment + update stream in sequence
+        # This reduces 4 queries to 2 (no separate fetch + update)
+        segment_is_duplicate = False
+        try:
+            await db_execute_with_retry(
+                live_stream_segments.insert().values(
+                    stream_id=stream_id,
+                    quality=quality,
+                    filename=safe_filename,
+                    sequence_number=sequence_number,
+                    duration_ms=duration_ms,
+                    size_bytes=len(data),
+                    received_at=now,
+                )
+            )
+        except Exception as e:
+            # Unique constraint violation = segment already exists (idempotent)
+            if "uq_live_segment_stream_quality_seq" in str(e).lower() or "unique" in str(e).lower():
+                logger.debug(f"Segment {safe_filename} already exists for {slug}/{quality}")
+                segment_is_duplicate = True
+            else:
+                raise
+
+        # Update stream in single query (combines count, status, qualities, timestamp)
+        # Only increment count if segment wasn't a duplicate
+        if not segment_is_duplicate:
+            update_values = prepare_stream_update_values(stream, quality, now)
+            await db_execute_with_retry(
+                live_streams.update()
+                .where(live_streams.c.id == stream_id)
+                .values(**update_values)
+            )
+
+    except Exception as e:
+        # Clean up orphaned file if DB operations failed after file write
+        if file_written:
+            try:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(
+                    _io_executor,
+                    lambda: dest_path.unlink(missing_ok=True)
+                )
+                logger.debug(f"Cleaned up orphaned segment file {dest_path}")
+            except Exception as cleanup_error:
+                logger.warning(f"Failed to cleanup orphaned file {dest_path}: {cleanup_error}")
+        raise
+    finally:
+        _active_uploads.discard(upload_key)
+
+    logger.debug(f"Received segment {safe_filename} for {slug}/{quality}")
+
+    return SegmentUploadResponse(
+        received=True,
+        sequence_number=sequence_number,
+        quality=quality,
+    )
+
+
+@router.get("/{slug}/status")
+@limiter.limit(RATE_LIMIT_LIVE_GLOBAL)  # Global per-IP limit
+async def get_ingest_status(
+    request: Request,
+    slug: str,
+    stream: dict = Depends(verify_stream_key),
+) -> IngestStatusResponse:
+    """
+    Get ingest status for a stream.
+
+    Returns the current stream status, segment count, and qualities.
+    """
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    # Verify slug matches authenticated stream
+    if stream["slug"] != slug:
+        raise HTTPException(status_code=403, detail="Stream key does not match slug")
+
+    # Parse qualities
+    qualities = []
+    if stream["qualities"]:
+        try:
+            qualities = json.loads(stream["qualities"])
+        except json.JSONDecodeError:
+            pass
+
+    return IngestStatusResponse(
+        stream_id=stream["id"],
+        slug=stream["slug"],
+        status=stream["status"],
+        segment_count=stream["segment_count"],
+        qualities=qualities,
+        last_segment_at=stream["last_segment_at"],
+    )
+
+
+def stop_accepting_uploads():
+    """Stop accepting new uploads (for graceful shutdown)."""
+    global _accepting_uploads
+    _accepting_uploads = False
+    logger.info("Stopped accepting new live segment uploads")
+
+
+async def wait_for_active_uploads(timeout: float = 10.0) -> bool:
+    """
+    Wait for active uploads to complete.
+
+    Returns True if all uploads completed, False if timeout.
+    """
+    if not _active_uploads:
+        return True
+
+    logger.info(f"Waiting for {len(_active_uploads)} active uploads to complete...")
+
+    start_time = asyncio.get_event_loop().time()
+    while _active_uploads:
+        if asyncio.get_event_loop().time() - start_time > timeout:
+            logger.warning(f"Timeout waiting for uploads: {_active_uploads}")
+            return False
+        await asyncio.sleep(0.1)
+
+    logger.info("All active uploads completed")
+    return True
+
+
+def get_active_upload_count() -> int:
+    """Get the number of active uploads."""
+    return len(_active_uploads)

--- a/api/live_playlist.py
+++ b/api/live_playlist.py
@@ -1,0 +1,399 @@
+"""HLS playlist generation for live streams.
+
+Generates master and variant playlists for HLS playback:
+- Master playlist: Lists all available quality variants
+- Variant playlist: Lists segments with proper timing
+
+Design decisions (from Ada/Brendan reviews):
+- Playlists are written to disk on each segment upload for performance
+- Static file serving via nginx/Starlette is more scalable than dynamic generation
+- DVR window is respected in playlist generation
+"""
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import sqlalchemy as sa
+
+from api.database import database, live_stream_segments, live_streams
+from api.db_retry import fetch_all_with_retry, fetch_one_with_retry
+from config import (
+    LIVE_HLS_PLAYLIST_LENGTH,
+    LIVE_HLS_SEGMENT_DURATION,
+    LIVE_STORAGE_PATH,
+    QUALITY_PRESETS,
+)
+
+logger = logging.getLogger(__name__)
+
+# Quality to bandwidth mapping (approximate, based on QUALITY_PRESETS)
+QUALITY_BANDWIDTH = {
+    "2160p": 15000000,  # 15 Mbps
+    "1440p": 8000000,   # 8 Mbps
+    "1080p": 5000000,   # 5 Mbps
+    "720p": 2500000,    # 2.5 Mbps
+    "480p": 1000000,    # 1 Mbps
+    "360p": 600000,     # 600 Kbps
+}
+
+# Quality to resolution mapping
+QUALITY_RESOLUTION = {
+    "2160p": (3840, 2160),
+    "1440p": (2560, 1440),
+    "1080p": (1920, 1080),
+    "720p": (1280, 720),
+    "480p": (854, 480),
+    "360p": (640, 360),
+}
+
+
+def generate_master_playlist(qualities: List[str], slug: str) -> str:
+    """
+    Generate HLS master playlist for a live stream.
+
+    Args:
+        qualities: List of available quality names (e.g., ["720p", "480p"])
+        slug: Stream slug for URL generation
+
+    Returns:
+        Master playlist content as string
+    """
+    lines = [
+        "#EXTM3U",
+        "#EXT-X-VERSION:6",
+        "",
+    ]
+
+    # Sort qualities by bandwidth (highest first for adaptive streaming)
+    sorted_qualities = sorted(
+        qualities,
+        key=lambda q: QUALITY_BANDWIDTH.get(q, 0),
+        reverse=True,
+    )
+
+    for quality in sorted_qualities:
+        bandwidth = QUALITY_BANDWIDTH.get(quality, 2500000)
+        resolution = QUALITY_RESOLUTION.get(quality, (1280, 720))
+
+        lines.extend([
+            f'#EXT-X-STREAM-INF:BANDWIDTH={bandwidth},RESOLUTION={resolution[0]}x{resolution[1]},CODECS="avc1.64001f,mp4a.40.2",NAME="{quality}"',
+            f"{quality}/stream.m3u8",
+            "",
+        ])
+
+    return "\n".join(lines)
+
+
+def generate_variant_playlist(
+    segments: List[dict],
+    media_sequence: int,
+    target_duration: int,
+    is_live: bool = True,
+) -> str:
+    """
+    Generate HLS variant playlist for a specific quality.
+
+    Args:
+        segments: List of segment records with sequence_number, duration_ms, filename
+        media_sequence: Media sequence number for first segment
+        target_duration: Target segment duration in seconds
+        is_live: Whether stream is live (affects playlist type)
+
+    Returns:
+        Variant playlist content as string
+    """
+    lines = [
+        "#EXTM3U",
+        "#EXT-X-VERSION:6",
+        f"#EXT-X-TARGETDURATION:{target_duration}",
+        f"#EXT-X-MEDIA-SEQUENCE:{media_sequence}",
+    ]
+
+    if is_live:
+        # Live stream - no end tag
+        lines.append("#EXT-X-PLAYLIST-TYPE:EVENT")
+    else:
+        # VOD - add end tag
+        lines.append("#EXT-X-PLAYLIST-TYPE:VOD")
+
+    # Add init segment
+    lines.extend([
+        "",
+        '#EXT-X-MAP:URI="init.mp4"',
+        "",
+    ])
+
+    for segment in segments:
+        # Calculate duration in seconds
+        duration_ms = segment.get("duration_ms") or (target_duration * 1000)
+        duration = duration_ms / 1000.0
+
+        lines.extend([
+            f"#EXTINF:{duration:.3f},",
+            segment["filename"],
+        ])
+
+    if not is_live:
+        lines.append("#EXT-X-ENDLIST")
+
+    return "\n".join(lines)
+
+
+async def write_playlist_atomic(dest_path: Path, content: str) -> None:
+    """
+    Write playlist atomically using tempfile and rename.
+
+    This ensures readers never see partial playlists.
+    Uses fsync for durability on NAS.
+    """
+    loop = asyncio.get_event_loop()
+
+    def _write():
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write to temp file in same directory
+        fd, temp_path = tempfile.mkstemp(dir=str(dest_path.parent), suffix=".m3u8.tmp")
+        fd_closed = False
+        try:
+            os.write(fd, content.encode("utf-8"))
+            os.fsync(fd)
+            os.close(fd)
+            fd_closed = True
+            # Atomic rename
+            os.rename(temp_path, str(dest_path))
+        except Exception:
+            if not fd_closed:
+                os.close(fd)
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            raise
+
+    await loop.run_in_executor(None, _write)
+
+
+async def update_master_playlist(stream_id: int, slug: str) -> None:
+    """
+    Update master playlist for a stream.
+
+    Should be called when a new quality variant is first seen.
+    """
+    # Get stream to get qualities
+    stream = await fetch_one_with_retry(
+        live_streams.select().where(live_streams.c.id == stream_id)
+    )
+
+    if not stream:
+        logger.warning(f"Stream {stream_id} not found for master playlist update")
+        return
+
+    if not stream["qualities"]:
+        logger.debug(f"No qualities yet for stream {slug}")
+        return
+
+    try:
+        qualities = json.loads(stream["qualities"])
+    except json.JSONDecodeError:
+        logger.warning(f"Invalid qualities JSON for stream {slug}")
+        return
+
+    if not qualities:
+        return
+
+    content = generate_master_playlist(qualities, slug)
+    dest_path = LIVE_STORAGE_PATH / slug / "master.m3u8"
+
+    await write_playlist_atomic(dest_path, content)
+    logger.debug(f"Updated master playlist for {slug} with qualities: {qualities}")
+
+
+async def update_variant_playlist(
+    stream_id: int,
+    slug: str,
+    quality: str,
+    dvr_window_seconds: int,
+) -> None:
+    """
+    Update variant playlist for a specific quality.
+
+    Should be called after each segment upload.
+
+    Args:
+        stream_id: Database ID of the stream
+        slug: Stream slug
+        quality: Quality name (e.g., "720p")
+        dvr_window_seconds: DVR window in seconds (0 = unlimited)
+    """
+    # Calculate DVR window cutoff
+    now = datetime.now(timezone.utc)
+    cutoff = None
+    if dvr_window_seconds > 0:
+        cutoff = now.timestamp() - dvr_window_seconds
+
+    # Fetch segments for this quality
+    query = (
+        live_stream_segments.select()
+        .where(live_stream_segments.c.stream_id == stream_id)
+        .where(live_stream_segments.c.quality == quality)
+        .order_by(live_stream_segments.c.sequence_number)
+    )
+
+    segments = await fetch_all_with_retry(query)
+
+    if not segments:
+        logger.debug(f"No segments yet for {slug}/{quality}")
+        return
+
+    # Apply DVR window filter
+    if cutoff:
+        filtered_segments = []
+        for seg in segments:
+            received_at = seg["received_at"]
+            if received_at and received_at.timestamp() >= cutoff:
+                filtered_segments.append(dict(seg))
+        segments = filtered_segments
+    else:
+        segments = [dict(seg) for seg in segments]
+
+    if not segments:
+        return
+
+    # Limit to playlist length
+    if len(segments) > LIVE_HLS_PLAYLIST_LENGTH:
+        segments = segments[-LIVE_HLS_PLAYLIST_LENGTH:]
+
+    # Get media sequence (first segment's sequence number)
+    media_sequence = segments[0]["sequence_number"]
+
+    # Get stream status
+    stream = await fetch_one_with_retry(
+        live_streams.select().where(live_streams.c.id == stream_id)
+    )
+    is_live = stream and stream["status"] in ("live", "ending")
+
+    content = generate_variant_playlist(
+        segments,
+        media_sequence,
+        LIVE_HLS_SEGMENT_DURATION,
+        is_live=is_live,
+    )
+
+    dest_path = LIVE_STORAGE_PATH / slug / quality / "stream.m3u8"
+    await write_playlist_atomic(dest_path, content)
+    logger.debug(f"Updated variant playlist for {slug}/{quality} with {len(segments)} segments")
+
+
+async def update_all_playlists_for_stream(stream_id: int) -> None:
+    """
+    Update master and all variant playlists for a stream.
+
+    Useful when stream status changes or for periodic refresh.
+    """
+    stream = await fetch_one_with_retry(
+        live_streams.select().where(live_streams.c.id == stream_id)
+    )
+
+    if not stream:
+        return
+
+    slug = stream["slug"]
+    dvr_window = stream["dvr_window_seconds"]
+
+    # Update master playlist
+    await update_master_playlist(stream_id, slug)
+
+    # Get qualities
+    if not stream["qualities"]:
+        return
+
+    try:
+        qualities = json.loads(stream["qualities"])
+    except json.JSONDecodeError:
+        return
+
+    # Update each variant playlist
+    for quality in qualities:
+        await update_variant_playlist(stream_id, slug, quality, dvr_window)
+
+
+async def finalize_playlists_for_vod(stream_id: int) -> None:
+    """
+    Finalize playlists for VOD by adding #EXT-X-ENDLIST.
+
+    Called when stream ends and VOD recording is triggered.
+    """
+    stream = await fetch_one_with_retry(
+        live_streams.select().where(live_streams.c.id == stream_id)
+    )
+
+    if not stream:
+        return
+
+    slug = stream["slug"]
+
+    if not stream["qualities"]:
+        return
+
+    try:
+        qualities = json.loads(stream["qualities"])
+    except json.JSONDecodeError:
+        return
+
+    # Update each variant playlist with is_live=False
+    for quality in qualities:
+        # Fetch ALL segments for VOD (no DVR window)
+        segments = await fetch_all_with_retry(
+            live_stream_segments.select()
+            .where(live_stream_segments.c.stream_id == stream_id)
+            .where(live_stream_segments.c.quality == quality)
+            .order_by(live_stream_segments.c.sequence_number)
+        )
+
+        if not segments:
+            continue
+
+        segments = [dict(seg) for seg in segments]
+        media_sequence = segments[0]["sequence_number"]
+
+        content = generate_variant_playlist(
+            segments,
+            media_sequence,
+            LIVE_HLS_SEGMENT_DURATION,
+            is_live=False,  # VOD mode
+        )
+
+        dest_path = LIVE_STORAGE_PATH / slug / quality / "stream.m3u8"
+        await write_playlist_atomic(dest_path, content)
+
+    logger.info(f"Finalized VOD playlists for stream {slug}")
+
+
+async def get_playlist_segments(
+    stream_id: int,
+    quality: str,
+) -> Tuple[List[dict], int]:
+    """
+    Get segments for playlist generation.
+
+    Returns:
+        Tuple of (segments list, media sequence number)
+    """
+    segments = await fetch_all_with_retry(
+        live_stream_segments.select()
+        .where(live_stream_segments.c.stream_id == stream_id)
+        .where(live_stream_segments.c.quality == quality)
+        .order_by(live_stream_segments.c.sequence_number)
+    )
+
+    if not segments:
+        return [], 0
+
+    segments = [dict(seg) for seg in segments]
+    media_sequence = segments[0]["sequence_number"] if segments else 0
+
+    return segments, media_sequence

--- a/api/live_playlist.py
+++ b/api/live_playlist.py
@@ -17,11 +17,9 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
-import sqlalchemy as sa
-
-from api.database import database, live_stream_segments, live_streams
+from api.database import live_stream_segments, live_streams
 from api.db_retry import fetch_all_with_retry, fetch_one_with_retry
 from config import (
     LIVE_HLS_PLAYLIST_LENGTH,
@@ -263,8 +261,9 @@ async def update_variant_playlist(
     if not segments:
         return
 
-    # Limit to playlist length
-    if len(segments) > LIVE_HLS_PLAYLIST_LENGTH:
+    # Limit to playlist length only when no explicit DVR cutoff is used.
+    # When cutoff is set, the DVR time window already constrains the playlist size.
+    if not cutoff and len(segments) > LIVE_HLS_PLAYLIST_LENGTH:
         segments = segments[-LIVE_HLS_PLAYLIST_LENGTH:]
 
     # Get media sequence (first segment's sequence number)

--- a/api/live_schemas.py
+++ b/api/live_schemas.py
@@ -1,0 +1,166 @@
+"""Pydantic schemas for live streaming API.
+
+Defines request/response models for:
+- Admin API: Create, update, list streams
+- Ingest API: Segment upload status
+- Public API: Stream info for viewers
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LiveStreamStatus(str, Enum):
+    """Live stream status values."""
+
+    IDLE = "idle"
+    LIVE = "live"
+    ENDING = "ending"
+    ENDED = "ended"
+
+
+# =============================================================================
+# Admin API Schemas
+# =============================================================================
+
+
+class LiveStreamCreate(BaseModel):
+    """Request to create a new live stream."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    description: str = Field(default="", max_length=5000)
+    category_id: Optional[int] = None
+    dvr_enabled: bool = Field(default=True)
+    dvr_window_seconds: int = Field(default=7200, ge=60, le=86400)  # 1 min to 24 hours
+    auto_record_vod: bool = Field(default=True)
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Title cannot be empty or whitespace")
+        return v
+
+
+class LiveStreamUpdate(BaseModel):
+    """Request to update a live stream."""
+
+    title: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=5000)
+    category_id: Optional[int] = None
+    dvr_enabled: Optional[bool] = None
+    dvr_window_seconds: Optional[int] = Field(None, ge=60, le=86400)
+    auto_record_vod: Optional[bool] = None
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            v = v.strip()
+            if not v:
+                raise ValueError("Title cannot be empty or whitespace")
+        return v
+
+
+class LiveStreamCreatedResponse(BaseModel):
+    """Response after creating a live stream. Includes the stream key (shown once)."""
+
+    id: int
+    title: str
+    slug: str
+    description: str
+    status: LiveStreamStatus
+    stream_key: str  # Only shown once at creation
+    category_id: Optional[int] = None
+    dvr_enabled: bool
+    dvr_window_seconds: int
+    auto_record_vod: bool
+    created_at: datetime
+
+
+class LiveStreamResponse(BaseModel):
+    """Response for a live stream (without stream key)."""
+
+    id: int
+    title: str
+    slug: str
+    description: str
+    status: LiveStreamStatus
+    qualities: Optional[List[str]] = None
+    category_id: Optional[int] = None
+    dvr_enabled: bool
+    dvr_window_seconds: int
+    auto_record_vod: bool
+    segment_count: int
+    vod_video_id: Optional[int] = None
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    last_segment_at: Optional[datetime] = None
+
+
+class LiveStreamListResponse(BaseModel):
+    """Response for listing live streams."""
+
+    streams: List[LiveStreamResponse]
+    total: int
+
+
+class LiveStreamKeyRegenerateResponse(BaseModel):
+    """Response after regenerating a stream key."""
+
+    stream_key: str  # New key, shown once
+
+
+# =============================================================================
+# Ingest API Schemas
+# =============================================================================
+
+
+class IngestStatusResponse(BaseModel):
+    """Response for ingest status endpoint."""
+
+    stream_id: int
+    slug: str
+    status: LiveStreamStatus
+    segment_count: int
+    qualities: List[str]
+    last_segment_at: Optional[datetime] = None
+
+
+class SegmentUploadResponse(BaseModel):
+    """Response after successful segment upload."""
+
+    received: bool = True
+    sequence_number: int
+    quality: str
+
+
+# =============================================================================
+# Public API Schemas
+# =============================================================================
+
+
+class PublicLiveStreamResponse(BaseModel):
+    """Public-facing stream info for viewers."""
+
+    title: str
+    slug: str
+    description: str
+    status: LiveStreamStatus
+    qualities: List[str]
+    category_id: Optional[int] = None
+    started_at: Optional[datetime] = None
+    dvr_enabled: bool
+    dvr_window_seconds: int
+
+
+class PublicLiveStreamListResponse(BaseModel):
+    """List of live streams for public viewing."""
+
+    streams: List[PublicLiveStreamResponse]
+    total: int

--- a/api/live_tasks.py
+++ b/api/live_tasks.py
@@ -7,18 +7,16 @@ Handles:
 """
 
 import asyncio
-import json
 import logging
-import os
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Optional
 
 import sqlalchemy as sa
 
-from api.database import database, live_stream_segments, live_streams
-from api.db_retry import db_execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
-from api.live_playlist import finalize_playlists_for_vod, update_all_playlists_for_stream
+from api.database import live_stream_segments, live_streams
+from api.db_retry import db_execute_with_retry, fetch_all_with_retry
+from api.live_playlist import finalize_playlists_for_vod
+from api.live_vod import trigger_vod_recording
 from config import (
     LIVE_DVR_CLEANUP_BATCH_SIZE,
     LIVE_DVR_CLEANUP_INTERVAL,
@@ -169,13 +167,13 @@ async def detect_stale_streams() -> int:
 
         logger.info(f"Stream {stream['slug']} marked as ended (stale timeout)")
 
-        # Finalize playlists for VOD
+        # Finalize playlists and trigger VOD recording
         if stream["auto_record_vod"]:
             try:
                 await finalize_playlists_for_vod(stream["id"])
-                # TODO: Trigger VOD recording
+                await trigger_vod_recording(stream["id"])
             except Exception as e:
-                logger.error(f"Failed to finalize playlists for stream {stream['slug']}: {e}")
+                logger.error(f"Failed to create VOD for stream {stream['slug']}: {e}")
 
         transitions += 1
 
@@ -257,6 +255,7 @@ async def stop_live_background_tasks(timeout: float = 10.0):
             try:
                 await task
             except asyncio.CancelledError:
+                # Task cancellation during shutdown is expected; suppress this error
                 pass
 
     _dvr_cleanup_task = None

--- a/api/live_tasks.py
+++ b/api/live_tasks.py
@@ -1,0 +1,274 @@
+"""Background tasks for live streaming.
+
+Handles:
+- DVR window cleanup: Delete old segments beyond DVR window
+- Stale stream detection: Mark streams as ending/ended when no segments received
+- Playlist updates: Periodic refresh of HLS playlists
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import sqlalchemy as sa
+
+from api.database import database, live_stream_segments, live_streams
+from api.db_retry import db_execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
+from api.live_playlist import finalize_playlists_for_vod, update_all_playlists_for_stream
+from config import (
+    LIVE_DVR_CLEANUP_BATCH_SIZE,
+    LIVE_DVR_CLEANUP_INTERVAL,
+    LIVE_STALE_GRACE_MULTIPLIER,
+    LIVE_STALE_THRESHOLD,
+    LIVE_STORAGE_PATH,
+)
+
+logger = logging.getLogger(__name__)
+
+# Background task handles
+_dvr_cleanup_task: Optional[asyncio.Task] = None
+_stale_detection_task: Optional[asyncio.Task] = None
+_running = False
+
+# Prometheus-style metrics (counter values)
+_dvr_segments_cleaned = 0
+_stale_streams_detected = 0
+
+
+async def cleanup_dvr_segments() -> int:
+    """
+    Delete segments older than DVR window for all active streams.
+
+    Returns the number of segments deleted.
+    """
+    total_deleted = 0
+    now = datetime.now(timezone.utc)
+
+    # Get all live/ending streams
+    streams = await fetch_all_with_retry(
+        live_streams.select().where(live_streams.c.status.in_(["live", "ending"]))
+    )
+
+    for stream in streams:
+        stream_id = stream["id"]
+        slug = stream["slug"]
+        dvr_window = stream["dvr_window_seconds"]
+
+        if dvr_window <= 0:
+            # DVR disabled or unlimited
+            continue
+
+        cutoff = now - timedelta(seconds=dvr_window)
+
+        # Find segments to delete
+        old_segments = await fetch_all_with_retry(
+            live_stream_segments.select()
+            .where(live_stream_segments.c.stream_id == stream_id)
+            .where(live_stream_segments.c.received_at < cutoff)
+            .order_by(live_stream_segments.c.received_at)
+            .limit(LIVE_DVR_CLEANUP_BATCH_SIZE)
+        )
+
+        if not old_segments:
+            continue
+
+        # Delete segments in batch
+        segment_ids = [seg["id"] for seg in old_segments]
+
+        await db_execute_with_retry(
+            live_stream_segments.delete().where(live_stream_segments.c.id.in_(segment_ids))
+        )
+
+        # Delete files asynchronously
+        loop = asyncio.get_event_loop()
+        for seg in old_segments:
+            file_path = LIVE_STORAGE_PATH / slug / seg["quality"] / seg["filename"]
+            try:
+                await loop.run_in_executor(None, lambda p=file_path: p.unlink(missing_ok=True))
+            except Exception as e:
+                logger.debug(f"Failed to delete segment file {file_path}: {e}")
+
+        total_deleted += len(segment_ids)
+        logger.debug(f"Cleaned {len(segment_ids)} DVR segments for stream {slug}")
+
+    return total_deleted
+
+
+async def detect_stale_streams() -> int:
+    """
+    Detect streams that haven't received segments recently.
+
+    Transitions:
+    - live -> ending: No segments for LIVE_STALE_THRESHOLD seconds
+    - ending -> ended: No segments for LIVE_STALE_THRESHOLD * GRACE_MULTIPLIER seconds
+
+    Returns the number of streams that transitioned state.
+    """
+    now = datetime.now(timezone.utc)
+    stale_cutoff = now - timedelta(seconds=LIVE_STALE_THRESHOLD)
+    final_cutoff = now - timedelta(seconds=LIVE_STALE_THRESHOLD * LIVE_STALE_GRACE_MULTIPLIER)
+
+    transitions = 0
+
+    # Check live streams for staleness
+    live_streams_query = await fetch_all_with_retry(
+        live_streams.select()
+        .where(live_streams.c.status == "live")
+        .where(
+            sa.or_(
+                live_streams.c.last_segment_at < stale_cutoff,
+                live_streams.c.last_segment_at.is_(None),
+            )
+        )
+    )
+
+    for stream in live_streams_query:
+        # Check if there's been a recent segment (race condition check)
+        if stream["last_segment_at"] and stream["last_segment_at"] >= stale_cutoff:
+            continue
+
+        # Transition to ending
+        await db_execute_with_retry(
+            live_streams.update()
+            .where(live_streams.c.id == stream["id"])
+            .where(live_streams.c.status == "live")
+            .values(status="ending")
+        )
+
+        logger.info(f"Stream {stream['slug']} marked as ending (no segments received)")
+        transitions += 1
+
+    # Check ending streams for final timeout
+    ending_streams = await fetch_all_with_retry(
+        live_streams.select()
+        .where(live_streams.c.status == "ending")
+        .where(
+            sa.or_(
+                live_streams.c.last_segment_at < final_cutoff,
+                live_streams.c.last_segment_at.is_(None),
+            )
+        )
+    )
+
+    for stream in ending_streams:
+        # Check if there's been a recent segment (grace period)
+        if stream["last_segment_at"] and stream["last_segment_at"] >= final_cutoff:
+            continue
+
+        # Finalize stream
+        await db_execute_with_retry(
+            live_streams.update()
+            .where(live_streams.c.id == stream["id"])
+            .where(live_streams.c.status == "ending")
+            .values(status="ended", ended_at=now)
+        )
+
+        logger.info(f"Stream {stream['slug']} marked as ended (stale timeout)")
+
+        # Finalize playlists for VOD
+        if stream["auto_record_vod"]:
+            try:
+                await finalize_playlists_for_vod(stream["id"])
+                # TODO: Trigger VOD recording
+            except Exception as e:
+                logger.error(f"Failed to finalize playlists for stream {stream['slug']}: {e}")
+
+        transitions += 1
+
+    return transitions
+
+
+async def _dvr_cleanup_loop():
+    """Background loop for DVR cleanup."""
+    global _dvr_segments_cleaned
+
+    while _running:
+        try:
+            deleted = await cleanup_dvr_segments()
+            if deleted > 0:
+                _dvr_segments_cleaned += deleted
+                logger.debug(f"DVR cleanup: deleted {deleted} segments (total: {_dvr_segments_cleaned})")
+        except Exception as e:
+            logger.error(f"DVR cleanup error: {e}")
+
+        await asyncio.sleep(LIVE_DVR_CLEANUP_INTERVAL)
+
+
+async def _stale_detection_loop():
+    """Background loop for stale stream detection."""
+    global _stale_streams_detected
+
+    # Run slightly less often than stale threshold
+    check_interval = max(10, LIVE_STALE_THRESHOLD // 2)
+
+    while _running:
+        try:
+            transitions = await detect_stale_streams()
+            if transitions > 0:
+                _stale_streams_detected += transitions
+                logger.debug(f"Stale detection: {transitions} transitions (total: {_stale_streams_detected})")
+        except Exception as e:
+            logger.error(f"Stale detection error: {e}")
+
+        await asyncio.sleep(check_interval)
+
+
+async def start_live_background_tasks():
+    """Start all live streaming background tasks."""
+    global _running, _dvr_cleanup_task, _stale_detection_task
+
+    if _running:
+        logger.warning("Live background tasks already running")
+        return
+
+    _running = True
+
+    _dvr_cleanup_task = asyncio.create_task(_dvr_cleanup_loop())
+    _stale_detection_task = asyncio.create_task(_stale_detection_loop())
+
+    logger.info("Started live streaming background tasks")
+
+
+async def stop_live_background_tasks(timeout: float = 10.0):
+    """Stop all live streaming background tasks gracefully."""
+    global _running, _dvr_cleanup_task, _stale_detection_task
+
+    if not _running:
+        return
+
+    _running = False
+
+    tasks = []
+    if _dvr_cleanup_task:
+        tasks.append(_dvr_cleanup_task)
+    if _stale_detection_task:
+        tasks.append(_stale_detection_task)
+
+    if tasks:
+        # Wait for tasks to complete with timeout
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+
+        for task in pending:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    _dvr_cleanup_task = None
+    _stale_detection_task = None
+
+    logger.info("Stopped live streaming background tasks")
+
+
+def get_live_task_metrics() -> dict:
+    """Get metrics for live streaming background tasks."""
+    return {
+        "dvr_segments_cleaned_total": _dvr_segments_cleaned,
+        "stale_streams_detected_total": _stale_streams_detected,
+        "running": _running,
+    }

--- a/api/live_vod.py
+++ b/api/live_vod.py
@@ -1,0 +1,261 @@
+"""VOD recording from live streams.
+
+When a live stream ends, this module:
+1. Revokes the stream key (prevents new segments)
+2. Creates a video record in the videos table
+3. Hardlinks segments from live/{slug}/ to videos/{video_slug}/
+4. Falls back to copy if hardlinks fail (different filesystems)
+5. Generates static HLS playlists with #EXT-X-ENDLIST
+6. Links the VOD to the stream via vod_video_id
+
+This allows live streams to become permanent VOD recordings seamlessly.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from slugify import slugify
+
+from api.database import database, live_stream_segments, live_streams, video_qualities, videos
+from api.db_retry import db_execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
+from api.live_playlist import QUALITY_BANDWIDTH, generate_master_playlist, generate_variant_playlist
+from config import LIVE_HLS_SEGMENT_DURATION, LIVE_STORAGE_PATH, VIDEOS_DIR
+
+logger = logging.getLogger(__name__)
+
+
+async def create_vod_from_stream(stream_id: int) -> Optional[int]:
+    """
+    Create a VOD recording from a live stream.
+
+    Args:
+        stream_id: The ID of the stream to record
+
+    Returns:
+        The video ID if successful, None otherwise
+    """
+    # Get stream info
+    stream = await fetch_one_with_retry(
+        live_streams.select().where(live_streams.c.id == stream_id)
+    )
+
+    if not stream:
+        logger.error(f"Stream {stream_id} not found for VOD recording")
+        return None
+
+    if stream["status"] != "ended":
+        logger.warning(f"Stream {stream_id} is not ended, cannot create VOD")
+        return None
+
+    if stream["vod_video_id"]:
+        logger.warning(f"Stream {stream_id} already has VOD video {stream['vod_video_id']}")
+        return stream["vod_video_id"]
+
+    slug = stream["slug"]
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+
+    # Generate video slug with timestamp
+    video_slug = f"{slug}-{timestamp}"
+
+    logger.info(f"Creating VOD recording for stream {slug} -> {video_slug}")
+
+    # Get qualities from stream
+    qualities = []
+    if stream["qualities"]:
+        try:
+            qualities = json.loads(stream["qualities"])
+        except json.JSONDecodeError:
+            pass
+
+    if not qualities:
+        logger.warning(f"No qualities found for stream {slug}")
+        return None
+
+    # Calculate total duration from segments
+    total_duration = 0.0
+    for quality in qualities:
+        segments = await fetch_all_with_retry(
+            live_stream_segments.select()
+            .where(live_stream_segments.c.stream_id == stream_id)
+            .where(live_stream_segments.c.quality == quality)
+        )
+        for seg in segments:
+            duration_ms = seg["duration_ms"] or (LIVE_HLS_SEGMENT_DURATION * 1000)
+            total_duration = max(total_duration, duration_ms / 1000.0 * seg["sequence_number"])
+
+    # Get resolution from first quality
+    primary_quality = qualities[0] if qualities else "720p"
+    resolution_map = {
+        "2160p": (3840, 2160),
+        "1440p": (2560, 1440),
+        "1080p": (1920, 1080),
+        "720p": (1280, 720),
+        "480p": (854, 480),
+        "360p": (640, 360),
+    }
+    width, height = resolution_map.get(primary_quality, (1280, 720))
+
+    # Create video record
+    try:
+        video_id = await db_execute_with_retry(
+            videos.insert().values(
+                title=stream["title"],
+                slug=video_slug,
+                description=stream["description"] or "",
+                category_id=stream["category_id"],
+                duration=total_duration,
+                source_width=width,
+                source_height=height,
+                status="ready",  # Already transcoded
+                created_at=stream["started_at"] or now,
+                published_at=now,
+                streaming_format="cmaf",  # Live uses CMAF
+                primary_codec="h264",
+            )
+        )
+    except Exception as e:
+        logger.error(f"Failed to create video record for stream {slug}: {e}")
+        return None
+
+    # Create video quality records
+    for quality in qualities:
+        res = resolution_map.get(quality, (1280, 720))
+        bitrate = QUALITY_BANDWIDTH.get(quality, 2500000) // 1000  # Convert to kbps
+        try:
+            await db_execute_with_retry(
+                video_qualities.insert().values(
+                    video_id=video_id,
+                    quality=quality,
+                    width=res[0],
+                    height=res[1],
+                    bitrate=bitrate,
+                )
+            )
+        except Exception as e:
+            logger.warning(f"Failed to create quality record for {quality}: {e}")
+
+    # Create video directory
+    video_dir = VIDEOS_DIR / video_slug
+    video_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy/hardlink segments for each quality
+    loop = asyncio.get_event_loop()
+    for quality in qualities:
+        src_dir = LIVE_STORAGE_PATH / slug / quality
+        dst_dir = video_dir / quality
+        dst_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy init segment
+        src_init = src_dir / "init.mp4"
+        dst_init = dst_dir / "init.mp4"
+        if src_init.exists():
+            try:
+                await loop.run_in_executor(
+                    None,
+                    lambda s=src_init, d=dst_init: _hardlink_or_copy(s, d),
+                )
+            except Exception as e:
+                logger.warning(f"Failed to copy init segment: {e}")
+
+        # Get segments for this quality
+        segments = await fetch_all_with_retry(
+            live_stream_segments.select()
+            .where(live_stream_segments.c.stream_id == stream_id)
+            .where(live_stream_segments.c.quality == quality)
+            .order_by(live_stream_segments.c.sequence_number)
+        )
+
+        # Copy each segment
+        for seg in segments:
+            src_seg = src_dir / seg["filename"]
+            dst_seg = dst_dir / seg["filename"]
+            if src_seg.exists():
+                try:
+                    await loop.run_in_executor(
+                        None,
+                        lambda s=src_seg, d=dst_seg: _hardlink_or_copy(s, d),
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to copy segment {seg['filename']}: {e}")
+
+        # Generate static VOD playlist
+        segments_list = [dict(seg) for seg in segments]
+        if segments_list:
+            playlist_content = generate_variant_playlist(
+                segments_list,
+                segments_list[0]["sequence_number"],
+                LIVE_HLS_SEGMENT_DURATION,
+                is_live=False,  # VOD mode
+            )
+            playlist_path = dst_dir / "stream.m3u8"
+            await loop.run_in_executor(
+                None,
+                lambda p=playlist_path, c=playlist_content: p.write_text(c),
+            )
+
+    # Generate master playlist
+    master_content = generate_master_playlist(qualities, video_slug)
+    master_path = video_dir / "master.m3u8"
+    await loop.run_in_executor(
+        None,
+        lambda p=master_path, c=master_content: p.write_text(c),
+    )
+
+    # Copy thumbnail if exists
+    thumb_src = LIVE_STORAGE_PATH / slug / "thumbnail.jpg"
+    thumb_dst = video_dir / "thumbnail.jpg"
+    if thumb_src.exists():
+        try:
+            await loop.run_in_executor(
+                None,
+                lambda s=thumb_src, d=thumb_dst: shutil.copy2(str(s), str(d)),
+            )
+        except Exception as e:
+            logger.debug(f"No thumbnail to copy: {e}")
+
+    # Update stream with VOD video ID
+    await db_execute_with_retry(
+        live_streams.update()
+        .where(live_streams.c.id == stream_id)
+        .values(vod_video_id=video_id)
+    )
+
+    logger.info(f"Created VOD video {video_id} ({video_slug}) from stream {slug}")
+    return video_id
+
+
+def _hardlink_or_copy(src: Path, dst: Path) -> None:
+    """
+    Try to hardlink src to dst, fall back to copy if that fails.
+
+    Hardlinks are preferred because they don't use additional disk space.
+    Falls back to copy for cross-filesystem operations.
+    """
+    try:
+        # Try hardlink first (fast, no space used)
+        os.link(str(src), str(dst))
+    except OSError:
+        # Fall back to copy (works across filesystems)
+        shutil.copy2(str(src), str(dst))
+
+
+async def trigger_vod_recording(stream_id: int) -> Optional[int]:
+    """
+    Trigger VOD recording for a stream.
+
+    This is a wrapper that can be called from the end stream endpoint.
+
+    Returns the video ID if successful, None otherwise.
+    """
+    try:
+        return await create_vod_from_stream(stream_id)
+    except Exception as e:
+        logger.error(f"VOD recording failed for stream {stream_id}: {e}")
+        return None

--- a/api/live_vod.py
+++ b/api/live_vod.py
@@ -12,6 +12,7 @@ This allows live streams to become permanent VOD recordings seamlessly.
 """
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -20,9 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from slugify import slugify
-
-from api.database import database, live_stream_segments, live_streams, video_qualities, videos
+from api.database import live_stream_segments, live_streams, video_qualities, videos
 from api.db_retry import db_execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
 from api.live_playlist import QUALITY_BANDWIDTH, generate_master_playlist, generate_variant_playlist
 from config import LIVE_HLS_SEGMENT_DURATION, LIVE_STORAGE_PATH, VIDEOS_DIR
@@ -72,23 +71,26 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
         try:
             qualities = json.loads(stream["qualities"])
         except json.JSONDecodeError:
-            pass
+            # Invalid qualities JSON; treat as empty and return None
+            logger.warning(f"Failed to decode qualities JSON for stream {slug}")
+            qualities = []
 
     if not qualities:
         logger.warning(f"No qualities found for stream {slug}")
         return None
 
-    # Calculate total duration from segments
+    # Calculate total duration by summing segment durations from the first quality
+    # (all qualities should have the same duration)
     total_duration = 0.0
-    for quality in qualities:
+    if qualities:
         segments = await fetch_all_with_retry(
             live_stream_segments.select()
             .where(live_stream_segments.c.stream_id == stream_id)
-            .where(live_stream_segments.c.quality == quality)
+            .where(live_stream_segments.c.quality == qualities[0])
         )
         for seg in segments:
             duration_ms = seg["duration_ms"] or (LIVE_HLS_SEGMENT_DURATION * 1000)
-            total_duration = max(total_duration, duration_ms / 1000.0 * seg["sequence_number"])
+            total_duration += duration_ms / 1000.0
 
     # Get resolution from first quality
     primary_quality = qualities[0] if qualities else "720p"
@@ -159,7 +161,7 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
             try:
                 await loop.run_in_executor(
                     None,
-                    lambda s=src_init, d=dst_init: _hardlink_or_copy(s, d),
+                    functools.partial(_hardlink_or_copy, src_init, dst_init),
                 )
             except Exception as e:
                 logger.warning(f"Failed to copy init segment: {e}")
@@ -180,7 +182,7 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
                 try:
                     await loop.run_in_executor(
                         None,
-                        lambda s=src_seg, d=dst_seg: _hardlink_or_copy(s, d),
+                        functools.partial(_hardlink_or_copy, src_seg, dst_seg),
                     )
                 except Exception as e:
                     logger.warning(f"Failed to copy segment {seg['filename']}: {e}")
@@ -197,7 +199,7 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
             playlist_path = dst_dir / "stream.m3u8"
             await loop.run_in_executor(
                 None,
-                lambda p=playlist_path, c=playlist_content: p.write_text(c),
+                functools.partial(playlist_path.write_text, playlist_content),
             )
 
     # Generate master playlist
@@ -205,7 +207,7 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
     master_path = video_dir / "master.m3u8"
     await loop.run_in_executor(
         None,
-        lambda p=master_path, c=master_content: p.write_text(c),
+        functools.partial(master_path.write_text, master_content),
     )
 
     # Copy thumbnail if exists
@@ -215,7 +217,7 @@ async def create_vod_from_stream(stream_id: int) -> Optional[int]:
         try:
             await loop.run_in_executor(
                 None,
-                lambda s=thumb_src, d=thumb_dst: shutil.copy2(str(s), str(d)),
+                functools.partial(shutil.copy2, str(thumb_src), str(thumb_dst)),
             )
         except Exception as e:
             logger.debug(f"No thumbnail to copy: {e}")

--- a/api/public.py
+++ b/api/public.py
@@ -42,6 +42,8 @@ from api.database import (
     configure_database,
     custom_field_definitions,
     database,
+    live_stream_segments,
+    live_streams,
     playback_sessions,
     playlists,
     quality_progress,
@@ -99,6 +101,8 @@ from config import (
     AUTOPLAY_ENABLED,
     UPNEXT_ENABLED,
     AUTOPLAY_COUNTDOWN_SECONDS,
+    LIVE_ENABLED,
+    LIVE_STORAGE_PATH,
     NAS_STORAGE,
     OPENAPI_DESCRIPTION,
     OPENAPI_TITLE,
@@ -123,6 +127,10 @@ from config import (
     WATERMARK_TEXT_COLOR,
     WATERMARK_TEXT_SIZE,
     WATERMARK_TYPE,
+)
+from api.live_schemas import (
+    PublicLiveStreamListResponse,
+    PublicLiveStreamResponse,
 )
 from api.versioning import VersionHeaderMiddleware, configure_openapi_schema
 
@@ -312,7 +320,24 @@ async def lifespan(app: FastAPI):
         )
     await database.connect()
     await configure_database()
+
+    # Start live streaming background tasks
+    if LIVE_ENABLED:
+        from api.live_tasks import start_live_background_tasks
+        await start_live_background_tasks()
+        logger.info("Started live streaming background tasks")
+
     yield
+
+    # Stop live streaming background tasks
+    if LIVE_ENABLED:
+        from api.live_tasks import stop_live_background_tasks
+        from api.live_ingest import stop_accepting_uploads, wait_for_active_uploads
+        stop_accepting_uploads()
+        await wait_for_active_uploads(timeout=10.0)
+        await stop_live_background_tasks(timeout=10.0)
+        logger.info("Stopped live streaming background tasks")
+
     await database.disconnect()
 
 
@@ -436,6 +461,21 @@ HLSStaticFiles = StreamingStaticFiles
 # Skip in test mode since CI doesn't have the storage directory
 if not os.environ.get("VLOG_TEST_MODE"):
     app.mount("/videos", HLSStaticFiles(directory=str(VIDEOS_DIR)), name="videos")
+
+# Serve live stream segments and playlists
+if not os.environ.get("VLOG_TEST_MODE") and LIVE_ENABLED:
+    try:
+        LIVE_STORAGE_PATH.mkdir(parents=True, exist_ok=True)
+        app.mount("/live", HLSStaticFiles(directory=str(LIVE_STORAGE_PATH)), name="live")
+        logger.info(f"Mounted live storage at /live from {LIVE_STORAGE_PATH}")
+    except (PermissionError, OSError) as e:
+        logger.warning(f"Could not mount live storage: {e}")
+
+# Mount live ingest API (for segment push from FFmpeg)
+if LIVE_ENABLED:
+    from api.live_ingest import router as live_ingest_router
+    app.include_router(live_ingest_router)
+    logger.info("Mounted live ingest API at /api/live/ingest")
 
 # Serve static web files
 WEB_DIR = Path(__file__).parent.parent / "web" / "public"
@@ -2153,6 +2193,91 @@ async def get_public_playlist_videos(request: Request, slug: str) -> List[Playli
         )
         for row in rows
     ]
+
+
+# ============================================================================
+# Live Streaming Public API
+# ============================================================================
+
+
+def _parse_qualities_json(qualities_str: Optional[str]) -> List[str]:
+    """Parse qualities JSON string to list."""
+    if not qualities_str:
+        return []
+    try:
+        return json.loads(qualities_str)
+    except json.JSONDecodeError:
+        return []
+
+
+@v1_router.get("/live/streams", summary="List live streams", description="Get all public live streams.")
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def list_public_live_streams(request: Request) -> PublicLiveStreamListResponse:
+    """
+    List live streams that are currently live or recently ended.
+
+    Only returns streams with status 'live' or 'ending'.
+    """
+    if not LIVE_ENABLED:
+        return PublicLiveStreamListResponse(streams=[], total=0)
+
+    rows = await fetch_all_with_retry(
+        live_streams.select()
+        .where(live_streams.c.status.in_(["live", "ending"]))
+        .order_by(live_streams.c.started_at.desc())
+    )
+
+    streams = []
+    for row in rows:
+        streams.append(
+            PublicLiveStreamResponse(
+                title=row["title"],
+                slug=row["slug"],
+                description=row["description"] or "",
+                status=row["status"],
+                qualities=_parse_qualities_json(row["qualities"]),
+                category_id=row["category_id"],
+                started_at=row["started_at"],
+                dvr_enabled=row["dvr_enabled"],
+                dvr_window_seconds=row["dvr_window_seconds"],
+            )
+        )
+
+    return PublicLiveStreamListResponse(streams=streams, total=len(streams))
+
+
+@v1_router.get("/live/streams/{slug}", summary="Get live stream", description="Get information about a live stream.")
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def get_public_live_stream(request: Request, slug: str) -> PublicLiveStreamResponse:
+    """
+    Get public information about a live stream.
+
+    Returns stream info if it exists and is live or ending.
+    Returns 404 if stream doesn't exist or is not active.
+    """
+    if not LIVE_ENABLED:
+        raise HTTPException(status_code=503, detail="Live streaming is disabled")
+
+    row = await fetch_one_with_retry(
+        live_streams.select()
+        .where(live_streams.c.slug == slug)
+        .where(live_streams.c.status.in_(["live", "ending"]))
+    )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Live stream not found")
+
+    return PublicLiveStreamResponse(
+        title=row["title"],
+        slug=row["slug"],
+        description=row["description"] or "",
+        status=row["status"],
+        qualities=_parse_qualities_json(row["qualities"]),
+        category_id=row["category_id"],
+        started_at=row["started_at"],
+        dvr_enabled=row["dvr_enabled"],
+        dvr_window_seconds=row["dvr_window_seconds"],
+    )
 
 
 # ============================================================================

--- a/config.py
+++ b/config.py
@@ -427,6 +427,12 @@ RATE_LIMIT_WORKER_DEFAULT = os.getenv("VLOG_RATE_LIMIT_WORKER_DEFAULT", "300/min
 RATE_LIMIT_WORKER_REGISTER = os.getenv("VLOG_RATE_LIMIT_WORKER_REGISTER", "5/hour")
 RATE_LIMIT_WORKER_PROGRESS = os.getenv("VLOG_RATE_LIMIT_WORKER_PROGRESS", "600/minute")
 
+# Live ingest API limits (per stream key, not per IP since authenticated)
+# 300 segments/minute is ~5 segments/second which covers 4-second segments with margin
+RATE_LIMIT_LIVE_SEGMENT = os.getenv("VLOG_RATE_LIMIT_LIVE_SEGMENT", "300/minute")
+# Global per-IP limit to prevent flood attacks via multiple stream keys
+RATE_LIMIT_LIVE_GLOBAL = os.getenv("VLOG_RATE_LIMIT_LIVE_GLOBAL", "1000/minute")
+
 # Storage backend for rate limiting
 # Options: "memory" (per-process), or a Redis URL like "redis://localhost:6379"
 # SECURITY: In-memory rate limiting doesn't work with multiple API instances.
@@ -665,3 +671,59 @@ UPNEXT_ENABLED = os.getenv("VLOG_UPNEXT_ENABLED", "true").lower() in ("true", "1
 
 # Countdown duration in seconds before autoplay starts (5-30)
 AUTOPLAY_COUNTDOWN_SECONDS = get_int_env("VLOG_AUTOPLAY_COUNTDOWN_SECONDS", 10, min_val=5, max_val=30)
+
+# =============================================================================
+# Live Streaming Configuration
+# HTTP segment push for live streaming without RTMP/SRT servers
+# =============================================================================
+
+# Master switch for live streaming feature
+LIVE_ENABLED = os.getenv("VLOG_LIVE_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Storage path for live stream segments
+LIVE_STORAGE_PATH = NAS_STORAGE / os.getenv("VLOG_LIVE_SUBDIR", "live")
+
+# Default DVR window in seconds (2 hours)
+LIVE_DEFAULT_DVR_WINDOW = get_int_env("VLOG_LIVE_DEFAULT_DVR_WINDOW", 7200, min_val=60, max_val=86400)
+
+# Stale stream detection threshold in seconds
+# If no segment received within this period, stream enters "ending" state
+LIVE_STALE_THRESHOLD = get_int_env("VLOG_LIVE_STALE_THRESHOLD", 60, min_val=10, max_val=300)
+
+# Grace period multiplier for stale detection
+# Stream finalizes to "ended" after stale_threshold * this multiplier
+LIVE_STALE_GRACE_MULTIPLIER = 2
+
+# Maximum segment size (50MB - generous for high bitrate 4K)
+LIVE_MAX_SEGMENT_SIZE = get_int_env("VLOG_LIVE_MAX_SEGMENT_SIZE", 50 * 1024 * 1024, min_val=1024 * 1024)
+
+# Rate limiting: segments per minute per stream
+LIVE_SEGMENT_RATE_LIMIT = get_int_env("VLOG_LIVE_SEGMENT_RATE_LIMIT", 300, min_val=10)
+
+# Global rate limit: segments per minute per source IP
+LIVE_GLOBAL_SEGMENT_RATE_LIMIT = get_int_env("VLOG_LIVE_GLOBAL_SEGMENT_RATE_LIMIT", 1000, min_val=100)
+
+# Maximum concurrent live streams
+LIVE_MAX_CONCURRENT_STREAMS = get_int_env("VLOG_LIVE_MAX_CONCURRENT_STREAMS", 10, min_val=1)
+
+# DVR cleanup interval in seconds
+LIVE_DVR_CLEANUP_INTERVAL = get_int_env("VLOG_LIVE_DVR_CLEANUP_INTERVAL", 30, min_val=10, max_val=300)
+
+# Batch size for DVR cleanup DELETEs (reduces lock contention)
+LIVE_DVR_CLEANUP_BATCH_SIZE = get_int_env("VLOG_LIVE_DVR_CLEANUP_BATCH_SIZE", 10, min_val=1, max_val=100)
+
+# HLS segment duration for live streams (must match FFmpeg -hls_time)
+LIVE_HLS_SEGMENT_DURATION = get_int_env("VLOG_LIVE_HLS_SEGMENT_DURATION", 4, min_val=1, max_val=10)
+
+# Number of segments to include in live playlist (sliding window)
+LIVE_HLS_PLAYLIST_LENGTH = get_int_env("VLOG_LIVE_HLS_PLAYLIST_LENGTH", 5, min_val=3, max_val=30)
+
+# Allowed quality names for live streams
+LIVE_ALLOWED_QUALITIES = frozenset({"2160p", "1440p", "1080p", "720p", "480p", "360p"})
+
+# Ensure live storage directory exists (skip in test/CI environments)
+if not os.environ.get("VLOG_TEST_MODE"):
+    try:
+        LIVE_STORAGE_PATH.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        pass  # CI environment without NAS access

--- a/migrations/versions/028_add_live_streams.py
+++ b/migrations/versions/028_add_live_streams.py
@@ -1,0 +1,130 @@
+"""add_live_streams
+
+Revision ID: 028
+Revises: 027
+Create Date: 2025-01-18
+
+Adds live streaming via HTTP segment push:
+- live_streams: Stream configuration and status
+- live_stream_segments: Segment tracking for DVR and VOD
+
+Implements GitHub issue #XXX (Live Streaming).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "028"
+down_revision: Union[str, Sequence[str], None] = "027"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create live_streams and live_stream_segments tables."""
+    # Create live_streams table
+    op.create_table(
+        "live_streams",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(255), unique=True, nullable=False),
+        sa.Column("description", sa.Text, default="", nullable=False),
+        # Auth (argon2id hashed like worker API keys)
+        sa.Column("stream_key_hash", sa.Text, nullable=False),
+        sa.Column("stream_key_prefix", sa.String(8), nullable=False),
+        sa.Column("hash_version", sa.Integer, default=2, nullable=False),
+        # Status
+        sa.Column(
+            "status",
+            sa.String(20),
+            sa.CheckConstraint(
+                "status IN ('idle', 'live', 'ending', 'ended')",
+                name="ck_live_streams_status",
+            ),
+            default="idle",
+            nullable=False,
+        ),
+        sa.Column("qualities", sa.Text, nullable=True),  # JSON: ["720p", "480p"]
+        # Timestamps
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_segment_at", sa.DateTime(timezone=True), nullable=True),
+        # Metrics
+        sa.Column("segment_count", sa.Integer, default=0, nullable=False),
+        # DVR/VOD
+        sa.Column("dvr_enabled", sa.Boolean, default=True, nullable=False),
+        sa.Column("dvr_window_seconds", sa.Integer, default=7200, nullable=False),
+        sa.Column("auto_record_vod", sa.Boolean, default=True, nullable=False),
+        sa.Column(
+            "vod_video_id",
+            sa.Integer,
+            sa.ForeignKey("videos.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "category_id",
+            sa.Integer,
+            sa.ForeignKey("categories.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_live_streams_slug", "live_streams", ["slug"])
+    op.create_index("ix_live_streams_status", "live_streams", ["status"])
+    op.create_index("ix_live_streams_stream_key_prefix", "live_streams", ["stream_key_prefix"])
+    op.create_index("ix_live_streams_created_at", "live_streams", ["created_at"])
+
+    # Create live_stream_segments table
+    op.create_table(
+        "live_stream_segments",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "stream_id",
+            sa.Integer,
+            sa.ForeignKey("live_streams.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("quality", sa.String(10), nullable=False),
+        sa.Column("filename", sa.String(255), nullable=False),
+        sa.Column("sequence_number", sa.Integer, nullable=False),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("size_bytes", sa.Integer, nullable=False),
+        sa.Column("received_at", sa.DateTime(timezone=True), nullable=False),
+        # Unique constraint prevents duplicate segment uploads
+        sa.UniqueConstraint("stream_id", "quality", "sequence_number", name="uq_live_segment_stream_quality_seq"),
+    )
+    # Critical indexes for performance (from Brendan's review)
+    op.create_index(
+        "ix_live_segments_stream_quality_seq",
+        "live_stream_segments",
+        ["stream_id", "quality", "sequence_number"],
+    )
+    op.create_index(
+        "ix_live_segments_received_at",
+        "live_stream_segments",
+        ["received_at"],
+    )
+    op.create_index(
+        "ix_live_segments_cleanup",
+        "live_stream_segments",
+        ["stream_id", "received_at"],
+    )
+
+
+def downgrade() -> None:
+    """Remove live_streams and live_stream_segments tables."""
+    # Drop live_stream_segments indexes and table
+    op.drop_index("ix_live_segments_cleanup", table_name="live_stream_segments")
+    op.drop_index("ix_live_segments_received_at", table_name="live_stream_segments")
+    op.drop_index("ix_live_segments_stream_quality_seq", table_name="live_stream_segments")
+    op.drop_table("live_stream_segments")
+
+    # Drop live_streams indexes and table
+    op.drop_index("ix_live_streams_created_at", table_name="live_streams")
+    op.drop_index("ix_live_streams_stream_key_prefix", table_name="live_streams")
+    op.drop_index("ix_live_streams_status", table_name="live_streams")
+    op.drop_index("ix_live_streams_slug", table_name="live_streams")
+    op.drop_table("live_streams")

--- a/scripts/vlog-live-push.sh
+++ b/scripts/vlog-live-push.sh
@@ -117,6 +117,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Check if input source exists
+# Use arrays for FFmpeg options to properly handle arguments with spaces
+INPUT_OPTS=()
 if [[ "$INPUT_SOURCE" == /dev/* ]]; then
     if [ ! -e "$INPUT_SOURCE" ]; then
         echo -e "${RED}Error: Video device $INPUT_SOURCE not found${NC}"
@@ -124,13 +126,13 @@ if [[ "$INPUT_SOURCE" == /dev/* ]]; then
         ls -la /dev/video* 2>/dev/null || echo "  (none found)"
         exit 1
     fi
-    INPUT_OPTS="-f v4l2 -framerate 30 -video_size $RESOLUTION -i $INPUT_SOURCE"
+    INPUT_OPTS=(-f v4l2 -framerate 30 -video_size "$RESOLUTION" -i "$INPUT_SOURCE")
     # Add audio input from default device
     if command -v arecord &>/dev/null; then
-        INPUT_OPTS="$INPUT_OPTS -f alsa -i default"
+        INPUT_OPTS+=(-f alsa -i default)
     fi
 elif [ -f "$INPUT_SOURCE" ]; then
-    INPUT_OPTS="-re -i $INPUT_SOURCE"
+    INPUT_OPTS=(-re -i "$INPUT_SOURCE")
 else
     echo -e "${RED}Error: Input source '$INPUT_SOURCE' not found${NC}"
     exit 1
@@ -157,13 +159,13 @@ while true; do
     # Run FFmpeg
     # Using CMAF (fMP4) for better compatibility with HTTP segment push
     ffmpeg \
-        $INPUT_OPTS \
+        "${INPUT_OPTS[@]}" \
         -c:v libx264 \
         -preset fast \
         -tune zerolatency \
         -b:v "$VIDEO_BITRATE" \
         -maxrate "$VIDEO_BITRATE" \
-        -bufsize "$(echo "$VIDEO_BITRATE" | sed 's/k$//')k" \
+        -bufsize "${VIDEO_BITRATE}" \
         -g 60 \
         -keyint_min 60 \
         -sc_threshold 0 \

--- a/scripts/vlog-live-push.sh
+++ b/scripts/vlog-live-push.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+#
+# vlog-live-push.sh - Secure FFmpeg live stream push script
+#
+# Usage:
+#   VLOG_STREAM_KEY=sk_live_xxx ./vlog-live-push.sh <stream-slug> <quality> [input-source]
+#
+# Examples:
+#   # Stream webcam at 720p
+#   VLOG_STREAM_KEY=sk_live_xxx ./vlog-live-push.sh my-stream 720p
+#
+#   # Stream specific video device at 1080p
+#   VLOG_STREAM_KEY=sk_live_xxx ./vlog-live-push.sh my-stream 1080p /dev/video1
+#
+#   # Stream a file as live source (for testing)
+#   VLOG_STREAM_KEY=sk_live_xxx ./vlog-live-push.sh my-stream 720p test.mp4
+#
+# Environment Variables:
+#   VLOG_STREAM_KEY   - Required. The stream key from vlog admin API
+#   VLOG_API_URL      - Optional. API URL (default: http://localhost:9000)
+#   VLOG_SEGMENT_TIME - Optional. Segment duration in seconds (default: 4)
+#
+# Security Notes:
+#   - Stream key is read from environment variable (not visible in `ps aux`)
+#   - Auth header is written to a temp file with chmod 600
+#   - Temp file is cleaned up on exit
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check required arguments
+if [ $# -lt 2 ]; then
+    echo -e "${RED}Usage: VLOG_STREAM_KEY=xxx $0 <stream-slug> <quality> [input-source]${NC}"
+    echo ""
+    echo "Arguments:"
+    echo "  stream-slug  - The stream slug (from admin API)"
+    echo "  quality      - Quality preset: 2160p, 1440p, 1080p, 720p, 480p, 360p"
+    echo "  input-source - Optional: video device or file (default: /dev/video0)"
+    echo ""
+    echo "Environment:"
+    echo "  VLOG_STREAM_KEY   - Required: Stream key from admin API"
+    echo "  VLOG_API_URL      - Optional: API URL (default: http://localhost:9000)"
+    echo "  VLOG_SEGMENT_TIME - Optional: Segment duration (default: 4)"
+    exit 1
+fi
+
+STREAM_SLUG="$1"
+QUALITY="$2"
+INPUT_SOURCE="${3:-/dev/video0}"
+
+# Validate stream key
+if [ -z "$VLOG_STREAM_KEY" ]; then
+    echo -e "${RED}Error: VLOG_STREAM_KEY environment variable is required${NC}"
+    echo "Get a stream key from: POST /api/v1/live/streams"
+    exit 1
+fi
+
+# Configuration
+API_URL="${VLOG_API_URL:-http://localhost:9000}"
+SEGMENT_TIME="${VLOG_SEGMENT_TIME:-4}"
+
+# Quality presets (resolution, video bitrate, audio bitrate, preset)
+declare -A QUALITY_RESOLUTION=(
+    ["2160p"]="3840x2160"
+    ["1440p"]="2560x1440"
+    ["1080p"]="1920x1080"
+    ["720p"]="1280x720"
+    ["480p"]="854x480"
+    ["360p"]="640x360"
+)
+
+declare -A QUALITY_VIDEO_BITRATE=(
+    ["2160p"]="15000k"
+    ["1440p"]="8000k"
+    ["1080p"]="5000k"
+    ["720p"]="2500k"
+    ["480p"]="1000k"
+    ["360p"]="600k"
+)
+
+declare -A QUALITY_AUDIO_BITRATE=(
+    ["2160p"]="192k"
+    ["1440p"]="192k"
+    ["1080p"]="128k"
+    ["720p"]="128k"
+    ["480p"]="96k"
+    ["360p"]="96k"
+)
+
+# Validate quality
+if [ -z "${QUALITY_RESOLUTION[$QUALITY]}" ]; then
+    echo -e "${RED}Error: Invalid quality '$QUALITY'${NC}"
+    echo "Valid qualities: 2160p, 1440p, 1080p, 720p, 480p, 360p"
+    exit 1
+fi
+
+RESOLUTION="${QUALITY_RESOLUTION[$QUALITY]}"
+VIDEO_BITRATE="${QUALITY_VIDEO_BITRATE[$QUALITY]}"
+AUDIO_BITRATE="${QUALITY_AUDIO_BITRATE[$QUALITY]}"
+
+# Create secure temp file for auth header
+HEADER_FILE=$(mktemp)
+chmod 600 "$HEADER_FILE"
+echo "Authorization: Bearer $VLOG_STREAM_KEY" > "$HEADER_FILE"
+
+# Cleanup on exit
+cleanup() {
+    echo -e "\n${YELLOW}Cleaning up...${NC}"
+    rm -f "$HEADER_FILE"
+}
+trap cleanup EXIT INT TERM
+
+# Check if input source exists
+if [[ "$INPUT_SOURCE" == /dev/* ]]; then
+    if [ ! -e "$INPUT_SOURCE" ]; then
+        echo -e "${RED}Error: Video device $INPUT_SOURCE not found${NC}"
+        echo "Available video devices:"
+        ls -la /dev/video* 2>/dev/null || echo "  (none found)"
+        exit 1
+    fi
+    INPUT_OPTS="-f v4l2 -framerate 30 -video_size $RESOLUTION -i $INPUT_SOURCE"
+    # Add audio input from default device
+    if command -v arecord &>/dev/null; then
+        INPUT_OPTS="$INPUT_OPTS -f alsa -i default"
+    fi
+elif [ -f "$INPUT_SOURCE" ]; then
+    INPUT_OPTS="-re -i $INPUT_SOURCE"
+else
+    echo -e "${RED}Error: Input source '$INPUT_SOURCE' not found${NC}"
+    exit 1
+fi
+
+# Build ingest URL
+INGEST_URL="${API_URL}/api/live/ingest/${STREAM_SLUG}/${QUALITY}"
+
+echo -e "${GREEN}Starting live stream...${NC}"
+echo "  Stream: $STREAM_SLUG"
+echo "  Quality: $QUALITY ($RESOLUTION @ $VIDEO_BITRATE)"
+echo "  Input: $INPUT_SOURCE"
+echo "  Target: $INGEST_URL"
+echo ""
+echo -e "${YELLOW}Press Ctrl+C to stop streaming${NC}"
+echo ""
+
+# Retry loop with exponential backoff
+MAX_RETRIES=10
+RETRY_COUNT=0
+RETRY_DELAY=5
+
+while true; do
+    # Run FFmpeg
+    # Using CMAF (fMP4) for better compatibility with HTTP segment push
+    ffmpeg \
+        $INPUT_OPTS \
+        -c:v libx264 \
+        -preset fast \
+        -tune zerolatency \
+        -b:v "$VIDEO_BITRATE" \
+        -maxrate "$VIDEO_BITRATE" \
+        -bufsize "$(echo "$VIDEO_BITRATE" | sed 's/k$//')k" \
+        -g 60 \
+        -keyint_min 60 \
+        -sc_threshold 0 \
+        -c:a aac \
+        -b:a "$AUDIO_BITRATE" \
+        -ar 44100 \
+        -f hls \
+        -hls_time "$SEGMENT_TIME" \
+        -hls_list_size 0 \
+        -hls_segment_type fmp4 \
+        -hls_fmp4_init_filename "init.mp4" \
+        -hls_segment_filename "seg_%04d.m4s" \
+        -method PUT \
+        -headers "@$HEADER_FILE" \
+        -http_persistent 1 \
+        "$INGEST_URL/stream.m3u8" \
+        2>&1 | while read -r line; do
+            # Log FFmpeg output with timestamp
+            echo "[$(date '+%H:%M:%S')] $line"
+        done
+
+    EXIT_CODE=${PIPESTATUS[0]}
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo -e "${GREEN}Stream ended normally${NC}"
+        break
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+        echo -e "${RED}Max retries ($MAX_RETRIES) exceeded, giving up${NC}"
+        exit 1
+    fi
+
+    echo -e "${YELLOW}FFmpeg exited with code $EXIT_CODE, retrying in $RETRY_DELAY seconds (attempt $RETRY_COUNT/$MAX_RETRIES)${NC}"
+    sleep $RETRY_DELAY
+
+    # Exponential backoff (max 60 seconds)
+    RETRY_DELAY=$((RETRY_DELAY * 2))
+    if [ $RETRY_DELAY -gt 60 ]; then
+        RETRY_DELAY=60
+    fi
+done
+
+echo -e "${GREEN}Live stream complete${NC}"


### PR DESCRIPTION
## Summary

- Adds live streaming capability without RTMP/SRT server infrastructure
- FFmpeg clients encode locally into HLS/CMAF segments and push via HTTP PUT
- Segments are stored on disk, playlists generated dynamically
- Streams automatically become VOD recordings when ended

## Features

### Authentication
- Stream keys with argon2id hashing (follows worker_auth.py pattern)
- Prefix-based lookup for efficient authentication
- Security logging for auth events

### Ingest API
- `PUT /api/live/ingest/{slug}/{quality}/init.mp4` - Push init segment
- `PUT /api/live/ingest/{slug}/{quality}/seg_NNNN.m4s` - Push media segment
- `GET /api/live/ingest/{slug}/status` - Get ingest status
- Rate limiting (300/min per stream, 1000/min global per IP)
- Magic byte validation, checksum verification, path containment

### Admin API
- Full CRUD for live streams
- Stream key regeneration
- Manual stream end with VOD trigger

### Public Playback
- HLS playlist serving (master + variant)
- Static file serving for segments
- DVR window support

### Background Tasks
- DVR segment cleanup (configurable window)
- Stale stream detection with grace period
- Automatic status transitions (idle → live → ending → ended)

### VOD Recording
- Automatic recording when stream ends
- Hardlinks segments to videos directory (copy fallback)
- Creates video record with ready status

## Files Changed

| File | Purpose |
|------|---------|
| `api/live_auth.py` | Stream key authentication |
| `api/live_ingest.py` | Segment push endpoints |
| `api/live_playlist.py` | HLS playlist generation |
| `api/live_schemas.py` | Pydantic models |
| `api/live_tasks.py` | Background tasks |
| `api/live_vod.py` | VOD recording |
| `api/admin.py` | Admin endpoints |
| `api/public.py` | Public endpoints |
| `api/database.py` | Table definitions |
| `config.py` | Configuration |
| `migrations/028_*.py` | Database migration |
| `scripts/vlog-live-push.sh` | FFmpeg push script |

## Test plan

- [ ] Create stream via admin API, capture stream_key
- [ ] Run FFmpeg push script with stream_key
- [ ] Verify segments appear in `/mnt/nas/vlog-storage/live/{slug}/`
- [ ] Open `https://vlog/live/{slug}/master.m3u8` in VLC or browser player
- [ ] Verify ~8-12 second latency
- [ ] End stream via API or let it go stale
- [ ] Verify VOD appears in videos list
- [ ] Verify VOD playback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)