### PR TITLE
feat(embed): Add video embed functionality (#210)

### DIFF
--- a/api/common.py
+++ b/api/common.py
@@ -234,8 +234,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
-        # Prevent clickjacking
-        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        # Prevent clickjacking (skip for embed pages - they use CSP frame-ancestors)
+        if not request.url.path.startswith("/embed/"):
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
         # Prevent MIME-type sniffing
         response.headers["X-Content-Type-Options"] = "nosniff"
         # XSS protection for legacy browsers

--- a/api/public.py
+++ b/api/public.py
@@ -390,11 +390,17 @@ def _is_valid_csp_domain(domain: str) -> bool:
     return bool(_CSP_DOMAIN_PATTERN.match(domain_to_check))
 
 
-def get_embed_csp_frame_ancestors() -> str:
+def build_embed_csp_frame_ancestors(embed_settings: Dict[str, Any]) -> str:
     """
     Build the frame-ancestors CSP directive value based on embed settings.
 
+    Uses the DB-backed settings so admin changes apply without restart.
     Security: Validates all domains before including in CSP header.
+
+    Args:
+        embed_settings: Dict from get_embed_settings() with keys:
+            - allow_all_domains: bool
+            - allowed_domains: str (comma-separated)
 
     Returns:
         CSP frame-ancestors value:
@@ -403,11 +409,11 @@ def get_embed_csp_frame_ancestors() -> str:
         - "'self' https://domain1.com ..." for domain whitelist
     """
     # Check for allow all domains first
-    if EMBED_ALLOW_ALL_DOMAINS:
+    if embed_settings.get("allow_all_domains", False):
         return "*"
 
     # Parse allowed domains from configuration
-    allowed = EMBED_ALLOWED_DOMAINS.strip()
+    allowed = embed_settings.get("allowed_domains", "'self'").strip()
 
     # If 'self' only or empty, return self
     if not allowed or allowed == "'self'":
@@ -827,8 +833,8 @@ async def embed_page(request: Request, slug: str):
         logger.warning(f"Embed: Database error for {slug}: {e}")
         return _build_embed_error_response("database_error", slug)
 
-    # Build CSP frame-ancestors directive
-    frame_ancestors = get_embed_csp_frame_ancestors()
+    # Build CSP frame-ancestors directive from DB-backed settings
+    frame_ancestors = build_embed_csp_frame_ancestors(embed_settings)
 
     # Return embed page with CSP header
     return FileResponse(

--- a/api/public.py
+++ b/api/public.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -364,12 +365,42 @@ async def get_embed_settings() -> Dict[str, Any]:
     return _cached_embed_settings
 
 
+# Domain validation pattern for CSP frame-ancestors (Issue #210 security fix)
+_CSP_DOMAIN_PATTERN = re.compile(
+    r'^([a-z]+://)?[a-z0-9]+([\-\.][a-z0-9]+)*\.[a-z]{2,}(:[0-9]{1,5})?$',
+    re.IGNORECASE
+)
+
+
+def _is_valid_csp_domain(domain: str) -> bool:
+    """
+    Validate that a domain is safe for CSP frame-ancestors.
+
+    Args:
+        domain: Domain string to validate (with or without protocol)
+
+    Returns:
+        True if domain is valid, False otherwise
+    """
+    # Remove protocol for validation if present
+    domain_to_check = domain
+    if domain.startswith("http://") or domain.startswith("https://"):
+        domain_to_check = domain.split("://", 1)[1]
+
+    return bool(_CSP_DOMAIN_PATTERN.match(domain_to_check))
+
+
 def get_embed_csp_frame_ancestors() -> str:
     """
     Build the frame-ancestors CSP directive value based on embed settings.
 
+    Security: Validates all domains before including in CSP header.
+
     Returns:
-        CSP frame-ancestors value (e.g., "'self'", "* ", "'self' https://example.com")
+        CSP frame-ancestors value:
+        - "*" if all domains allowed (public mode)
+        - "'self'" if only same-origin allowed (default secure mode)
+        - "'self' https://domain1.com ..." for domain whitelist
     """
     # Check for allow all domains first
     if EMBED_ALLOW_ALL_DOMAINS:
@@ -387,13 +418,32 @@ def get_embed_csp_frame_ancestors() -> str:
     if not domains:
         return "'self'"
 
-    # Include 'self' and add https:// prefix to domains if not present
+    # Include 'self' and validate/normalize each domain
     parts = ["'self'"]
     for domain in domains:
-        if domain.startswith("'") or domain.startswith("http"):
-            parts.append(domain)
+        # Skip 'self' if explicitly listed (already included)
+        if domain == "'self'":
+            continue
+
+        # Validate domain format to prevent CSP injection
+        if domain.startswith("'"):
+            # CSP keywords like 'none' - skip these in domain list
+            logger.warning(f"Skipping CSP keyword in embed domains: {domain}")
+            continue
+        elif domain.startswith("http://") or domain.startswith("https://"):
+            if _is_valid_csp_domain(domain):
+                parts.append(domain)
+            else:
+                logger.warning(f"Invalid CSP domain format skipped: {domain}")
         else:
-            parts.append(f"https://{domain}")
+            if _is_valid_csp_domain(domain):
+                parts.append(f"https://{domain}")
+            else:
+                logger.warning(f"Invalid CSP domain format skipped: {domain}")
+
+    # If all domains were invalid, fall back to self-only
+    if len(parts) == 1:
+        logger.warning("All configured embed domains were invalid, using 'self' only")
 
     return " ".join(parts)
 
@@ -679,6 +729,48 @@ async def tag_page(slug: str):
 # =============================================================================
 
 
+def _is_video_embeddable(video: dict) -> bool:
+    """Check if video meets all requirements for embedding."""
+    return (
+        video["status"] == VideoStatus.READY
+        and video["published_at"] is not None
+        and video["deleted_at"] is None
+    )
+
+
+def _build_embed_error_response(
+    reason: str,
+    slug: str,
+) -> FileResponse:
+    """
+    Build appropriate error response for embed requests.
+
+    Args:
+        reason: Error reason ('disabled', 'invalid_slug', 'not_found', 'not_embeddable', 'database_error')
+        slug: Video slug for logging
+
+    Returns:
+        FileResponse with embed-error.html and appropriate headers
+    """
+    status_codes = {
+        "disabled": 404,
+        "invalid_slug": 400,
+        "not_found": 404,
+        "not_embeddable": 404,
+        "database_error": 503,
+    }
+
+    headers = {"Content-Security-Policy": "frame-ancestors 'none'"}
+    if reason == "database_error":
+        headers["Retry-After"] = "30"
+
+    return FileResponse(
+        WEB_DIR / "embed-error.html",
+        status_code=status_codes.get(reason, 500),
+        headers=headers,
+    )
+
+
 @app.get("/embed/{slug}", response_class=HTMLResponse)
 @limiter.limit(RATE_LIMIT_EMBED)
 async def embed_page(request: Request, slug: str):
@@ -689,6 +781,7 @@ async def embed_page(request: Request, slug: str):
     Sets appropriate CSP frame-ancestors header based on configuration.
 
     Security:
+    - Validates slug format before database query
     - Only serves videos with status='ready' and published_at set
     - CSP frame-ancestors controls which domains can embed
     - Does NOT set X-Frame-Options (CSP takes precedence)
@@ -698,16 +791,16 @@ async def embed_page(request: Request, slug: str):
     - start: Start time in seconds (default: 0)
     - controls: 0 or 1 (default: 1)
     """
+    # Validate slug format (security: prevents log injection, ensures valid input)
+    if not validate_slug(slug):
+        return _build_embed_error_response("invalid_slug", slug)
+
     # Check if embeds are enabled
     embed_settings = await get_embed_settings()
     if not embed_settings["enabled"]:
-        return FileResponse(
-            WEB_DIR / "embed-error.html",
-            status_code=404,
-            headers={"Content-Security-Policy": "frame-ancestors 'none'"},
-        )
+        return _build_embed_error_response("disabled", slug)
 
-    # Validate video exists and is ready/published
+    # Validate video exists and is embeddable
     try:
         query = sa.select(
             videos.c.id,
@@ -721,35 +814,18 @@ async def embed_page(request: Request, slug: str):
 
         if not video:
             logger.debug(f"Embed: Video not found: {slug}")
-            return FileResponse(
-                WEB_DIR / "embed-error.html",
-                status_code=404,
-                headers={"Content-Security-Policy": "frame-ancestors 'none'"},
-            )
+            return _build_embed_error_response("not_found", slug)
 
-        # Video must be ready, published, and not deleted
-        if (
-            video["status"] != VideoStatus.READY
-            or video["published_at"] is None
-            or video["deleted_at"] is not None
-        ):
-            logger.debug(f"Embed: Video not embeddable: {slug} (status={video['status']}, published={video['published_at'] is not None})")
-            return FileResponse(
-                WEB_DIR / "embed-error.html",
-                status_code=404,
-                headers={"Content-Security-Policy": "frame-ancestors 'none'"},
+        if not _is_video_embeddable(video):
+            logger.debug(
+                f"Embed: Video not embeddable: {slug} "
+                f"(status={video['status']}, published={video['published_at'] is not None})"
             )
+            return _build_embed_error_response("not_embeddable", slug)
 
     except Exception as e:
         logger.warning(f"Embed: Database error for {slug}: {e}")
-        return FileResponse(
-            WEB_DIR / "embed-error.html",
-            status_code=503,
-            headers={
-                "Content-Security-Policy": "frame-ancestors 'none'",
-                "Retry-After": "30",
-            },
-        )
+        return _build_embed_error_response("database_error", slug)
 
     # Build CSP frame-ancestors directive
     frame_ancestors = get_embed_csp_frame_ancestors()
@@ -771,11 +847,18 @@ async def get_embed_code(request: Request, slug: str):
 
     Returns the iframe HTML and URL for embedding the video on external sites.
 
+    Security:
+    - Validates slug format before database query
+
     Returns 404 if:
     - Video doesn't exist
     - Video is not ready or not published
     - Embeds are disabled
     """
+    # Validate slug format (security: prevents log injection, ensures valid input)
+    if not validate_slug(slug):
+        raise HTTPException(status_code=400, detail="Invalid video slug")
+
     # Check if embeds are enabled
     embed_settings = await get_embed_settings()
     if not embed_settings["enabled"]:
@@ -795,11 +878,7 @@ async def get_embed_code(request: Request, slug: str):
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    if (
-        video["status"] != VideoStatus.READY
-        or video["published_at"] is None
-        or video["deleted_at"] is not None
-    ):
+    if not _is_video_embeddable(video):
         raise HTTPException(status_code=404, detail="Video not available for embedding")
 
     # Build embed URL

--- a/api/public.py
+++ b/api/public.py
@@ -70,6 +70,7 @@ from api.pagination import encode_cursor, validate_cursor
 from api.schemas import (
     CategoryResponse,
     ChapterInfo,
+    EmbedCodeResponse,
     PaginatedVideoListResponse,
     PlaybackEnd,
     PlaybackHeartbeat,
@@ -98,6 +99,12 @@ from config import (
     DOWNLOADS_ENABLED,
     DOWNLOADS_MAX_CONCURRENT,
     DOWNLOADS_RATE_LIMIT_PER_HOUR,
+    EMBED_ALLOWED_DOMAINS,
+    EMBED_ALLOW_ALL_DOMAINS,
+    EMBED_DEFAULT_AUTOPLAY,
+    EMBED_ENABLED,
+    EMBED_MIN_PLAYBACK_FOR_VIEW,
+    RATE_LIMIT_EMBED,
     AUTOPLAY_ENABLED,
     UPNEXT_ENABLED,
     AUTOPLAY_COUNTDOWN_SECONDS,
@@ -299,6 +306,103 @@ def reset_cdn_settings_cache() -> None:
     global _cached_cdn_settings, _cached_cdn_settings_time
     _cached_cdn_settings = {}
     _cached_cdn_settings_time = 0
+
+
+# Cached embed settings (refreshed every 60 seconds)
+_cached_embed_settings: Dict[str, Any] = {}
+_cached_embed_settings_time: float = 0
+_EMBED_SETTINGS_CACHE_TTL = 60  # Refresh every 60 seconds
+
+
+async def get_embed_settings() -> Dict[str, Any]:
+    """
+    Get embed settings from database with caching and env var fallback.
+
+    Settings are cached locally for 60 seconds to avoid database round-trips
+    on every embed page request.
+
+    Returns:
+        Dict with keys:
+        - enabled: Whether embeds are enabled
+        - allowed_domains: Domain whitelist for frame-ancestors CSP
+        - allow_all_domains: Allow embedding on any domain
+        - default_autoplay: Default autoplay behavior
+        - min_playback_for_view: Seconds before counting as view
+    """
+    global _cached_embed_settings, _cached_embed_settings_time
+
+    now = time.time()
+    if _cached_embed_settings and (now - _cached_embed_settings_time) < _EMBED_SETTINGS_CACHE_TTL:
+        return _cached_embed_settings
+
+    try:
+        from api.settings_service import get_settings_service
+
+        service = get_settings_service()
+
+        settings = {
+            "enabled": await service.get("embed.enabled", EMBED_ENABLED),
+            "allowed_domains": await service.get("embed.allowed_domains", EMBED_ALLOWED_DOMAINS),
+            "allow_all_domains": await service.get("embed.allow_all_domains", EMBED_ALLOW_ALL_DOMAINS),
+            "default_autoplay": await service.get("embed.default_autoplay", EMBED_DEFAULT_AUTOPLAY),
+            "min_playback_for_view": await service.get("embed.min_playback_for_view", EMBED_MIN_PLAYBACK_FOR_VIEW),
+        }
+
+        _cached_embed_settings = settings
+        _cached_embed_settings_time = now
+    except Exception as e:
+        logger.debug(f"Failed to get embed settings from DB, using env vars: {e}")
+        _cached_embed_settings = {
+            "enabled": EMBED_ENABLED,
+            "allowed_domains": EMBED_ALLOWED_DOMAINS,
+            "allow_all_domains": EMBED_ALLOW_ALL_DOMAINS,
+            "default_autoplay": EMBED_DEFAULT_AUTOPLAY,
+            "min_playback_for_view": EMBED_MIN_PLAYBACK_FOR_VIEW,
+        }
+        _cached_embed_settings_time = now
+
+    return _cached_embed_settings
+
+
+def get_embed_csp_frame_ancestors() -> str:
+    """
+    Build the frame-ancestors CSP directive value based on embed settings.
+
+    Returns:
+        CSP frame-ancestors value (e.g., "'self'", "* ", "'self' https://example.com")
+    """
+    # Check for allow all domains first
+    if EMBED_ALLOW_ALL_DOMAINS:
+        return "*"
+
+    # Parse allowed domains from configuration
+    allowed = EMBED_ALLOWED_DOMAINS.strip()
+
+    # If 'self' only or empty, return self
+    if not allowed or allowed == "'self'":
+        return "'self'"
+
+    # Parse comma-separated domains and build frame-ancestors value
+    domains = [d.strip() for d in allowed.split(",") if d.strip()]
+    if not domains:
+        return "'self'"
+
+    # Include 'self' and add https:// prefix to domains if not present
+    parts = ["'self'"]
+    for domain in domains:
+        if domain.startswith("'") or domain.startswith("http"):
+            parts.append(domain)
+        else:
+            parts.append(f"https://{domain}")
+
+    return " ".join(parts)
+
+
+def reset_embed_settings_cache() -> None:
+    """Reset the cached embed settings. Useful for testing."""
+    global _cached_embed_settings, _cached_embed_settings_time
+    _cached_embed_settings = {}
+    _cached_embed_settings_time = 0
 
 
 def validate_safe_path(base: Path, user_path: str) -> Path:
@@ -568,6 +672,160 @@ async def category_page(slug: str):
 async def tag_page(slug: str):
     """Serve the tag page."""
     return FileResponse(WEB_DIR / "tag.html")
+
+
+# =============================================================================
+# Video Embed Routes (Issue #210)
+# =============================================================================
+
+
+@app.get("/embed/{slug}", response_class=HTMLResponse)
+@limiter.limit(RATE_LIMIT_EMBED)
+async def embed_page(request: Request, slug: str):
+    """
+    Serve the embed player page for a video.
+
+    Returns a minimal video player designed for iframe embedding.
+    Sets appropriate CSP frame-ancestors header based on configuration.
+
+    Security:
+    - Only serves videos with status='ready' and published_at set
+    - CSP frame-ancestors controls which domains can embed
+    - Does NOT set X-Frame-Options (CSP takes precedence)
+
+    Query Parameters:
+    - autoplay: 0 or 1 (default: from settings)
+    - start: Start time in seconds (default: 0)
+    - controls: 0 or 1 (default: 1)
+    """
+    # Check if embeds are enabled
+    embed_settings = await get_embed_settings()
+    if not embed_settings["enabled"]:
+        return FileResponse(
+            WEB_DIR / "embed-error.html",
+            status_code=404,
+            headers={"Content-Security-Policy": "frame-ancestors 'none'"},
+        )
+
+    # Validate video exists and is ready/published
+    try:
+        query = sa.select(
+            videos.c.id,
+            videos.c.slug,
+            videos.c.status,
+            videos.c.published_at,
+            videos.c.deleted_at,
+        ).where(videos.c.slug == slug)
+
+        video = await fetch_one_with_retry(query)
+
+        if not video:
+            logger.debug(f"Embed: Video not found: {slug}")
+            return FileResponse(
+                WEB_DIR / "embed-error.html",
+                status_code=404,
+                headers={"Content-Security-Policy": "frame-ancestors 'none'"},
+            )
+
+        # Video must be ready, published, and not deleted
+        if (
+            video["status"] != VideoStatus.READY
+            or video["published_at"] is None
+            or video["deleted_at"] is not None
+        ):
+            logger.debug(f"Embed: Video not embeddable: {slug} (status={video['status']}, published={video['published_at'] is not None})")
+            return FileResponse(
+                WEB_DIR / "embed-error.html",
+                status_code=404,
+                headers={"Content-Security-Policy": "frame-ancestors 'none'"},
+            )
+
+    except Exception as e:
+        logger.warning(f"Embed: Database error for {slug}: {e}")
+        return FileResponse(
+            WEB_DIR / "embed-error.html",
+            status_code=503,
+            headers={
+                "Content-Security-Policy": "frame-ancestors 'none'",
+                "Retry-After": "30",
+            },
+        )
+
+    # Build CSP frame-ancestors directive
+    frame_ancestors = get_embed_csp_frame_ancestors()
+
+    # Return embed page with CSP header
+    return FileResponse(
+        WEB_DIR / "embed.html",
+        headers={
+            "Content-Security-Policy": f"frame-ancestors {frame_ancestors}",
+        },
+    )
+
+
+@v1_router.get("/videos/{slug}/embed-code", response_model=EmbedCodeResponse)
+@limiter.limit(RATE_LIMIT_PUBLIC_DEFAULT)
+async def get_embed_code(request: Request, slug: str):
+    """
+    Get the embed code for a video.
+
+    Returns the iframe HTML and URL for embedding the video on external sites.
+
+    Returns 404 if:
+    - Video doesn't exist
+    - Video is not ready or not published
+    - Embeds are disabled
+    """
+    # Check if embeds are enabled
+    embed_settings = await get_embed_settings()
+    if not embed_settings["enabled"]:
+        raise HTTPException(status_code=404, detail="Video embedding is disabled")
+
+    # Validate video exists and is embeddable
+    query = sa.select(
+        videos.c.id,
+        videos.c.slug,
+        videos.c.status,
+        videos.c.published_at,
+        videos.c.deleted_at,
+    ).where(videos.c.slug == slug)
+
+    video = await fetch_one_with_retry(query)
+
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    if (
+        video["status"] != VideoStatus.READY
+        or video["published_at"] is None
+        or video["deleted_at"] is not None
+    ):
+        raise HTTPException(status_code=404, detail="Video not available for embedding")
+
+    # Build embed URL
+    # Use request's base URL for the embed URL
+    base_url = str(request.base_url).rstrip("/")
+    embed_url = f"{base_url}/embed/{slug}"
+
+    # Standard dimensions for 16:9 aspect ratio
+    width = 560
+    height = 315
+
+    # Build iframe HTML with proper attributes
+    iframe_html = (
+        f'<iframe src="{embed_url}" '
+        f'width="{width}" height="{height}" '
+        f'frameborder="0" '
+        f'allow="autoplay; fullscreen; picture-in-picture" '
+        f'allowfullscreen></iframe>'
+    )
+
+    return EmbedCodeResponse(
+        embed_url=embed_url,
+        iframe_html=iframe_html,
+        width=width,
+        height=height,
+    )
 
 
 async def get_video_tags(video_ids: List[int]) -> dict:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1602,3 +1602,15 @@ class WebhookStatsResponse(BaseModel):
     failed_deliveries: int = 0
     total_deliveries_24h: int = 0
     successful_deliveries_24h: int = 0
+
+
+# ============ Video Embed Models (Issue #210) ============
+
+
+class EmbedCodeResponse(BaseModel):
+    """Response for video embed code API."""
+
+    embed_url: str = Field(..., description="URL for the embed iframe src")
+    iframe_html: str = Field(..., description="Ready-to-use iframe HTML snippet")
+    width: int = Field(default=560, description="Default iframe width in pixels")
+    height: int = Field(default=315, description="Default iframe height in pixels")

--- a/api/settings_service.py
+++ b/api/settings_service.py
@@ -1185,6 +1185,42 @@ KNOWN_SETTINGS = [
         "Countdown duration in seconds before autoplay starts",
         {"min": 5, "max": 30},
     ),
+    # Embed settings (Issue #210)
+    (
+        "embed.enabled",
+        "embed",
+        "boolean",
+        "Enable video embedding feature",
+        None,
+    ),
+    (
+        "embed.allowed_domains",
+        "embed",
+        "string",
+        "Domain whitelist for frame-ancestors CSP ('self' = same-origin only, or comma-separated domains)",
+        None,
+    ),
+    (
+        "embed.allow_all_domains",
+        "embed",
+        "boolean",
+        "Allow embedding on any domain (security warning: only for public platforms)",
+        None,
+    ),
+    (
+        "embed.default_autoplay",
+        "embed",
+        "boolean",
+        "Default autoplay behavior for embedded videos",
+        None,
+    ),
+    (
+        "embed.min_playback_for_view",
+        "embed",
+        "integer",
+        "Minimum seconds of playback before counting as a view",
+        {"min": 1, "max": 60},
+    ),
     # Webhook settings (Issue #203)
     (
         "webhooks.enabled",
@@ -1332,6 +1368,12 @@ SETTING_TO_ENV_MAP = {
     "webhooks.request_timeout": "VLOG_WEBHOOKS_REQUEST_TIMEOUT",
     "webhooks.max_concurrent_deliveries": "VLOG_WEBHOOKS_MAX_CONCURRENT_DELIVERIES",
     "webhooks.delivery_batch_size": "VLOG_WEBHOOKS_DELIVERY_BATCH_SIZE",
+    # Embed settings (Issue #210)
+    "embed.enabled": "VLOG_EMBED_ENABLED",
+    "embed.allowed_domains": "VLOG_EMBED_ALLOWED_DOMAINS",
+    "embed.allow_all_domains": "VLOG_EMBED_ALLOW_ALL_DOMAINS",
+    "embed.default_autoplay": "VLOG_EMBED_DEFAULT_AUTOPLAY",
+    "embed.min_playback_for_view": "VLOG_EMBED_MIN_PLAYBACK_FOR_VIEW",
 }
 
 

--- a/config.py
+++ b/config.py
@@ -747,6 +747,34 @@ UPNEXT_ENABLED = os.getenv("VLOG_UPNEXT_ENABLED", "true").lower() in ("true", "1
 AUTOPLAY_COUNTDOWN_SECONDS = get_int_env("VLOG_AUTOPLAY_COUNTDOWN_SECONDS", 10, min_val=5, max_val=30)
 
 # =============================================================================
+# Video Embed Configuration (Issue #210)
+# Allow embedding videos on external websites with security controls
+# =============================================================================
+
+# Master switch for embed feature
+EMBED_ENABLED = os.getenv("VLOG_EMBED_ENABLED", "true").lower() in ("true", "1", "yes")
+
+# Domain whitelist for frame-ancestors CSP directive
+# SECURITY: Defaults to 'self' only - external embeds blocked by default
+# Set to comma-separated domains to allow specific sites: "example.com,blog.example.com"
+# This is the recommended secure configuration for controlled embedding
+EMBED_ALLOWED_DOMAINS = os.getenv("VLOG_EMBED_ALLOWED_DOMAINS", "'self'")
+
+# Allow embedding on ANY domain (sets frame-ancestors to *)
+# SECURITY WARNING: Only enable for truly public video platforms
+# When True, overrides EMBED_ALLOWED_DOMAINS
+EMBED_ALLOW_ALL_DOMAINS = os.getenv("VLOG_EMBED_ALLOW_ALL_DOMAINS", "false").lower() in ("true", "1", "yes")
+
+# Default autoplay behavior for embeds (can be overridden via query param)
+EMBED_DEFAULT_AUTOPLAY = os.getenv("VLOG_EMBED_DEFAULT_AUTOPLAY", "false").lower() in ("true", "1", "yes")
+
+# Minimum seconds of playback before counting as a view (prevents view inflation)
+EMBED_MIN_PLAYBACK_FOR_VIEW = get_int_env("VLOG_EMBED_MIN_PLAYBACK_FOR_VIEW", 5, min_val=1, max_val=60)
+
+# Rate limit for embed page requests (higher than normal to allow pages with multiple embeds)
+RATE_LIMIT_EMBED = os.getenv("VLOG_RATE_LIMIT_EMBED", "500/minute")
+
+# =============================================================================
 # Live Streaming Configuration
 # HTTP segment push for live streaming without RTMP/SRT servers
 # =============================================================================

--- a/web/public/embed-error.html
+++ b/web/public/embed-error.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'none'; base-uri 'self';">
+    <title>Video Unavailable</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background-color: #0a0a0a;
+            color: #a3a3a3;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            padding: 1rem;
+        }
+
+        .error-container {
+            text-align: center;
+            max-width: 320px;
+        }
+
+        .error-icon {
+            width: 64px;
+            height: 64px;
+            margin: 0 auto 1rem;
+            color: #525252;
+        }
+
+        .error-title {
+            font-size: 1.125rem;
+            font-weight: 500;
+            color: #e5e5e5;
+            margin-bottom: 0.5rem;
+        }
+
+        .error-message {
+            font-size: 0.875rem;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-container">
+        <svg class="error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M15.182 15.182a4.5 4.5 0 01-6.364 0M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <h1 class="error-title">Video Unavailable</h1>
+        <p class="error-message">This video cannot be played at this time.</p>
+    </div>
+</body>
+</html>

--- a/web/public/embed.html
+++ b/web/public/embed.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob: https://cdn.damenknight.com; connect-src 'self' https://cdn.damenknight.com; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+    <title>Embedded Video</title>
+    <link rel="stylesheet" href="/static/vendor/tailwind.css">
+    <link rel="stylesheet" href="/static/css/bundle.css">
+    <link rel="stylesheet" href="/static/css/pages/player.css">
+    <link rel="stylesheet" href="/static/css/pages/embed.css">
+    <!-- Shaka Player for DASH/HLS playback -->
+    <script src="/static/vendor/shaka-player.compiled.min.js"></script>
+    <!-- hls.js for legacy HLS playback (fallback) -->
+    <script src="/static/vendor/hls.min.js"></script>
+    <script src="/static/js/player-controls.js"></script>
+    <script defer src="/static/js/utils.js"></script>
+    <script defer src="/static/js/pages/embed.js"></script>
+</head>
+<body class="embed-body">
+    <!-- Loading State -->
+    <div id="embed-loading" class="embed-loading">
+        <div class="embed-spinner"></div>
+    </div>
+
+    <!-- Error State (hidden by default) -->
+    <div id="embed-error" class="embed-error" style="display: none;">
+        <div class="embed-error-content">
+            <svg class="embed-error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="12" y1="8" x2="12" y2="12"></line>
+                <line x1="12" y1="16" x2="12.01" y2="16"></line>
+            </svg>
+            <p id="embed-error-message">Video unavailable</p>
+        </div>
+    </div>
+
+    <!-- Video Player Container -->
+    <div id="embed-player-container" class="embed-player-container" style="display: none;">
+        <div id="player-container" class="player-container">
+            <video
+                id="player"
+                preload="auto"
+                playsinline
+                controls
+            ></video>
+        </div>
+    </div>
+
+    <script>
+        // Pass embed configuration to the embed.js script
+        window.EMBED_CONFIG = {
+            slug: window.location.pathname.split('/').pop(),
+            params: new URLSearchParams(window.location.search)
+        };
+    </script>
+</body>
+</html>

--- a/web/public/embed.html
+++ b/web/public/embed.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob: https://cdn.damenknight.com; connect-src 'self' https://cdn.damenknight.com; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; media-src 'self' blob: https://cdn.damenknight.com; connect-src 'self' https://cdn.damenknight.com; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
     <title>Embedded Video</title>
     <link rel="stylesheet" href="/static/vendor/tailwind.css">
     <link rel="stylesheet" href="/static/css/bundle.css">
@@ -24,7 +24,7 @@
     </div>
 
     <!-- Error State (hidden by default) -->
-    <div id="embed-error" class="embed-error" style="display: none;">
+    <div id="embed-error" class="embed-error embed-hidden">
         <div class="embed-error-content">
             <svg class="embed-error-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="10"></circle>
@@ -36,7 +36,7 @@
     </div>
 
     <!-- Video Player Container -->
-    <div id="embed-player-container" class="embed-player-container" style="display: none;">
+    <div id="embed-player-container" class="embed-player-container embed-hidden">
         <div id="player-container" class="player-container">
             <video
                 id="player"

--- a/web/public/static/css/pages/embed.css
+++ b/web/public/static/css/pages/embed.css
@@ -1,0 +1,133 @@
+/**
+ * VLog Embed Player Styles
+ * Minimal, responsive styles for iframe embedding
+ */
+
+/* Reset and base styles */
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background-color: #000;
+}
+
+.embed-body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background-color: #000;
+}
+
+/* Loading state */
+.embed-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background-color: #0a0a0a;
+}
+
+.embed-spinner {
+    width: 48px;
+    height: 48px;
+    border: 3px solid #333;
+    border-top-color: #3b82f6;
+    border-radius: 50%;
+    animation: embed-spin 1s linear infinite;
+}
+
+@keyframes embed-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Error state */
+.embed-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background-color: #0a0a0a;
+    padding: 1rem;
+}
+
+.embed-error-content {
+    text-align: center;
+    color: #a3a3a3;
+}
+
+.embed-error-icon {
+    width: 48px;
+    height: 48px;
+    margin: 0 auto 1rem;
+    color: #525252;
+}
+
+.embed-error-content p {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 0.875rem;
+    margin: 0;
+}
+
+/* Player container */
+.embed-player-container {
+    width: 100%;
+    height: 100%;
+    background-color: #000;
+}
+
+.embed-player-container .player-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.embed-player-container video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background-color: #000;
+}
+
+/* Override player controls for embed mode */
+.embed-player-container .player-control-bar {
+    /* Slightly transparent background for embed */
+    background: linear-gradient(
+        to top,
+        rgba(0, 0, 0, 0.9) 0%,
+        rgba(0, 0, 0, 0.6) 50%,
+        transparent 100%
+    );
+}
+
+/* Hide theater mode button in embed (not applicable) */
+.embed-player-container .theater-btn {
+    display: none !important;
+}
+
+/* Hide share button in embed mode (handled by JS but CSS backup) */
+.embed-player-container .share-btn {
+    display: none !important;
+}
+
+/* Adjust fullscreen behavior for embedded context */
+.embed-player-container .player-container:fullscreen,
+.embed-player-container .player-container:-webkit-full-screen {
+    width: 100%;
+    height: 100%;
+}
+
+.embed-player-container .player-container:fullscreen video,
+.embed-player-container .player-container:-webkit-full-screen video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}

--- a/web/public/static/css/pages/embed.css
+++ b/web/public/static/css/pages/embed.css
@@ -118,6 +118,11 @@ body {
     display: none !important;
 }
 
+/* Hidden state class (used instead of inline styles for CSP compliance) */
+.embed-hidden {
+    display: none !important;
+}
+
 /* Adjust fullscreen behavior for embedded context */
 .embed-player-container .player-container:fullscreen,
 .embed-player-container .player-container:-webkit-full-screen {

--- a/web/public/static/css/pages/player.css
+++ b/web/public/static/css/pages/player.css
@@ -1034,6 +1034,125 @@
     flex-shrink: 0;
 }
 
+/* Share modal tabs (Issue #210) */
+.share-modal-tabs {
+    display: flex;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 0 16px;
+}
+
+.share-modal-tab {
+    padding: 12px 16px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--vlog-text-secondary, #a1a1aa);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color var(--vlog-transition-base, 0.2s ease),
+                border-color var(--vlog-transition-base, 0.2s ease);
+}
+
+.share-modal-tab:hover {
+    color: white;
+}
+
+.share-modal-tab.active {
+    color: white;
+    border-bottom-color: var(--vlog-primary, #3b82f6);
+}
+
+.share-modal-tab:focus-visible {
+    outline: 2px solid var(--vlog-primary, #3b82f6);
+    outline-offset: -2px;
+}
+
+.share-tab-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* Link tab styling - horizontal layout */
+#share-tab-link {
+    flex-direction: row;
+    gap: 8px;
+}
+
+/* Embed tab styling (Issue #210) */
+.embed-options {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.embed-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--vlog-text-secondary, #a1a1aa);
+    font-size: 13px;
+}
+
+.embed-option-checkbox {
+    cursor: pointer;
+}
+
+.embed-option-checkbox:hover {
+    color: white;
+}
+
+.embed-start-time {
+    width: 70px;
+    background: var(--vlog-bg-secondary, #111827);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--vlog-radius-sm, 4px);
+    padding: 6px 10px;
+    color: white;
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+}
+
+.embed-start-time:focus {
+    border-color: var(--vlog-primary, #3b82f6);
+}
+
+.embed-start-time::placeholder {
+    color: var(--vlog-text-tertiary, #71717a);
+}
+
+.embed-option input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--vlog-primary, #3b82f6);
+    cursor: pointer;
+}
+
+.embed-code-textarea {
+    width: 100%;
+    background: var(--vlog-bg-secondary, #111827);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--vlog-radius-sm, 4px);
+    padding: 10px 12px;
+    color: white;
+    font-size: 12px;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    resize: none;
+    outline: none;
+    line-height: 1.5;
+}
+
+.embed-code-textarea:focus {
+    border-color: var(--vlog-primary, #3b82f6);
+}
+
+.embed-copy-btn {
+    align-self: flex-end;
+}
+
 /* Mobile responsive */
 @media (max-width: 640px) {
     .player-control-bar {

--- a/web/public/static/js/pages/embed.js
+++ b/web/public/static/js/pages/embed.js
@@ -15,35 +15,113 @@ function debugLog(...args) {
 // Slug validation pattern
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+// Default minimum playback seconds before counting a view (matches backend EMBED_MIN_PLAYBACK_FOR_VIEW)
+const DEFAULT_MIN_PLAYBACK_FOR_VIEW_SECONDS = 5;
+
+// Network timeout defaults (in milliseconds)
+const FETCH_TIMEOUT_SESSION = 5000;
+const FETCH_TIMEOUT_HEARTBEAT = 5000;
+const FETCH_TIMEOUT_VIDEO_DATA = 10000;
+
+// Retry configuration
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY = 1000;
+
+// Heartbeat circuit breaker configuration
+const MAX_HEARTBEAT_FAILURES = 3;
+const HEARTBEAT_INTERVAL_MS = 30000;
+const MAX_HEARTBEAT_BACKOFF_MS = 300000; // 5 minutes
+
+/**
+ * Fetch with timeout support
+ * @param {string} url - URL to fetch
+ * @param {object} options - Fetch options
+ * @param {number} timeout - Timeout in milliseconds
+ * @returns {Promise<Response>}
+ */
+async function fetchWithTimeout(url, options = {}, timeout = 10000) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+        const response = await fetch(url, {
+            ...options,
+            signal: controller.signal
+        });
+        clearTimeout(timeoutId);
+        return response;
+    } catch (error) {
+        clearTimeout(timeoutId);
+        if (error.name === 'AbortError') {
+            throw new Error('Request timeout');
+        }
+        throw error;
+    }
+}
+
+/**
+ * Generate a cryptographically secure UUID
+ * @returns {string} UUID v4
+ */
+function generateSecureUUID() {
+    // Use native crypto.randomUUID if available (modern browsers)
+    if (crypto && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+
+    // Fallback using crypto.getRandomValues
+    if (crypto && crypto.getRandomValues) {
+        const bytes = new Uint8Array(16);
+        crypto.getRandomValues(bytes);
+        // Set version (4) and variant (8, 9, A, or B)
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+        const hex = [...bytes].map(b => b.toString(16).padStart(2, '0'));
+        return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`;
+    }
+
+    // Last resort fallback (not cryptographically secure, but functional)
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
 /**
  * Embed analytics tracker
  * Tracks view sessions with source='embed' and minimum playback validation
  */
 class EmbedAnalytics {
-    constructor(videoId, player, minPlaybackSeconds = 5) {
+    constructor(videoId, player, minPlaybackSeconds = DEFAULT_MIN_PLAYBACK_FOR_VIEW_SECONDS) {
         this.videoId = videoId;
         this.player = player;
         this.minPlaybackSeconds = minPlaybackSeconds;
         this.sessionToken = null;
-        this.sessionUUID = this.generateUUID();
+        this.sessionUUID = generateSecureUUID();
         this.heartbeatInterval = null;
         this.playbackSeconds = 0;
         this.viewCounted = false;
         this.playbackTimer = null;
-    }
 
-    generateUUID() {
-        // Generate a simple UUID for session tracking
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            const r = Math.random() * 16 | 0;
-            const v = c === 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
+        // Session state tracking
+        this.sessionStarting = false;
+        this.destroyed = false;
+
+        // Circuit breaker for heartbeats
+        this.heartbeatFailures = 0;
+        this.heartbeatBackoff = HEARTBEAT_INTERVAL_MS;
     }
 
     async startSession(quality) {
+        // Prevent duplicate session starts
+        if (this.sessionToken || this.sessionStarting || this.destroyed) return;
+
+        this.sessionStarting = true;
+
         try {
-            const res = await fetch('/api/analytics/session', {
+            const res = await fetchWithTimeout('/api/analytics/session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
@@ -53,23 +131,35 @@ class EmbedAnalytics {
                     source: 'embed',
                     session_uuid: this.sessionUUID
                 })
-            });
+            }, FETCH_TIMEOUT_SESSION);
+
+            if (!res.ok) {
+                throw new Error(`Session creation failed: ${res.status}`);
+            }
+
             const data = await res.json();
             this.sessionToken = data.session_token;
             this.startHeartbeat();
             this.startPlaybackTracking();
+            debugLog('Analytics session started');
         } catch (e) {
             console.error('Failed to start analytics session:', e);
+            // Don't start heartbeat/tracking if session creation failed
+        } finally {
+            this.sessionStarting = false;
         }
     }
 
     startHeartbeat() {
-        this.heartbeatInterval = setInterval(() => this.sendHeartbeat(), 30000);
+        if (this.destroyed) return;
+        this.heartbeatInterval = setInterval(() => this.sendHeartbeat(), this.heartbeatBackoff);
     }
 
     startPlaybackTracking() {
+        if (this.destroyed) return;
         // Track actual playback time (not just video time)
         this.playbackTimer = setInterval(() => {
+            if (this.destroyed) return;
             if (!this.player.paused()) {
                 this.playbackSeconds++;
 
@@ -83,10 +173,17 @@ class EmbedAnalytics {
     }
 
     async sendHeartbeat() {
-        if (!this.sessionToken) return;
+        if (!this.sessionToken || this.destroyed) return;
+
+        // Circuit breaker: stop if too many failures
+        if (this.heartbeatFailures >= MAX_HEARTBEAT_FAILURES) {
+            debugLog('Heartbeat circuit breaker open, stopping heartbeats');
+            this.clearHeartbeatInterval();
+            return;
+        }
 
         try {
-            await fetch('/api/analytics/heartbeat', {
+            const res = await fetchWithTimeout('/api/analytics/heartbeat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
@@ -97,9 +194,52 @@ class EmbedAnalytics {
                     playing: !this.player.paused(),
                     session_uuid: this.sessionUUID
                 })
-            });
+            }, FETCH_TIMEOUT_HEARTBEAT);
+
+            if (!res.ok) {
+                throw new Error(`Heartbeat failed: ${res.status}`);
+            }
+
+            // Reset failure count and backoff on success
+            this.heartbeatFailures = 0;
+            if (this.heartbeatBackoff !== HEARTBEAT_INTERVAL_MS) {
+                this.heartbeatBackoff = HEARTBEAT_INTERVAL_MS;
+                this.restartHeartbeatWithBackoff();
+            }
         } catch (e) {
             console.error('Heartbeat failed:', e);
+            this.heartbeatFailures++;
+
+            // Exponential backoff for retries
+            if (this.heartbeatFailures < MAX_HEARTBEAT_FAILURES) {
+                this.heartbeatBackoff = Math.min(
+                    this.heartbeatBackoff * 2,
+                    MAX_HEARTBEAT_BACKOFF_MS
+                );
+                this.restartHeartbeatWithBackoff();
+                debugLog(`Heartbeat backoff increased to ${this.heartbeatBackoff}ms`);
+            }
+        }
+    }
+
+    restartHeartbeatWithBackoff() {
+        this.clearHeartbeatInterval();
+        if (!this.destroyed) {
+            this.heartbeatInterval = setInterval(() => this.sendHeartbeat(), this.heartbeatBackoff);
+        }
+    }
+
+    clearHeartbeatInterval() {
+        if (this.heartbeatInterval) {
+            clearInterval(this.heartbeatInterval);
+            this.heartbeatInterval = null;
+        }
+    }
+
+    clearPlaybackTimer() {
+        if (this.playbackTimer) {
+            clearInterval(this.playbackTimer);
+            this.playbackTimer = null;
         }
     }
 
@@ -115,32 +255,43 @@ class EmbedAnalytics {
     }
 
     async endSession(completed = false) {
+        // Clear intervals first (idempotent)
+        this.clearHeartbeatInterval();
+        this.clearPlaybackTimer();
+
         if (!this.sessionToken) return;
 
-        clearInterval(this.heartbeatInterval);
-        clearInterval(this.playbackTimer);
+        const token = this.sessionToken;
+        this.sessionToken = null; // Clear immediately to prevent double-send
 
         try {
             const data = JSON.stringify({
-                session_token: this.sessionToken,
+                session_token: token,
                 position: this.player.currentTime(),
                 completed: completed
             });
 
+            // Always prefer sendBeacon for reliability on unload
             if (navigator.sendBeacon) {
                 navigator.sendBeacon('/api/analytics/end', new Blob([data], { type: 'application/json' }));
             } else {
-                await fetch('/api/analytics/end', {
+                await fetchWithTimeout('/api/analytics/end', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',
-                    body: data
-                });
+                    body: data,
+                    keepalive: true // Important for unload scenarios
+                }, 3000);
             }
         } catch (e) {
             console.error('Failed to end session:', e);
         }
+    }
 
+    destroy() {
+        this.destroyed = true;
+        this.clearHeartbeatInterval();
+        this.clearPlaybackTimer();
         this.sessionToken = null;
     }
 }
@@ -156,6 +307,7 @@ class EmbedPlayer {
         this.analytics = null;
         this.hls = null;
         this.shakaPlayer = null;
+        this.destroyed = false;
 
         // Parse embed configuration from URL
         this.config = window.EMBED_CONFIG || {
@@ -212,29 +364,65 @@ class EmbedPlayer {
             return;
         }
 
-        try {
-            // Fetch video data
-            const res = await fetch(`/api/videos/${encodeURIComponent(slug)}`);
-            if (!res.ok) {
-                this.showError('Video not found');
-                return;
+        // Retry with exponential backoff
+        for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+            try {
+                const res = await fetchWithTimeout(
+                    `/api/videos/${encodeURIComponent(slug)}`,
+                    {},
+                    FETCH_TIMEOUT_VIDEO_DATA
+                );
+
+                if (res.status === 404) {
+                    // Don't retry 404s
+                    this.showError('Video not found');
+                    return;
+                }
+
+                if (!res.ok) {
+                    throw new Error(`HTTP ${res.status}`);
+                }
+
+                this.videoData = await res.json();
+
+                // Validate required fields
+                if (!this.videoData.status) {
+                    throw new Error('Invalid video data');
+                }
+
+                // Check video is ready
+                if (this.videoData.status !== 'ready') {
+                    this.showError('Video is being prepared');
+                    return;
+                }
+
+                // Validate stream URLs exist
+                if (!this.videoData.stream_url && !this.videoData.dash_url) {
+                    this.showError('Video files unavailable');
+                    return;
+                }
+
+                // Initialize player
+                this.showPlayer();
+                this.initPlayer();
+                return; // Success
+
+            } catch (e) {
+                console.error(`Failed to load video (attempt ${attempt + 1}/${MAX_RETRIES}):`, e);
+
+                if (attempt === MAX_RETRIES - 1) {
+                    // Last attempt failed
+                    if (e.message === 'Request timeout') {
+                        this.showError('Connection timeout - please try again');
+                    } else {
+                        this.showError('Unable to load video');
+                    }
+                } else {
+                    // Wait before retry with exponential backoff + jitter
+                    const delay = RETRY_BASE_DELAY * Math.pow(2, attempt) + Math.random() * 1000;
+                    await new Promise(resolve => setTimeout(resolve, delay));
+                }
             }
-
-            this.videoData = await res.json();
-
-            // Check video is ready
-            if (this.videoData.status !== 'ready') {
-                this.showError('Video is being prepared');
-                return;
-            }
-
-            // Initialize player
-            this.showPlayer();
-            this.initPlayer();
-
-        } catch (e) {
-            console.error('Failed to load video:', e);
-            this.showError('Unable to load video');
         }
     }
 
@@ -321,13 +509,9 @@ class EmbedPlayer {
             this.analytics.startSession(quality);
         }, { once: true });
 
-        // End session on video complete or unload
+        // End session on video complete
         this.video.addEventListener('ended', () => {
             this.analytics.endSession(true);
-        });
-
-        window.addEventListener('beforeunload', () => {
-            this.analytics.endSession(false);
         });
 
         // Handle start time
@@ -461,10 +645,86 @@ class EmbedPlayer {
             }
         }
     }
+
+    /**
+     * Clean up all resources
+     * Called on page unload or when embed is removed from DOM
+     */
+    destroy() {
+        if (this.destroyed) return;
+        this.destroyed = true;
+
+        debugLog('Destroying embed player');
+
+        // Clean up analytics
+        if (this.analytics) {
+            this.analytics.endSession(false);
+            this.analytics.destroy();
+            this.analytics = null;
+        }
+
+        // Clean up Shaka Player
+        if (this.shakaPlayer) {
+            try {
+                this.shakaPlayer.destroy();
+            } catch (e) {
+                console.error('Failed to destroy Shaka player:', e);
+            }
+            this.shakaPlayer = null;
+        }
+
+        // Clean up HLS.js
+        if (this.hls) {
+            try {
+                this.hls.destroy();
+            } catch (e) {
+                console.error('Failed to destroy HLS player:', e);
+            }
+            this.hls = null;
+        }
+
+        // Clean up custom controls
+        if (this.playerControls && this.playerControls.destroy) {
+            try {
+                this.playerControls.destroy();
+            } catch (e) {
+                console.error('Failed to destroy player controls:', e);
+            }
+            this.playerControls = null;
+        }
+
+        // Clean up video element
+        if (this.video) {
+            this.video.pause();
+            this.video.src = '';
+            this.video.load();
+            this.video = null;
+        }
+    }
 }
+
+// Global reference for cleanup
+let embedPlayerInstance = null;
 
 // Initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
-    const embedPlayer = new EmbedPlayer();
-    embedPlayer.init();
+    embedPlayerInstance = new EmbedPlayer();
+    embedPlayerInstance.init();
+
+    // Expose for external cleanup (e.g., parent page removing iframe)
+    window.embedPlayerInstance = embedPlayerInstance;
+});
+
+// Clean up on page unload
+window.addEventListener('beforeunload', () => {
+    if (embedPlayerInstance) {
+        embedPlayerInstance.destroy();
+    }
+});
+
+// Also handle pagehide for mobile browsers
+window.addEventListener('pagehide', () => {
+    if (embedPlayerInstance) {
+        embedPlayerInstance.destroy();
+    }
 });

--- a/web/public/static/js/pages/embed.js
+++ b/web/public/static/js/pages/embed.js
@@ -1,0 +1,470 @@
+/**
+ * VLog Embed Player Module
+ * Minimal video player for iframe embedding
+ *
+ * Used by: embed.html
+ * Dependencies: utils.js, player-controls.js, shaka-player, hls.js
+ */
+
+// Debug logging - only enabled on localhost
+const DEBUG_MODE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+function debugLog(...args) {
+    if (DEBUG_MODE) console.log('[embed]', ...args);
+}
+
+// Slug validation pattern
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Embed analytics tracker
+ * Tracks view sessions with source='embed' and minimum playback validation
+ */
+class EmbedAnalytics {
+    constructor(videoId, player, minPlaybackSeconds = 5) {
+        this.videoId = videoId;
+        this.player = player;
+        this.minPlaybackSeconds = minPlaybackSeconds;
+        this.sessionToken = null;
+        this.sessionUUID = this.generateUUID();
+        this.heartbeatInterval = null;
+        this.playbackSeconds = 0;
+        this.viewCounted = false;
+        this.playbackTimer = null;
+    }
+
+    generateUUID() {
+        // Generate a simple UUID for session tracking
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+
+    async startSession(quality) {
+        try {
+            const res = await fetch('/api/analytics/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({
+                    video_id: this.videoId,
+                    quality: quality,
+                    source: 'embed',
+                    session_uuid: this.sessionUUID
+                })
+            });
+            const data = await res.json();
+            this.sessionToken = data.session_token;
+            this.startHeartbeat();
+            this.startPlaybackTracking();
+        } catch (e) {
+            console.error('Failed to start analytics session:', e);
+        }
+    }
+
+    startHeartbeat() {
+        this.heartbeatInterval = setInterval(() => this.sendHeartbeat(), 30000);
+    }
+
+    startPlaybackTracking() {
+        // Track actual playback time (not just video time)
+        this.playbackTimer = setInterval(() => {
+            if (!this.player.paused()) {
+                this.playbackSeconds++;
+
+                // Count view after minimum playback threshold
+                if (!this.viewCounted && this.playbackSeconds >= this.minPlaybackSeconds) {
+                    this.viewCounted = true;
+                    debugLog('View counted after', this.minPlaybackSeconds, 'seconds');
+                }
+            }
+        }, 1000);
+    }
+
+    async sendHeartbeat() {
+        if (!this.sessionToken) return;
+
+        try {
+            await fetch('/api/analytics/heartbeat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({
+                    session_token: this.sessionToken,
+                    position: this.player.currentTime(),
+                    quality: this.getCurrentQuality(),
+                    playing: !this.player.paused(),
+                    session_uuid: this.sessionUUID
+                })
+            });
+        } catch (e) {
+            console.error('Heartbeat failed:', e);
+        }
+    }
+
+    getCurrentQuality() {
+        const qualityLevels = this.player.qualityLevels?.();
+        if (qualityLevels && Array.isArray(qualityLevels)) {
+            const activeTrack = qualityLevels.find(t => t.active);
+            if (activeTrack) {
+                return activeTrack.height + 'p';
+            }
+        }
+        return null;
+    }
+
+    async endSession(completed = false) {
+        if (!this.sessionToken) return;
+
+        clearInterval(this.heartbeatInterval);
+        clearInterval(this.playbackTimer);
+
+        try {
+            const data = JSON.stringify({
+                session_token: this.sessionToken,
+                position: this.player.currentTime(),
+                completed: completed
+            });
+
+            if (navigator.sendBeacon) {
+                navigator.sendBeacon('/api/analytics/end', new Blob([data], { type: 'application/json' }));
+            } else {
+                await fetch('/api/analytics/end', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: data
+                });
+            }
+        } catch (e) {
+            console.error('Failed to end session:', e);
+        }
+
+        this.sessionToken = null;
+    }
+}
+
+/**
+ * Embed player initialization
+ */
+class EmbedPlayer {
+    constructor() {
+        this.video = null;
+        this.videoData = null;
+        this.playerControls = null;
+        this.analytics = null;
+        this.hls = null;
+        this.shakaPlayer = null;
+
+        // Parse embed configuration from URL
+        this.config = window.EMBED_CONFIG || {
+            slug: window.location.pathname.split('/').pop(),
+            params: new URLSearchParams(window.location.search)
+        };
+
+        // Parse query parameters
+        this.autoplay = this.parseBoolean(this.config.params.get('autoplay'), false);
+        this.startTime = this.parseNumber(this.config.params.get('start'), 0);
+        this.showControls = this.parseBoolean(this.config.params.get('controls'), true);
+
+        debugLog('Embed config:', {
+            slug: this.config.slug,
+            autoplay: this.autoplay,
+            startTime: this.startTime,
+            showControls: this.showControls
+        });
+    }
+
+    parseBoolean(value, defaultValue) {
+        if (value === null || value === undefined) return defaultValue;
+        return value === '1' || value === 'true';
+    }
+
+    parseNumber(value, defaultValue) {
+        if (value === null || value === undefined) return defaultValue;
+        const num = parseInt(value, 10);
+        return isNaN(num) || num < 0 ? defaultValue : num;
+    }
+
+    showError(message = 'Video unavailable') {
+        document.getElementById('embed-loading').style.display = 'none';
+        document.getElementById('embed-player-container').style.display = 'none';
+
+        const errorEl = document.getElementById('embed-error');
+        const errorMsg = document.getElementById('embed-error-message');
+        errorMsg.textContent = message;
+        errorEl.style.display = 'flex';
+    }
+
+    showPlayer() {
+        document.getElementById('embed-loading').style.display = 'none';
+        document.getElementById('embed-error').style.display = 'none';
+        document.getElementById('embed-player-container').style.display = 'block';
+    }
+
+    async init() {
+        const slug = this.config.slug;
+
+        // Validate slug
+        if (!slug || !SLUG_PATTERN.test(slug)) {
+            this.showError('Video not found');
+            return;
+        }
+
+        try {
+            // Fetch video data
+            const res = await fetch(`/api/videos/${encodeURIComponent(slug)}`);
+            if (!res.ok) {
+                this.showError('Video not found');
+                return;
+            }
+
+            this.videoData = await res.json();
+
+            // Check video is ready
+            if (this.videoData.status !== 'ready') {
+                this.showError('Video is being prepared');
+                return;
+            }
+
+            // Initialize player
+            this.showPlayer();
+            this.initPlayer();
+
+        } catch (e) {
+            console.error('Failed to load video:', e);
+            this.showError('Unable to load video');
+        }
+    }
+
+    initPlayer() {
+        this.video = document.getElementById('player');
+        const container = document.getElementById('player-container');
+        const streamUrl = this.videoData.stream_url;
+        const dashUrl = this.videoData.dash_url;
+        const streamingFormat = this.videoData.streaming_format || 'hls_ts';
+
+        debugLog('Initializing player, format:', streamingFormat);
+
+        // Set poster image
+        if (this.videoData.thumbnail_url) {
+            this.video.poster = this.videoData.thumbnail_url;
+        }
+
+        // Use Shaka Player for CMAF/DASH content
+        if (typeof shaka !== 'undefined' && dashUrl && streamingFormat === 'cmaf') {
+            this.initShakaPlayer(dashUrl, streamUrl);
+        } else if (typeof Hls !== 'undefined' && Hls.isSupported()) {
+            this.initHlsPlayer(streamUrl);
+        } else if (this.video.canPlayType('application/vnd.apple.mpegurl')) {
+            // Safari native HLS
+            debugLog('Using native HLS support');
+            this.video.src = streamUrl;
+        } else {
+            this.showError('Playback not supported');
+            return;
+        }
+
+        // Initialize custom controls or keep native
+        if (this.showControls) {
+            try {
+                if (window.VLogPlayerControls) {
+                    this.video.removeAttribute('controls');
+                    this.playerControls = new VLogPlayerControls(container, this.video, {
+                        onQualityChange: (index) => this.changeQuality(index),
+                        // Disable share button in embed mode
+                        disableShare: true
+                    });
+
+                    // Set chapters if available
+                    if (this.videoData.chapters && this.videoData.chapters.length > 0) {
+                        this.playerControls.setChapters(this.videoData.chapters);
+                    }
+
+                    // Set sprite sheet info
+                    if (this.videoData.sprite_sheet_info) {
+                        this.playerControls.setSpriteSheetInfo(this.videoData.sprite_sheet_info);
+                    }
+                }
+            } catch (e) {
+                console.error('Failed to init custom controls:', e);
+                this.video.controls = true;
+            }
+        } else {
+            // Hide controls if disabled
+            this.video.controls = false;
+        }
+
+        // Initialize analytics
+        this.analytics = new EmbedAnalytics(this.videoData.id, {
+            currentTime: () => this.video.currentTime,
+            paused: () => this.video.paused,
+            qualityLevels: () => {
+                if (this.shakaPlayer) {
+                    return this.shakaPlayer.getVariantTracks();
+                }
+                return this.hls ? this.hls.levels : null;
+            }
+        });
+
+        // Start session on first play
+        this.video.addEventListener('play', () => {
+            let quality = 'auto';
+            if (this.shakaPlayer) {
+                const tracks = this.shakaPlayer.getVariantTracks();
+                const active = tracks.find(t => t.active);
+                if (active) quality = active.height + 'p';
+            } else if (this.hls?.levels?.[this.hls.currentLevel]) {
+                quality = this.hls.levels[this.hls.currentLevel].height + 'p';
+            }
+            this.analytics.startSession(quality);
+        }, { once: true });
+
+        // End session on video complete or unload
+        this.video.addEventListener('ended', () => {
+            this.analytics.endSession(true);
+        });
+
+        window.addEventListener('beforeunload', () => {
+            this.analytics.endSession(false);
+        });
+
+        // Handle start time
+        if (this.startTime > 0) {
+            const seekToStart = () => {
+                if (this.video.duration && this.startTime < this.video.duration) {
+                    this.video.currentTime = this.startTime;
+                    debugLog('Seeking to start time:', this.startTime);
+                }
+            };
+
+            if (this.video.readyState >= 1) {
+                seekToStart();
+            } else {
+                this.video.addEventListener('loadedmetadata', seekToStart, { once: true });
+            }
+        }
+
+        // Handle autoplay
+        if (this.autoplay) {
+            this.video.muted = true; // Required for autoplay without user interaction
+            this.video.play().catch(e => {
+                debugLog('Autoplay failed:', e);
+            });
+        }
+    }
+
+    initShakaPlayer(dashUrl, hlsUrl) {
+        shaka.polyfill.installAll();
+
+        if (!shaka.Player.isBrowserSupported()) {
+            debugLog('Shaka not supported, falling back to HLS');
+            this.initHlsPlayer(hlsUrl);
+            return;
+        }
+
+        this.shakaPlayer = new shaka.Player(this.video);
+
+        this.shakaPlayer.addEventListener('error', (event) => {
+            console.error('Shaka error:', event.detail);
+            // Fallback to HLS on error
+            this.shakaPlayer.destroy();
+            this.shakaPlayer = null;
+            this.initHlsPlayer(hlsUrl);
+        });
+
+        this.shakaPlayer.load(dashUrl).then(() => {
+            debugLog('Shaka player loaded');
+            this.updateQualityLevels();
+        }).catch((error) => {
+            console.error('Shaka load failed:', error);
+            this.shakaPlayer.destroy();
+            this.shakaPlayer = null;
+            this.initHlsPlayer(hlsUrl);
+        });
+    }
+
+    initHlsPlayer(streamUrl) {
+        this.hls = new Hls({
+            enableWorker: true,
+            lowLatencyMode: false
+        });
+
+        this.hls.loadSource(streamUrl);
+        this.hls.attachMedia(this.video);
+
+        this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
+            debugLog('HLS manifest parsed');
+            this.updateQualityLevels();
+        });
+
+        this.hls.on(Hls.Events.ERROR, (event, data) => {
+            if (data.fatal) {
+                console.error('HLS fatal error:', data.type, data.details);
+                this.showError('Playback error');
+            }
+        });
+    }
+
+    updateQualityLevels() {
+        if (!this.playerControls) return;
+
+        let levels = [];
+
+        if (this.shakaPlayer) {
+            levels = this.shakaPlayer.getVariantTracks().map(track => ({
+                height: track.height,
+                width: track.width,
+                bitrate: track.bandwidth
+            }));
+        } else if (this.hls) {
+            levels = this.hls.levels.map(level => ({
+                height: level.height,
+                width: level.width,
+                bitrate: level.bitrate
+            }));
+        }
+
+        // Sort by height descending
+        levels.sort((a, b) => b.height - a.height);
+
+        // Add auto option
+        const qualityOptions = [
+            { label: 'Auto', value: -1 },
+            ...levels.map((level, index) => ({
+                label: level.height + 'p',
+                value: index
+            }))
+        ];
+
+        this.playerControls.setQualityLevels(qualityOptions);
+    }
+
+    changeQuality(index) {
+        if (index === -1) {
+            // Auto
+            if (this.shakaPlayer) {
+                this.shakaPlayer.configure({ abr: { enabled: true } });
+            } else if (this.hls) {
+                this.hls.currentLevel = -1;
+            }
+        } else {
+            if (this.shakaPlayer) {
+                this.shakaPlayer.configure({ abr: { enabled: false } });
+                const tracks = this.shakaPlayer.getVariantTracks();
+                if (tracks[index]) {
+                    this.shakaPlayer.selectVariantTrack(tracks[index], true);
+                }
+            } else if (this.hls) {
+                this.hls.currentLevel = index;
+            }
+        }
+    }
+}
+
+// Initialize when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    const embedPlayer = new EmbedPlayer();
+    embedPlayer.init();
+});

--- a/web/public/static/js/pages/embed.js
+++ b/web/public/static/js/pages/embed.js
@@ -65,12 +65,12 @@ async function fetchWithTimeout(url, options = {}, timeout = 10000) {
  */
 function generateSecureUUID() {
     // Use native crypto.randomUUID if available (modern browsers)
-    if (crypto && crypto.randomUUID) {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
         return crypto.randomUUID();
     }
 
     // Fallback using crypto.getRandomValues
-    if (crypto && crypto.getRandomValues) {
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
         const bytes = new Uint8Array(16);
         crypto.getRandomValues(bytes);
         // Set version (4) and variant (8, 9, A, or B)
@@ -246,9 +246,24 @@ class EmbedAnalytics {
     getCurrentQuality() {
         const qualityLevels = this.player.qualityLevels?.();
         if (qualityLevels && Array.isArray(qualityLevels)) {
+            // Check for Shaka-style active track first
             const activeTrack = qualityLevels.find(t => t.active);
-            if (activeTrack) {
+            if (activeTrack && typeof activeTrack.height === 'number') {
                 return activeTrack.height + 'p';
+            }
+
+            // For HLS.js: use currentLevelIndex to find the active level
+            const currentLevelIndex = this.player.currentLevelIndex?.();
+            if (typeof currentLevelIndex === 'number' && currentLevelIndex >= 0) {
+                const currentLevel = qualityLevels[currentLevelIndex];
+                if (currentLevel && typeof currentLevel.height === 'number') {
+                    return currentLevel.height + 'p';
+                }
+            }
+
+            // Auto mode or unknown - return 'auto' instead of null
+            if (currentLevelIndex === -1) {
+                return 'auto';
             }
         }
         return null;
@@ -340,19 +355,19 @@ class EmbedPlayer {
     }
 
     showError(message = 'Video unavailable') {
-        document.getElementById('embed-loading').style.display = 'none';
-        document.getElementById('embed-player-container').style.display = 'none';
+        document.getElementById('embed-loading').classList.add('embed-hidden');
+        document.getElementById('embed-player-container').classList.add('embed-hidden');
 
         const errorEl = document.getElementById('embed-error');
         const errorMsg = document.getElementById('embed-error-message');
         errorMsg.textContent = message;
-        errorEl.style.display = 'flex';
+        errorEl.classList.remove('embed-hidden');
     }
 
     showPlayer() {
-        document.getElementById('embed-loading').style.display = 'none';
-        document.getElementById('embed-error').style.display = 'none';
-        document.getElementById('embed-player-container').style.display = 'block';
+        document.getElementById('embed-loading').classList.add('embed-hidden');
+        document.getElementById('embed-error').classList.add('embed-hidden');
+        document.getElementById('embed-player-container').classList.remove('embed-hidden');
     }
 
     async init() {
@@ -484,7 +499,7 @@ class EmbedPlayer {
             this.video.controls = false;
         }
 
-        // Initialize analytics
+        // Initialize analytics with player interface
         this.analytics = new EmbedAnalytics(this.videoData.id, {
             currentTime: () => this.video.currentTime,
             paused: () => this.video.paused,
@@ -493,6 +508,10 @@ class EmbedPlayer {
                     return this.shakaPlayer.getVariantTracks();
                 }
                 return this.hls ? this.hls.levels : null;
+            },
+            // For HLS.js: get current level index (-1 = auto)
+            currentLevelIndex: () => {
+                return this.hls ? this.hls.currentLevel : -1;
             }
         });
 
@@ -597,28 +616,30 @@ class EmbedPlayer {
         let levels = [];
 
         if (this.shakaPlayer) {
-            levels = this.shakaPlayer.getVariantTracks().map(track => ({
+            levels = this.shakaPlayer.getVariantTracks().map((track, originalIndex) => ({
                 height: track.height,
                 width: track.width,
-                bitrate: track.bandwidth
+                bitrate: track.bandwidth,
+                originalIndex: originalIndex
             }));
         } else if (this.hls) {
-            levels = this.hls.levels.map(level => ({
+            levels = this.hls.levels.map((level, originalIndex) => ({
                 height: level.height,
                 width: level.width,
-                bitrate: level.bitrate
+                bitrate: level.bitrate,
+                originalIndex: originalIndex
             }));
         }
 
-        // Sort by height descending
+        // Sort by height descending (for display order)
         levels.sort((a, b) => b.height - a.height);
 
-        // Add auto option
+        // Add auto option; use originalIndex so changeQuality() sets the correct level
         const qualityOptions = [
             { label: 'Auto', value: -1 },
-            ...levels.map((level, index) => ({
+            ...levels.map(level => ({
                 label: level.height + 'p',
-                value: index
+                value: level.originalIndex
             }))
         ];
 

--- a/web/public/static/js/player-controls.js
+++ b/web/public/static/js/player-controls.js
@@ -62,6 +62,9 @@ class VLogPlayerControls {
         this.onQualityChange = options.onQualityChange || (() => {});
         this.onCaptionsToggle = options.onCaptionsToggle || (() => {});
 
+        // Feature flags (Issue #210)
+        this.disableShare = options.disableShare || false;
+
         // Chapters state (Issue #413 Phase 7A)
         this.chapters = [];
         this.currentChapterIndex = -1;
@@ -326,7 +329,7 @@ class VLogPlayerControls {
         `;
         this.container.appendChild(this.shortcutsModal);
 
-        // Share modal (Issue #413 Phase 5)
+        // Share modal (Issue #413 Phase 5, extended for embed in Issue #210)
         this.shareModal = document.createElement('div');
         this.shareModal.className = 'player-share-modal';
         this.shareModal.setAttribute('role', 'dialog');
@@ -344,18 +347,48 @@ class VLogPlayerControls {
                         </svg>
                     </button>
                 </div>
+                <div class="share-modal-tabs" role="tablist" aria-label="Share options">
+                    <button class="share-modal-tab active" role="tab" aria-selected="true" aria-controls="share-tab-link" id="share-tab-btn-link" data-tab="link">Link</button>
+                    <button class="share-modal-tab" role="tab" aria-selected="false" aria-controls="share-tab-embed" id="share-tab-btn-embed" data-tab="embed">Embed</button>
+                </div>
                 <div class="share-modal-body">
-                    <input type="text" class="share-modal-input" readonly aria-label="Video URL">
-                    <button class="share-modal-copy" aria-label="Copy link">
-                        <svg viewBox="0 0 24 24" fill="currentColor" class="share-copy-icon">
-                            <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
-                        </svg>
-                        <span class="share-modal-copy-text">Copy</span>
-                    </button>
+                    <!-- Link Tab -->
+                    <div class="share-tab-content" id="share-tab-link" role="tabpanel" aria-labelledby="share-tab-btn-link">
+                        <input type="text" class="share-modal-input" readonly aria-label="Video URL">
+                        <button class="share-modal-copy" aria-label="Copy link">
+                            <svg viewBox="0 0 24 24" fill="currentColor" class="share-copy-icon">
+                                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                            </svg>
+                            <span class="share-modal-copy-text">Copy</span>
+                        </button>
+                    </div>
+                    <!-- Embed Tab (Issue #210) -->
+                    <div class="share-tab-content" id="share-tab-embed" role="tabpanel" aria-labelledby="share-tab-btn-embed" style="display: none;">
+                        <div class="embed-options">
+                            <label class="embed-option">
+                                <span>Start at</span>
+                                <input type="text" class="embed-start-time" placeholder="0:00" aria-label="Start time">
+                            </label>
+                            <label class="embed-option embed-option-checkbox">
+                                <input type="checkbox" class="embed-autoplay">
+                                <span>Autoplay</span>
+                            </label>
+                        </div>
+                        <textarea class="embed-code-textarea" readonly aria-label="Embed code" rows="3"></textarea>
+                        <button class="share-modal-copy embed-copy-btn" aria-label="Copy embed code">
+                            <svg viewBox="0 0 24 24" fill="currentColor" class="share-copy-icon">
+                                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                            </svg>
+                            <span class="embed-copy-text">Copy</span>
+                        </button>
+                    </div>
                 </div>
             </div>
         `;
         this.container.appendChild(this.shareModal);
+
+        // Share modal current tab state
+        this.shareCurrentTab = 'link';
 
         // Chapters panel (Issue #413 Phase 7)
         this.chaptersPanel = document.createElement('div');
@@ -409,6 +442,15 @@ class VLogPlayerControls {
         this.shareCopyBtn = this.shareModal.querySelector('.share-modal-copy');
         this.shareCloseBtn = this.shareModal.querySelector('.share-close-btn');
 
+        // Embed tab references (Issue #210)
+        this.shareTabBtns = this.shareModal.querySelectorAll('.share-modal-tab');
+        this.shareLinkTabContent = this.shareModal.querySelector('#share-tab-link');
+        this.shareEmbedTabContent = this.shareModal.querySelector('#share-tab-embed');
+        this.embedStartTimeInput = this.shareModal.querySelector('.embed-start-time');
+        this.embedAutoplayCheckbox = this.shareModal.querySelector('.embed-autoplay');
+        this.embedCodeTextarea = this.shareModal.querySelector('.embed-code-textarea');
+        this.embedCopyBtn = this.shareModal.querySelector('.embed-copy-btn');
+
         // Chapters references (Issue #413 Phase 7A)
         this.chaptersBtn = this.controlBar.querySelector('.chapters-btn');
         this.chapterMarkers = this.controlBar.querySelector('.player-chapter-markers');
@@ -421,6 +463,11 @@ class VLogPlayerControls {
 
         // Build speed options after DOM refs are cached
         this.buildSpeedOptions();
+
+        // Hide share button if disabled (Issue #210 - embed mode)
+        if (this.disableShare && this.shareBtn) {
+            this.shareBtn.style.display = 'none';
+        }
     }
 
     bindEvents() {
@@ -568,6 +615,23 @@ class VLogPlayerControls {
         });
         this.shareCopyBtn.addEventListener('click', () => {
             this.copyShareLink();
+        });
+
+        // Embed tab event handlers (Issue #210)
+        this.shareTabBtns.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const tab = btn.dataset.tab;
+                this.switchShareTab(tab);
+            });
+        });
+        this.embedStartTimeInput.addEventListener('input', () => {
+            this.updateEmbedCode();
+        });
+        this.embedAutoplayCheckbox.addEventListener('change', () => {
+            this.updateEmbedCode();
+        });
+        this.embedCopyBtn.addEventListener('click', () => {
+            this.copyEmbedCode();
         });
 
         // Chapters button and panel (Issue #413 Phase 7)
@@ -1139,6 +1203,20 @@ class VLogPlayerControls {
         const shareUrl = window.location.origin + window.location.pathname;
         this.shareInput.value = shareUrl;
 
+        // Reset to link tab (Issue #210)
+        this.shareCurrentTab = 'link';
+        this.shareTabBtns.forEach(btn => {
+            const isLink = btn.dataset.tab === 'link';
+            btn.classList.toggle('active', isLink);
+            btn.setAttribute('aria-selected', isLink.toString());
+        });
+        this.shareLinkTabContent.style.display = 'block';
+        this.shareEmbedTabContent.style.display = 'none';
+
+        // Reset embed options
+        this.embedStartTimeInput.value = '';
+        this.embedAutoplayCheckbox.checked = false;
+
         this.shareModal.classList.add('visible');
         this.shareModal.setAttribute('aria-hidden', 'false');
         this.shareBtn.setAttribute('aria-expanded', 'true');
@@ -1188,6 +1266,115 @@ class VLogPlayerControls {
             console.error('Copy failed:', err);
 
             // Provide more specific error messages
+            const message = err.name === 'NotAllowedError'
+                ? 'Permission denied'
+                : 'Copy failed';
+            copyText.textContent = message;
+
+            setTimeout(() => {
+                copyText.textContent = 'Copy';
+            }, 2000);
+        }
+    }
+
+    // Embed tab methods (Issue #210)
+    switchShareTab(tab) {
+        if (tab === this.shareCurrentTab) return;
+
+        this.shareCurrentTab = tab;
+
+        // Update tab button states
+        this.shareTabBtns.forEach(btn => {
+            const isActive = btn.dataset.tab === tab;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-selected', isActive.toString());
+        });
+
+        // Show/hide tab content
+        this.shareLinkTabContent.style.display = tab === 'link' ? 'block' : 'none';
+        this.shareEmbedTabContent.style.display = tab === 'embed' ? 'block' : 'none';
+
+        // Focus appropriate element
+        if (tab === 'link') {
+            this.shareCopyBtn.focus();
+        } else {
+            // Generate embed code when switching to embed tab
+            this.updateEmbedCode();
+            this.embedCopyBtn.focus();
+        }
+    }
+
+    updateEmbedCode() {
+        // Get current video URL slug
+        const pathParts = window.location.pathname.split('/');
+        const slug = pathParts[pathParts.length - 1] || pathParts[pathParts.length - 2];
+
+        // Build embed URL with parameters
+        const embedUrl = new URL(`${window.location.origin}/embed/${slug}`);
+
+        // Parse start time input (format: "1:30" or "90")
+        const startTimeValue = this.embedStartTimeInput.value.trim();
+        if (startTimeValue) {
+            const startSeconds = this.parseTimeInput(startTimeValue);
+            if (startSeconds > 0) {
+                embedUrl.searchParams.set('start', startSeconds.toString());
+            }
+        }
+
+        // Add autoplay parameter
+        if (this.embedAutoplayCheckbox.checked) {
+            embedUrl.searchParams.set('autoplay', '1');
+        }
+
+        // Generate iframe HTML
+        const iframeHtml = `<iframe src="${embedUrl.toString()}" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>`;
+
+        this.embedCodeTextarea.value = iframeHtml;
+    }
+
+    parseTimeInput(value) {
+        // Handle MM:SS or H:MM:SS format
+        if (value.includes(':')) {
+            const parts = value.split(':').map(p => parseInt(p, 10) || 0);
+            if (parts.length === 2) {
+                return parts[0] * 60 + parts[1];
+            } else if (parts.length === 3) {
+                return parts[0] * 3600 + parts[1] * 60 + parts[2];
+            }
+        }
+        // Handle plain seconds
+        const seconds = parseInt(value, 10);
+        return isNaN(seconds) || seconds < 0 ? 0 : seconds;
+    }
+
+    async copyEmbedCode() {
+        const code = this.embedCodeTextarea.value;
+        const copyText = this.embedCopyBtn.querySelector('.embed-copy-text');
+
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(code);
+            } else {
+                // Fallback for HTTP or older browsers
+                this.embedCodeTextarea.select();
+                this.embedCodeTextarea.setSelectionRange(0, 99999);
+                const success = document.execCommand('copy');
+                if (!success) {
+                    throw new Error('execCommand copy returned false');
+                }
+            }
+
+            copyText.textContent = 'Copied!';
+            this.embedCopyBtn.classList.add('copied');
+            this._announce('Embed code copied to clipboard');
+
+            setTimeout(() => {
+                copyText.textContent = 'Copy';
+                this.embedCopyBtn.classList.remove('copied');
+            }, 2000);
+        } catch (err) {
+            console.error('Copy failed:', err);
+
             const message = err.name === 'NotAllowedError'
                 ? 'Permission denied'
                 : 'Copy failed';

--- a/web/public/static/js/player-controls.js
+++ b/web/public/static/js/player-controls.js
@@ -444,8 +444,8 @@ class VLogPlayerControls {
 
         // Embed tab references (Issue #210)
         this.shareTabBtns = this.shareModal.querySelectorAll('.share-modal-tab');
-        this.shareLinkTabContent = this.shareModal.querySelector('#share-tab-link');
-        this.shareEmbedTabContent = this.shareModal.querySelector('#share-tab-embed');
+        this.shareTabLink = this.shareModal.querySelector('#share-tab-link');
+        this.shareTabEmbed = this.shareModal.querySelector('#share-tab-embed');
         this.embedStartTimeInput = this.shareModal.querySelector('.embed-start-time');
         this.embedAutoplayCheckbox = this.shareModal.querySelector('.embed-autoplay');
         this.embedCodeTextarea = this.shareModal.querySelector('.embed-code-textarea');
@@ -624,8 +624,11 @@ class VLogPlayerControls {
                 this.switchShareTab(tab);
             });
         });
+        // Debounce start time input to avoid excessive updates during typing
+        let embedCodeDebounceTimer = null;
         this.embedStartTimeInput.addEventListener('input', () => {
-            this.updateEmbedCode();
+            clearTimeout(embedCodeDebounceTimer);
+            embedCodeDebounceTimer = setTimeout(() => this.updateEmbedCode(), 300);
         });
         this.embedAutoplayCheckbox.addEventListener('change', () => {
             this.updateEmbedCode();
@@ -1210,8 +1213,8 @@ class VLogPlayerControls {
             btn.classList.toggle('active', isLink);
             btn.setAttribute('aria-selected', isLink.toString());
         });
-        this.shareLinkTabContent.style.display = 'block';
-        this.shareEmbedTabContent.style.display = 'none';
+        this.shareTabLink.style.display = 'block';
+        this.shareTabEmbed.style.display = 'none';
 
         // Reset embed options
         this.embedStartTimeInput.value = '';
@@ -1291,8 +1294,8 @@ class VLogPlayerControls {
         });
 
         // Show/hide tab content
-        this.shareLinkTabContent.style.display = tab === 'link' ? 'block' : 'none';
-        this.shareEmbedTabContent.style.display = tab === 'embed' ? 'block' : 'none';
+        this.shareTabLink.style.display = tab === 'link' ? 'block' : 'none';
+        this.shareTabEmbed.style.display = tab === 'embed' ? 'block' : 'none';
 
         // Focus appropriate element
         if (tab === 'link') {
@@ -1312,10 +1315,10 @@ class VLogPlayerControls {
         // Build embed URL with parameters
         const embedUrl = new URL(`${window.location.origin}/embed/${slug}`);
 
-        // Parse start time input (format: "1:30" or "90")
+        // Convert start time input to seconds (supports "1:30" or "90" formats)
         const startTimeValue = this.embedStartTimeInput.value.trim();
         if (startTimeValue) {
-            const startSeconds = this.parseTimeInput(startTimeValue);
+            const startSeconds = this.convertTimeFormatToSeconds(startTimeValue);
             if (startSeconds > 0) {
                 embedUrl.searchParams.set('start', startSeconds.toString());
             }
@@ -1326,25 +1329,58 @@ class VLogPlayerControls {
             embedUrl.searchParams.set('autoplay', '1');
         }
 
-        // Generate iframe HTML
-        const iframeHtml = `<iframe src="${embedUrl.toString()}" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>`;
+        // Generate iframe HTML (matches server-side format with picture-in-picture)
+        const iframeHtml = `<iframe src="${embedUrl.toString()}" width="560" height="315" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>`;
 
         this.embedCodeTextarea.value = iframeHtml;
     }
 
-    parseTimeInput(value) {
+    /**
+     * Convert time format string to seconds
+     * Supports: "90" (seconds), "1:30" (MM:SS), "1:30:00" (H:MM:SS)
+     * @param {string} value - Time string to parse
+     * @returns {number} Time in seconds (0 if invalid)
+     */
+    convertTimeFormatToSeconds(value) {
+        if (!value) return 0;
+
+        // Maximum allowed time: 24 hours (prevents unreasonable values)
+        const MAX_SECONDS = 86400;
+
+        let totalSeconds = 0;
+
         // Handle MM:SS or H:MM:SS format
         if (value.includes(':')) {
-            const parts = value.split(':').map(p => parseInt(p, 10) || 0);
+            const parts = value.split(':').map(p => {
+                const num = parseInt(p, 10);
+                return isNaN(num) ? 0 : num;
+            });
+
             if (parts.length === 2) {
-                return parts[0] * 60 + parts[1];
+                // MM:SS - cap seconds at 59 for normalization
+                const minutes = parts[0];
+                const seconds = Math.min(parts[1], 59);
+                totalSeconds = minutes * 60 + seconds;
             } else if (parts.length === 3) {
-                return parts[0] * 3600 + parts[1] * 60 + parts[2];
+                // H:MM:SS - cap each component
+                const hours = parts[0];
+                const minutes = Math.min(parts[1], 59);
+                const seconds = Math.min(parts[2], 59);
+                totalSeconds = hours * 3600 + minutes * 60 + seconds;
             }
+        } else {
+            // Handle plain seconds
+            const seconds = parseInt(value, 10);
+            totalSeconds = isNaN(seconds) || seconds < 0 ? 0 : seconds;
         }
-        // Handle plain seconds
-        const seconds = parseInt(value, 10);
-        return isNaN(seconds) || seconds < 0 ? 0 : seconds;
+
+        // Cap at maximum
+        if (totalSeconds > MAX_SECONDS) {
+            console.warn(`Start time ${totalSeconds}s exceeds maximum ${MAX_SECONDS}s, capping`);
+            return MAX_SECONDS;
+        }
+
+        return totalSeconds;
     }
 
     async copyEmbedCode() {


### PR DESCRIPTION
## Summary

- Add iframe embed code generation for videos to be embedded on external websites
- Create minimal, responsive embed player with security-first design
- Extend share modal with Link/Embed tabs for easy embed code access

## Changes

### Backend
- `/embed/{slug}` route with CSP frame-ancestors header for domain control
- `/api/v1/videos/{slug}/embed-code` endpoint returning iframe HTML
- Embed configuration in `config.py` with security-first defaults
- Settings service integration for admin UI visibility

### Frontend
- `embed.html` - Minimal embed player template
- `embed-error.html` - Clean error display for unavailable videos
- `embed.js` - Player initialization with analytics tracking (source='embed')
- `embed.css` - Responsive styles, hides share/theater buttons
- Share modal extended with tabs, start time input, autoplay option

### Security Features
- Domain whitelist defaults to `'self'` only
- Optional `EMBED_ALLOW_ALL_DOMAINS=true` for public embeds
- Rate limiting: 500/min per IP for embed routes
- View count protection: 5+ seconds minimum playback
- Query parameter validation (start, autoplay, controls)

## Test plan

- [ ] Navigate to a video and open share modal - verify Link/Embed tabs appear
- [ ] Switch to Embed tab - verify iframe code is generated
- [ ] Enter start time (e.g., "1:30") - verify code updates with `?start=90`
- [ ] Check autoplay - verify code updates with `?autoplay=1`
- [ ] Copy embed code - verify clipboard contains correct iframe HTML
- [ ] Load `/embed/{slug}` directly - verify minimal player works
- [ ] Load `/embed/nonexistent` - verify error page displays
- [ ] Embed iframe on external test page - verify video plays correctly
- [ ] Check CSP header on embed page - verify `frame-ancestors 'self'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)