### PR TITLE
feat(workers): Add API key expiration and rotation support (#226)

### DIFF
--- a/api/audit.py
+++ b/api/audit.py
@@ -85,6 +85,10 @@ class AuditAction(str, Enum):
     WORKER_DISABLE = "worker_disable"
     WORKER_ENABLE = "worker_enable"
     WORKER_DELETE = "worker_delete"
+    # API key rotation actions (Issue #226)
+    WORKER_KEY_ROTATE = "worker_key_rotate"
+    WORKER_KEY_EXPIRED = "worker_key_expired"
+    WORKER_BULK_REVOKE = "worker_bulk_revoke"
 
     # Settings actions
     SETTINGS_CHANGE = "settings_change"

--- a/api/audit.py
+++ b/api/audit.py
@@ -87,7 +87,6 @@ class AuditAction(str, Enum):
     WORKER_DELETE = "worker_delete"
     # API key rotation actions (Issue #226)
     WORKER_KEY_ROTATE = "worker_key_rotate"
-    WORKER_KEY_EXPIRED = "worker_key_expired"
     WORKER_BULK_REVOKE = "worker_bulk_revoke"
 
     # Settings actions

--- a/api/database.py
+++ b/api/database.py
@@ -439,6 +439,7 @@ worker_api_keys = sa.Table(
     sa.Index("ix_worker_api_keys_key_prefix", "key_prefix"),
     sa.Index("ix_worker_api_keys_worker_id", "worker_id"),
     sa.Index("ix_worker_api_keys_rotated_from", "rotated_from"),
+    sa.Index("ix_worker_api_keys_expires_at", "expires_at"),
 )
 
 # Deployment events for worker management (Issue #410)

--- a/api/database.py
+++ b/api/database.py
@@ -428,8 +428,17 @@ worker_api_keys = sa.Table(
     sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
     sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
     sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+    # Rotation tracking (Issue #226): self-referential FK to track key rotation chain
+    # NULL = original key, otherwise points to the previous key that was rotated
+    sa.Column(
+        "rotated_from",
+        sa.Integer,
+        sa.ForeignKey("worker_api_keys.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
     sa.Index("ix_worker_api_keys_key_prefix", "key_prefix"),
     sa.Index("ix_worker_api_keys_worker_id", "worker_id"),
+    sa.Index("ix_worker_api_keys_rotated_from", "rotated_from"),
 )
 
 # Deployment events for worker management (Issue #410)

--- a/api/settings_service.py
+++ b/api/settings_service.py
@@ -845,6 +845,35 @@ KNOWN_SETTINGS = [
         "Debounce delay for filesystem events (seconds)",
         {"min": 0.0, "max": 60.0},
     ),
+    # API key expiration and rotation settings (Issue #226)
+    (
+        "workers.api_key_expiration_days",
+        "workers",
+        "integer",
+        "API key expiration in days (0 = never expires)",
+        {"min": 0, "max": 365},
+    ),
+    (
+        "workers.api_key_grace_period_hours",
+        "workers",
+        "integer",
+        "Grace period after expiration where key still works with warning (max 24)",
+        {"min": 0, "max": 24},
+    ),
+    (
+        "workers.api_key_rotation_overlap_hours",
+        "workers",
+        "integer",
+        "Hours old key remains valid after rotation (max 24)",
+        {"min": 0, "max": 24},
+    ),
+    (
+        "workers.api_key_expiration_warning_days",
+        "workers",
+        "integer",
+        "Days before expiration to show warnings",
+        {"min": 1, "max": 90},
+    ),
     # Analytics settings
     ("analytics.cache_enabled", "analytics", "boolean", "Enable analytics caching", None),
     ("analytics.cache_ttl", "analytics", "integer", "Analytics cache TTL in seconds", {"min": 1, "max": 3600}),
@@ -1293,6 +1322,11 @@ SETTING_TO_ENV_MAP = {
     "workers.offline_threshold_minutes": "VLOG_WORKER_OFFLINE_THRESHOLD",
     "workers.fallback_poll_interval": "VLOG_WORKER_FALLBACK_POLL_INTERVAL",
     "workers.debounce_delay": "VLOG_WORKER_DEBOUNCE_DELAY",
+    # API key expiration/rotation settings (Issue #226)
+    "workers.api_key_expiration_days": "VLOG_WORKER_API_KEY_EXPIRATION_DAYS",
+    "workers.api_key_grace_period_hours": "VLOG_WORKER_API_KEY_GRACE_PERIOD_HOURS",
+    "workers.api_key_rotation_overlap_hours": "VLOG_WORKER_API_KEY_ROTATION_OVERLAP_HOURS",
+    "workers.api_key_expiration_warning_days": "VLOG_WORKER_API_KEY_EXPIRATION_WARNING_DAYS",
     # Analytics settings
     "analytics.cache_enabled": "VLOG_ANALYTICS_CACHE_ENABLED",
     "analytics.cache_ttl": "VLOG_ANALYTICS_CACHE_TTL",

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -3076,7 +3076,7 @@ async def revoke_worker(
 
 
 @v1_router.post("/workers/{worker_id}/rotate", response_model=KeyRotationResponse)
-@limiter.limit("10/hour")  # Rate limit: 10 rotations per worker per hour
+@limiter.limit("10/hour")  # Rate limit: 10 rotations per IP per hour (plus 5-min per-worker cooldown)
 async def rotate_worker_api_key(
     request: Request,
     worker_id: str,
@@ -3159,13 +3159,18 @@ async def list_expiring_keys(
     Returns:
         Paginated list of expiring keys with worker info
     """
-    # Validate pagination
+    # Validate days parameter - return 400 for invalid values
+    if days < 1 or days > 365:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid 'days' parameter: {days}. Must be between 1 and 365.",
+        )
+
+    # Validate pagination (clamp to valid range)
     if page < 1:
         page = 1
     if per_page < 1 or per_page > 100:
         per_page = min(max(per_page, 1), 100)
-    if days < 1 or days > 365:
-        days = min(max(days, 1), 365)
 
     keys, total_count = await get_expiring_keys(
         days=days,

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -3090,7 +3090,7 @@ async def rotate_worker_api_key(
     If not revoked immediately, the old key remains valid for the configured
     overlap period (default: 2 hours).
 
-    Rate limit: 10 rotations per worker per hour, 5-minute cooldown between rotations.
+    Rate limit: 10 rotations per IP per hour, plus 5-minute per-worker cooldown between rotations.
 
     Requires X-Admin-Secret header with VLOG_WORKER_ADMIN_SECRET value.
 

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -110,19 +110,31 @@ from api.metrics import (
     get_metrics,
     sanitize_label,
 )
+from api.audit import AuditAction, log_audit
 from api.pubsub import Publisher
 from api.redis_client import get_redis
 from api.settings_service import get_setting as get_db_setting
 from api.webhook_service import trigger_webhook_event
-from api.worker_auth import get_key_prefix, hash_api_key, verify_worker_key
+from api.worker_auth import (
+    DEFAULT_EXPIRATION_DAYS,
+    bulk_revoke_expired_keys,
+    get_expiring_keys,
+    get_key_prefix,
+    hash_api_key,
+    rotate_worker_key,
+    verify_worker_key,
+)
 from api.worker_schemas import (
+    BulkRevokeResponse,
     ClaimJobResponse,
     CompleteJobRequest,
     CompleteJobResponse,
+    ExpiringKeysResponse,
     FailJobRequest,
     FailJobResponse,
     HeartbeatRequest,
     HeartbeatResponse,
+    KeyRotationResponse,
     ProgressUpdateRequest,
     ProgressUpdateResponse,
     SegmentFinalizeRequest,
@@ -1142,6 +1154,12 @@ async def register_worker(
     key_prefix = get_key_prefix(api_key)
     now = datetime.now(timezone.utc)
 
+    # Calculate API key expiration based on settings (Issue #226)
+    expiration_days = await get_db_setting("workers.api_key_expiration_days", DEFAULT_EXPIRATION_DAYS)
+    key_expires_at = None
+    if expiration_days > 0:
+        key_expires_at = now + timedelta(days=expiration_days)
+
     worker_name = data.worker_name or f"worker-{worker_id[:8]}"
 
     # Validate and serialize capabilities
@@ -1179,6 +1197,7 @@ async def register_worker(
             )
 
             # Create API key record with argon2id hash (Issue #445)
+            # Includes expiration date based on settings (Issue #226)
             await database.execute(
                 worker_api_keys.insert().values(
                     worker_id=result["worker_db_id"],
@@ -1186,6 +1205,7 @@ async def register_worker(
                     hash_version=hash_version,
                     key_prefix=key_prefix,
                     created_at=now,
+                    expires_at=key_expires_at,
                 )
             )
 
@@ -3048,6 +3068,171 @@ async def revoke_worker(
     await database.execute(workers.update().where(workers.c.id == worker["id"]).values(status="disabled"))
 
     return StatusResponse(status="ok", message=f"Worker {worker_id} has been revoked")
+
+
+# =============================================================================
+# API Key Rotation Endpoints (Issue #226)
+# =============================================================================
+
+
+@v1_router.post("/workers/{worker_id}/rotate", response_model=KeyRotationResponse)
+@limiter.limit("10/hour")  # Rate limit: 10 rotations per worker per hour
+async def rotate_worker_api_key(
+    request: Request,
+    worker_id: str,
+    revoke_old: bool = False,
+    _admin: None = Depends(verify_admin_secret),
+):
+    """
+    Rotate a worker's API key.
+
+    Creates a new API key and optionally revokes the old one immediately.
+    If not revoked immediately, the old key remains valid for the configured
+    overlap period (default: 2 hours).
+
+    Rate limit: 10 rotations per worker per hour, 5-minute cooldown between rotations.
+
+    Requires X-Admin-Secret header with VLOG_WORKER_ADMIN_SECRET value.
+
+    Args:
+        worker_id: Worker UUID to rotate key for
+        revoke_old: If true, revoke old key immediately instead of after overlap
+
+    Returns:
+        KeyRotationResponse with new key and expiration info
+    """
+    # Find worker by UUID
+    worker = await database.fetch_one(workers.select().where(workers.c.worker_id == worker_id))
+    if not worker:
+        raise HTTPException(status_code=404, detail="Worker not found")
+
+    # Rotate the key (handles cooldown check internally)
+    new_api_key, new_expires_at, old_key_expires_at, overlap_hours = await rotate_worker_key(
+        worker_db_id=worker["id"],
+        worker_uuid=worker_id,
+        revoke_old=revoke_old,
+    )
+
+    # Audit log
+    log_audit(
+        AuditAction.WORKER_KEY_ROTATE,
+        client_ip=request.client.host if request.client else None,
+        resource_type="worker",
+        resource_id=worker_id,
+        resource_name=worker["worker_name"],
+        details={
+            "revoke_old": revoke_old,
+            "overlap_hours": overlap_hours,
+        },
+    )
+
+    return KeyRotationResponse(
+        status="ok",
+        new_api_key=new_api_key,
+        expires_at=new_expires_at,
+        old_key_expires_at=old_key_expires_at,
+        overlap_hours=overlap_hours,
+    )
+
+
+@v1_router.get("/workers/expiring-keys", response_model=ExpiringKeysResponse)
+@limiter.limit(RATE_LIMIT_WORKER_DEFAULT)
+async def list_expiring_keys(
+    request: Request,
+    days: int = 14,
+    include_grace: bool = False,
+    page: int = 1,
+    per_page: int = 50,
+    _admin: None = Depends(verify_admin_secret),
+):
+    """
+    List API keys expiring within the specified number of days.
+
+    Requires X-Admin-Secret header with VLOG_WORKER_ADMIN_SECRET value.
+
+    Args:
+        days: Number of days to look ahead (default: 14)
+        include_grace: Include keys in grace period (already expired but still valid)
+        page: Page number for pagination
+        per_page: Results per page (max 100)
+
+    Returns:
+        Paginated list of expiring keys with worker info
+    """
+    # Validate pagination
+    if page < 1:
+        page = 1
+    if per_page < 1 or per_page > 100:
+        per_page = min(max(per_page, 1), 100)
+    if days < 1 or days > 365:
+        days = min(max(days, 1), 365)
+
+    keys, total_count = await get_expiring_keys(
+        days=days,
+        include_grace=include_grace,
+        page=page,
+        per_page=per_page,
+    )
+
+    return ExpiringKeysResponse(
+        keys=keys,
+        total_count=total_count,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@v1_router.post("/workers/revoke-expired", response_model=BulkRevokeResponse)
+@limiter.limit("1/minute")  # Rate limit: 1 bulk revoke per minute
+async def revoke_expired_keys(
+    request: Request,
+    dry_run: bool = True,
+    include_grace_period: bool = False,
+    _admin: None = Depends(verify_admin_secret),
+):
+    """
+    Revoke all expired API keys in bulk.
+
+    By default, only revokes keys that are past the grace period.
+    Use include_grace_period=true to also revoke keys still in grace period.
+
+    IMPORTANT: Use dry_run=true first to preview what would be revoked.
+
+    Rate limit: 1 request per minute.
+
+    Requires X-Admin-Secret header with VLOG_WORKER_ADMIN_SECRET value.
+
+    Args:
+        dry_run: If true (default), only return count without actually revoking
+        include_grace_period: If true, also revoke keys still in grace period
+
+    Returns:
+        Count of revoked keys and list of affected worker IDs
+    """
+    revoked_count, affected_worker_ids = await bulk_revoke_expired_keys(
+        dry_run=dry_run,
+        include_grace_period=include_grace_period,
+    )
+
+    # Audit log (only if not dry run)
+    if not dry_run and revoked_count > 0:
+        log_audit(
+            AuditAction.WORKER_BULK_REVOKE,
+            client_ip=request.client.host if request.client else None,
+            resource_type="worker_api_keys",
+            details={
+                "revoked_count": revoked_count,
+                "include_grace_period": include_grace_period,
+                "affected_workers": len(affected_worker_ids),
+            },
+        )
+
+    return BulkRevokeResponse(
+        status="ok",
+        dry_run=dry_run,
+        revoked_count=revoked_count,
+        affected_worker_ids=affected_worker_ids,
+    )
 
 
 @v1_router.get("/health")

--- a/api/worker_auth.py
+++ b/api/worker_auth.py
@@ -4,16 +4,19 @@ import asyncio
 import hashlib
 import hmac
 import logging
-from datetime import datetime, timezone
+import secrets
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Optional, Tuple
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
-from fastapi import HTTPException, Request, Security
+from fastapi import HTTPException, Request, Response, Security
 from fastapi.security import APIKeyHeader
 
 from api.common import ensure_utc
 from api.database import database, worker_api_keys, workers
+from api.settings_service import get_setting
 from config import TRUSTED_PROXIES
 
 # Security event logger - separate from regular application logging
@@ -38,6 +41,25 @@ _password_hasher = PasswordHasher(
     memory_cost=65536,  # 64MB memory
     parallelism=4,  # threads
 )
+
+
+class KeyExpirationStatus(str, Enum):
+    """Status of API key expiration check (Issue #226)."""
+
+    VALID = "valid"  # Key is valid and not near expiration
+    EXPIRING_SOON = "expiring_soon"  # Key will expire within warning period
+    IN_GRACE_PERIOD = "in_grace_period"  # Key is expired but within grace period
+    EXPIRED = "expired"  # Key is expired and past grace period
+
+
+# Rotation cooldown in seconds (5 minutes per security review)
+ROTATION_COOLDOWN_SECONDS = 300
+
+# Default settings for key expiration (used if not set in database)
+DEFAULT_EXPIRATION_DAYS = 90
+DEFAULT_GRACE_PERIOD_HOURS = 4
+DEFAULT_OVERLAP_HOURS = 2
+DEFAULT_WARNING_DAYS = 14
 
 
 def hash_api_key(key: str) -> Tuple[str, int]:
@@ -121,6 +143,58 @@ def _get_hash_version(record: dict) -> int:
         return record["hash_version"]
     except (KeyError, TypeError):
         return HASH_VERSION_SHA256
+
+
+async def _check_key_expiration_with_grace(
+    expires_at: Optional[datetime],
+    grace_period_hours: Optional[int] = None,
+    warning_days: Optional[int] = None,
+) -> Tuple[KeyExpirationStatus, Optional[datetime]]:
+    """
+    Check key expiration status with grace period logic (Issue #226).
+
+    Args:
+        expires_at: Key expiration timestamp (None = never expires)
+        grace_period_hours: Hours after expiration key is still valid (defaults to setting)
+        warning_days: Days before expiration to warn (defaults to setting)
+
+    Returns:
+        Tuple of (status, grace_period_ends_at)
+        - status: KeyExpirationStatus enum value
+        - grace_period_ends_at: When grace period ends (None if not in grace period)
+    """
+    if expires_at is None:
+        return KeyExpirationStatus.VALID, None
+
+    now = datetime.now(timezone.utc)
+    expires_at = ensure_utc(expires_at)
+
+    # Get settings from database (with defaults)
+    if grace_period_hours is None:
+        grace_period_hours = await get_setting(
+            "workers.api_key_grace_period_hours", DEFAULT_GRACE_PERIOD_HOURS
+        )
+    if warning_days is None:
+        warning_days = await get_setting(
+            "workers.api_key_expiration_warning_days", DEFAULT_WARNING_DAYS
+        )
+
+    # Calculate grace period end
+    grace_period_ends = expires_at + timedelta(hours=grace_period_hours)
+
+    # Check status
+    if now < expires_at:
+        # Key hasn't expired yet
+        days_until = (expires_at - now).days
+        if days_until <= warning_days:
+            return KeyExpirationStatus.EXPIRING_SOON, None
+        return KeyExpirationStatus.VALID, None
+    elif now < grace_period_ends:
+        # Key is expired but within grace period
+        return KeyExpirationStatus.IN_GRACE_PERIOD, grace_period_ends
+    else:
+        # Key is fully expired (past grace period)
+        return KeyExpirationStatus.EXPIRED, None
 
 
 async def authenticate_api_key(api_key: str, request: Optional[Request] = None) -> dict:
@@ -273,24 +347,52 @@ async def verify_worker_key(
     key_record = await authenticate_api_key(api_key, request)
     prefix = get_key_prefix(api_key)
 
-    # Check expiration (handle both timezone-aware and naive datetimes from SQLite)
+    # Check expiration with grace period (Issue #226)
     now = datetime.now(timezone.utc)
-    if key_record["expires_at"]:
-        expires_at = ensure_utc(key_record["expires_at"])
-        if expires_at < now:
-            security_logger.warning(
-                "Authentication failed: expired API key",
-                extra={
-                    "event": "auth_failure",
-                    "reason": "expired_key",
-                    "key_prefix": prefix,
-                    "worker_id": key_record["worker_id"],
-                    "hash_version": _get_hash_version(key_record),
-                    "expired_at": expires_at.isoformat(),
-                    **ctx,
-                },
-            )
-            raise HTTPException(status_code=401, detail="API key expired")
+    expiration_status, grace_ends = await _check_key_expiration_with_grace(
+        key_record["expires_at"]
+    )
+
+    # Store whether key is expiring for header injection
+    key_expiring = False
+
+    if expiration_status == KeyExpirationStatus.EXPIRED:
+        security_logger.warning(
+            "Authentication failed: expired API key (past grace period)",
+            extra={
+                "event": "auth_failure",
+                "reason": "expired_key",
+                "key_prefix": prefix,
+                "worker_id": key_record["worker_id"],
+                "hash_version": _get_hash_version(key_record),
+                "expired_at": key_record["expires_at"].isoformat() if key_record["expires_at"] else None,
+                **ctx,
+            },
+        )
+        raise HTTPException(
+            status_code=401,
+            detail="API key expired. Rotate using: vlog worker rotate <worker-id>",
+        )
+    elif expiration_status == KeyExpirationStatus.IN_GRACE_PERIOD:
+        # Allow but warn - key is expired but within grace period
+        security_logger.warning(
+            "API key in grace period - will expire soon",
+            extra={
+                "event": "auth_grace_period",
+                "key_prefix": prefix,
+                "worker_id": key_record["worker_id"],
+                "expired_at": key_record["expires_at"].isoformat() if key_record["expires_at"] else None,
+                "grace_ends_at": grace_ends.isoformat() if grace_ends else None,
+                **ctx,
+            },
+        )
+        key_expiring = True
+    elif expiration_status == KeyExpirationStatus.EXPIRING_SOON:
+        # Log that key is expiring soon
+        logger.info(
+            f"API key expiring soon for worker {key_record['worker_id']}",
+        )
+        key_expiring = True
 
     # Update last_used_at in background (non-blocking)
     async def update_last_used():
@@ -345,10 +447,299 @@ async def verify_worker_key(
         },
     )
 
-    return dict(worker)
+    # Return worker dict with expiration info for response header injection
+    worker_dict = dict(worker)
+    worker_dict["_key_expiring"] = key_expiring
+    worker_dict["_key_id"] = key_record["id"]
+    return worker_dict
 
 
 async def get_worker_by_id(worker_id: str) -> Optional[dict]:
     """Get a worker by its UUID."""
     worker = await database.fetch_one(workers.select().where(workers.c.worker_id == worker_id))
     return dict(worker) if worker else None
+
+
+async def rotate_worker_key(
+    worker_db_id: int,
+    worker_uuid: str,
+    revoke_old: bool = False,
+) -> Tuple[str, datetime, Optional[datetime], int]:
+    """
+    Rotate a worker's API key with overlap period (Issue #226).
+
+    Creates a new API key for the worker and optionally schedules the old key
+    for expiration after the overlap period.
+
+    Args:
+        worker_db_id: Database ID of the worker (integer PK)
+        worker_uuid: UUID of the worker (for logging)
+        revoke_old: If True, revoke old key immediately instead of scheduling expiration
+
+    Returns:
+        Tuple of (new_api_key, new_expires_at, old_key_expires_at, overlap_hours)
+
+    Raises:
+        HTTPException(429): If rotation was attempted too recently (cooldown)
+        HTTPException(404): If no active key found for worker
+    """
+    now = datetime.now(timezone.utc)
+
+    # Get settings
+    expiration_days = await get_setting("workers.api_key_expiration_days", DEFAULT_EXPIRATION_DAYS)
+    overlap_hours = await get_setting("workers.api_key_rotation_overlap_hours", DEFAULT_OVERLAP_HOURS)
+
+    # Check cooldown - find the most recent key for this worker
+    latest_key = await database.fetch_one(
+        worker_api_keys.select()
+        .where(worker_api_keys.c.worker_id == worker_db_id)
+        .order_by(worker_api_keys.c.created_at.desc())
+        .limit(1)
+    )
+
+    if not latest_key:
+        raise HTTPException(status_code=404, detail="No API key found for worker")
+
+    # Check cooldown (5 minutes between rotations)
+    key_created_at = ensure_utc(latest_key["created_at"])
+    seconds_since_last = (now - key_created_at).total_seconds()
+    if seconds_since_last < ROTATION_COOLDOWN_SECONDS:
+        remaining = int(ROTATION_COOLDOWN_SECONDS - seconds_since_last)
+        raise HTTPException(
+            status_code=429,
+            detail=f"Rotation cooldown active. Please wait {remaining} seconds.",
+            headers={"Retry-After": str(remaining)},
+        )
+
+    # Generate new key
+    new_api_key = secrets.token_urlsafe(32)  # 256-bit key
+    key_hash, hash_version = hash_api_key(new_api_key)
+    key_prefix = get_key_prefix(new_api_key)
+
+    # Calculate expiration for new key
+    new_expires_at = None
+    if expiration_days > 0:
+        new_expires_at = now + timedelta(days=expiration_days)
+
+    # Calculate old key expiration (either immediate revoke or scheduled)
+    old_key_expires_at = None
+    if revoke_old:
+        # Revoke immediately
+        old_key_expires_at = now
+    else:
+        # Schedule expiration after overlap period
+        old_key_expires_at = now + timedelta(hours=overlap_hours)
+
+    # Find the current active key (non-revoked, non-expired)
+    active_key = await database.fetch_one(
+        worker_api_keys.select()
+        .where(worker_api_keys.c.worker_id == worker_db_id)
+        .where(worker_api_keys.c.revoked_at.is_(None))
+        .order_by(worker_api_keys.c.created_at.desc())
+        .limit(1)
+    )
+
+    if not active_key:
+        raise HTTPException(status_code=404, detail="No active API key found for worker")
+
+    old_key_id = active_key["id"]
+
+    # Use transaction for atomicity
+    async with database.transaction():
+        # Create new key with reference to old key (rotated_from)
+        await database.execute(
+            worker_api_keys.insert().values(
+                worker_id=worker_db_id,
+                key_hash=key_hash,
+                hash_version=hash_version,
+                key_prefix=key_prefix,
+                created_at=now,
+                expires_at=new_expires_at,
+                rotated_from=old_key_id,
+            )
+        )
+
+        # Update old key - either revoke or set expiration
+        if revoke_old:
+            await database.execute(
+                worker_api_keys.update()
+                .where(worker_api_keys.c.id == old_key_id)
+                .values(revoked_at=now)
+            )
+        else:
+            # Set expires_at if not already set, or update if new expiration is sooner
+            await database.execute(
+                worker_api_keys.update()
+                .where(worker_api_keys.c.id == old_key_id)
+                .values(expires_at=old_key_expires_at)
+            )
+
+    security_logger.info(
+        "API key rotated",
+        extra={
+            "event": "key_rotate",
+            "worker_id": worker_uuid,
+            "old_key_id": old_key_id,
+            "revoked_immediately": revoke_old,
+            "overlap_hours": overlap_hours,
+        },
+    )
+
+    return new_api_key, new_expires_at, old_key_expires_at, overlap_hours
+
+
+async def get_expiring_keys(
+    days: int = DEFAULT_WARNING_DAYS,
+    include_grace: bool = False,
+    page: int = 1,
+    per_page: int = 50,
+) -> Tuple[list, int]:
+    """
+    Get list of API keys expiring within the specified number of days.
+
+    Args:
+        days: Number of days to look ahead for expiring keys
+        include_grace: If True, also include keys in grace period (already expired)
+        page: Page number for pagination
+        per_page: Number of results per page
+
+    Returns:
+        Tuple of (list of expiring key info dicts, total count)
+    """
+    import sqlalchemy as sa
+
+    now = datetime.now(timezone.utc)
+    threshold = now + timedelta(days=days)
+
+    # Get grace period for calculating if key is in grace period
+    grace_period_hours = await get_setting(
+        "workers.api_key_grace_period_hours", DEFAULT_GRACE_PERIOD_HOURS
+    )
+
+    # Base query - keys that are not revoked and have an expiration date
+    base_conditions = [
+        worker_api_keys.c.revoked_at.is_(None),
+        worker_api_keys.c.expires_at.isnot(None),
+    ]
+
+    if include_grace:
+        # Include keys expired up to grace_period_hours ago
+        grace_start = now - timedelta(hours=grace_period_hours)
+        base_conditions.append(worker_api_keys.c.expires_at > grace_start)
+        base_conditions.append(worker_api_keys.c.expires_at <= threshold)
+    else:
+        # Only future expirations
+        base_conditions.append(worker_api_keys.c.expires_at > now)
+        base_conditions.append(worker_api_keys.c.expires_at <= threshold)
+
+    # Count total
+    count_query = sa.select(sa.func.count()).select_from(worker_api_keys).where(sa.and_(*base_conditions))
+    total_count = await database.fetch_val(count_query)
+
+    # Fetch paginated results with worker info
+    offset = (page - 1) * per_page
+    query = (
+        sa.select(
+            worker_api_keys.c.id.label("key_id"),
+            worker_api_keys.c.expires_at,
+            workers.c.worker_id,
+            workers.c.worker_name,
+        )
+        .select_from(worker_api_keys.join(workers, worker_api_keys.c.worker_id == workers.c.id))
+        .where(sa.and_(*base_conditions))
+        .order_by(worker_api_keys.c.expires_at.asc())
+        .offset(offset)
+        .limit(per_page)
+    )
+
+    rows = await database.fetch_all(query)
+
+    results = []
+    for row in rows:
+        expires_at = ensure_utc(row["expires_at"])
+        days_until = (expires_at - now).days
+        in_grace = expires_at < now  # If already expired, it's in grace period
+
+        results.append({
+            "worker_id": row["worker_id"],
+            "worker_name": row["worker_name"],
+            "key_id": row["key_id"],
+            "expires_at": expires_at,
+            "days_until_expiration": max(0, days_until),
+            "in_grace_period": in_grace,
+        })
+
+    return results, total_count or 0
+
+
+async def bulk_revoke_expired_keys(
+    dry_run: bool = True,
+    include_grace_period: bool = False,
+) -> Tuple[int, list]:
+    """
+    Revoke expired API keys in bulk (Issue #226).
+
+    Args:
+        dry_run: If True, only return count without actually revoking
+        include_grace_period: If False, only revoke keys past grace period
+
+    Returns:
+        Tuple of (count of revoked/would-be-revoked keys, list of affected worker UUIDs)
+    """
+    import sqlalchemy as sa
+
+    now = datetime.now(timezone.utc)
+
+    # Get grace period setting
+    grace_period_hours = await get_setting(
+        "workers.api_key_grace_period_hours", DEFAULT_GRACE_PERIOD_HOURS
+    )
+
+    # Determine cutoff time
+    if include_grace_period:
+        # Revoke anything that's expired (regardless of grace period)
+        cutoff = now
+    else:
+        # Only revoke keys past grace period
+        cutoff = now - timedelta(hours=grace_period_hours)
+
+    # Find expired keys
+    conditions = [
+        worker_api_keys.c.revoked_at.is_(None),
+        worker_api_keys.c.expires_at.isnot(None),
+        worker_api_keys.c.expires_at < cutoff,
+    ]
+
+    # Get list of affected worker UUIDs before revoking
+    affected_query = (
+        sa.select(workers.c.worker_id)
+        .select_from(worker_api_keys.join(workers, worker_api_keys.c.worker_id == workers.c.id))
+        .where(sa.and_(*conditions))
+        .distinct()
+    )
+    affected_rows = await database.fetch_all(affected_query)
+    affected_worker_ids = [row["worker_id"] for row in affected_rows]
+
+    # Count keys to revoke
+    count_query = sa.select(sa.func.count()).select_from(worker_api_keys).where(sa.and_(*conditions))
+    count = await database.fetch_val(count_query) or 0
+
+    if not dry_run and count > 0:
+        # Actually revoke the keys
+        await database.execute(
+            worker_api_keys.update()
+            .where(sa.and_(*conditions))
+            .values(revoked_at=now)
+        )
+
+        security_logger.info(
+            "Bulk key revocation completed",
+            extra={
+                "event": "bulk_revoke",
+                "count": count,
+                "include_grace_period": include_grace_period,
+                "affected_workers": len(affected_worker_ids),
+            },
+        )
+
+    return count, affected_worker_ids

--- a/api/worker_auth.py
+++ b/api/worker_auth.py
@@ -353,9 +353,6 @@ async def verify_worker_key(
         key_record["expires_at"]
     )
 
-    # Store whether key is expiring for header injection
-    key_expiring = False
-
     if expiration_status == KeyExpirationStatus.EXPIRED:
         security_logger.warning(
             "Authentication failed: expired API key (past grace period)",
@@ -386,13 +383,11 @@ async def verify_worker_key(
                 **ctx,
             },
         )
-        key_expiring = True
     elif expiration_status == KeyExpirationStatus.EXPIRING_SOON:
         # Log that key is expiring soon
         logger.info(
             f"API key expiring soon for worker {key_record['worker_id']}",
         )
-        key_expiring = True
 
     # Update last_used_at in background (non-blocking)
     async def update_last_used():

--- a/api/worker_auth.py
+++ b/api/worker_auth.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 
 from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHashError, VerifyMismatchError
-from fastapi import HTTPException, Request, Response, Security
+from fastapi import HTTPException, Request, Security
 from fastapi.security import APIKeyHeader
 
 from api.common import ensure_utc
@@ -447,11 +447,7 @@ async def verify_worker_key(
         },
     )
 
-    # Return worker dict with expiration info for response header injection
-    worker_dict = dict(worker)
-    worker_dict["_key_expiring"] = key_expiring
-    worker_dict["_key_id"] = key_record["id"]
-    return worker_dict
+    return dict(worker)
 
 
 async def get_worker_by_id(worker_id: str) -> Optional[dict]:
@@ -464,12 +460,14 @@ async def rotate_worker_key(
     worker_db_id: int,
     worker_uuid: str,
     revoke_old: bool = False,
-) -> Tuple[str, datetime, Optional[datetime], int]:
+) -> Tuple[str, Optional[datetime], Optional[datetime], int]:
     """
     Rotate a worker's API key with overlap period (Issue #226).
 
     Creates a new API key for the worker and optionally schedules the old key
     for expiration after the overlap period.
+
+    Uses SELECT FOR UPDATE to prevent concurrent rotation race conditions.
 
     Args:
         worker_db_id: Database ID of the worker (integer PK)
@@ -483,36 +481,16 @@ async def rotate_worker_key(
         HTTPException(429): If rotation was attempted too recently (cooldown)
         HTTPException(404): If no active key found for worker
     """
+    import sqlalchemy as sa
+
     now = datetime.now(timezone.utc)
 
-    # Get settings
+    # Get settings (before transaction to avoid holding lock during I/O)
     expiration_days = await get_setting("workers.api_key_expiration_days", DEFAULT_EXPIRATION_DAYS)
     overlap_hours = await get_setting("workers.api_key_rotation_overlap_hours", DEFAULT_OVERLAP_HOURS)
 
-    # Check cooldown - find the most recent key for this worker
-    latest_key = await database.fetch_one(
-        worker_api_keys.select()
-        .where(worker_api_keys.c.worker_id == worker_db_id)
-        .order_by(worker_api_keys.c.created_at.desc())
-        .limit(1)
-    )
-
-    if not latest_key:
-        raise HTTPException(status_code=404, detail="No API key found for worker")
-
-    # Check cooldown (5 minutes between rotations)
-    key_created_at = ensure_utc(latest_key["created_at"])
-    seconds_since_last = (now - key_created_at).total_seconds()
-    if seconds_since_last < ROTATION_COOLDOWN_SECONDS:
-        remaining = int(ROTATION_COOLDOWN_SECONDS - seconds_since_last)
-        raise HTTPException(
-            status_code=429,
-            detail=f"Rotation cooldown active. Please wait {remaining} seconds.",
-            headers={"Retry-After": str(remaining)},
-        )
-
-    # Generate new key
-    new_api_key = secrets.token_urlsafe(32)  # 256-bit key
+    # Generate new key material before transaction to minimize lock time
+    new_api_key = secrets.token_urlsafe(32)  # 256-bit entropy, 43 base64url chars
     key_hash, hash_version = hash_api_key(new_api_key)
     key_prefix = get_key_prefix(new_api_key)
 
@@ -521,71 +499,144 @@ async def rotate_worker_key(
     if expiration_days > 0:
         new_expires_at = now + timedelta(days=expiration_days)
 
-    # Calculate old key expiration (either immediate revoke or scheduled)
-    old_key_expires_at = None
-    if revoke_old:
-        # Revoke immediately
-        old_key_expires_at = now
-    else:
-        # Schedule expiration after overlap period
-        old_key_expires_at = now + timedelta(hours=overlap_hours)
+    old_key_id = None
+    old_key_current_expires = None
+    actual_old_key_expires_at = None
 
-    # Find the current active key (non-revoked, non-expired)
-    active_key = await database.fetch_one(
-        worker_api_keys.select()
-        .where(worker_api_keys.c.worker_id == worker_db_id)
-        .where(worker_api_keys.c.revoked_at.is_(None))
-        .order_by(worker_api_keys.c.created_at.desc())
-        .limit(1)
-    )
-
-    if not active_key:
-        raise HTTPException(status_code=404, detail="No active API key found for worker")
-
-    old_key_id = active_key["id"]
-
-    # Use transaction for atomicity
-    async with database.transaction():
-        # Create new key with reference to old key (rotated_from)
-        await database.execute(
-            worker_api_keys.insert().values(
-                worker_id=worker_db_id,
-                key_hash=key_hash,
-                hash_version=hash_version,
-                key_prefix=key_prefix,
-                created_at=now,
-                expires_at=new_expires_at,
-                rotated_from=old_key_id,
+    try:
+        # Use transaction with row locking to prevent concurrent rotations
+        async with database.transaction():
+            # Lock the worker row to prevent concurrent rotations (FOR UPDATE)
+            # This ensures only one rotation can proceed at a time for this worker
+            worker_lock = await database.fetch_one(
+                sa.select(workers.c.id)
+                .where(workers.c.id == worker_db_id)
+                .with_for_update()
             )
+
+            if not worker_lock:
+                raise HTTPException(status_code=404, detail="Worker not found")
+
+            # Check cooldown - find the most recent key for this worker
+            # Done inside transaction after acquiring lock to prevent TOCTOU race
+            latest_key = await database.fetch_one(
+                worker_api_keys.select()
+                .where(worker_api_keys.c.worker_id == worker_db_id)
+                .order_by(worker_api_keys.c.created_at.desc())
+                .limit(1)
+            )
+
+            if not latest_key:
+                raise HTTPException(status_code=404, detail="No API key found for worker")
+
+            # Check cooldown (5 minutes between rotations)
+            key_created_at = ensure_utc(latest_key["created_at"])
+            seconds_since_last = (now - key_created_at).total_seconds()
+            if seconds_since_last < ROTATION_COOLDOWN_SECONDS:
+                remaining = int(ROTATION_COOLDOWN_SECONDS - seconds_since_last)
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"Rotation cooldown active. Try again later.",
+                    headers={"Retry-After": str(remaining)},
+                )
+
+            # Find the current active key (non-revoked)
+            active_key = await database.fetch_one(
+                worker_api_keys.select()
+                .where(worker_api_keys.c.worker_id == worker_db_id)
+                .where(worker_api_keys.c.revoked_at.is_(None))
+                .order_by(worker_api_keys.c.created_at.desc())
+                .limit(1)
+            )
+
+            if not active_key:
+                raise HTTPException(status_code=404, detail="No active API key found for worker")
+
+            old_key_id = active_key["id"]
+            old_key_current_expires = active_key["expires_at"]
+
+            # Create new key with reference to old key (rotated_from)
+            await database.execute(
+                worker_api_keys.insert().values(
+                    worker_id=worker_db_id,
+                    key_hash=key_hash,
+                    hash_version=hash_version,
+                    key_prefix=key_prefix,
+                    created_at=now,
+                    expires_at=new_expires_at,
+                    rotated_from=old_key_id,
+                )
+            )
+
+            # Update old key - either revoke or set expiration
+            if revoke_old:
+                await database.execute(
+                    worker_api_keys.update()
+                    .where(worker_api_keys.c.id == old_key_id)
+                    .values(revoked_at=now)
+                )
+                actual_old_key_expires_at = now
+            else:
+                # Calculate overlap expiration
+                overlap_expires_at = now + timedelta(hours=overlap_hours)
+
+                # Only shorten expiration, never extend it
+                # If old key already has a sooner expiration, preserve it
+                if old_key_current_expires is not None:
+                    old_key_current_expires = ensure_utc(old_key_current_expires)
+                    if old_key_current_expires < overlap_expires_at:
+                        # Keep existing sooner expiration
+                        actual_old_key_expires_at = old_key_current_expires
+                    else:
+                        # Use overlap expiration (sooner)
+                        actual_old_key_expires_at = overlap_expires_at
+                        await database.execute(
+                            worker_api_keys.update()
+                            .where(worker_api_keys.c.id == old_key_id)
+                            .values(expires_at=overlap_expires_at)
+                        )
+                else:
+                    # No existing expiration, set overlap expiration
+                    actual_old_key_expires_at = overlap_expires_at
+                    await database.execute(
+                        worker_api_keys.update()
+                        .where(worker_api_keys.c.id == old_key_id)
+                        .values(expires_at=overlap_expires_at)
+                    )
+
+        # Transaction committed successfully
+        security_logger.info(
+            "API key rotated",
+            extra={
+                "event": "key_rotate",
+                "worker_id": worker_uuid,
+                "old_key_id": old_key_id,
+                "revoked_immediately": revoke_old,
+                "overlap_hours": overlap_hours,
+            },
         )
 
-        # Update old key - either revoke or set expiration
-        if revoke_old:
-            await database.execute(
-                worker_api_keys.update()
-                .where(worker_api_keys.c.id == old_key_id)
-                .values(revoked_at=now)
-            )
-        else:
-            # Set expires_at if not already set, or update if new expiration is sooner
-            await database.execute(
-                worker_api_keys.update()
-                .where(worker_api_keys.c.id == old_key_id)
-                .values(expires_at=old_key_expires_at)
-            )
+        return new_api_key, new_expires_at, actual_old_key_expires_at, overlap_hours
 
-    security_logger.info(
-        "API key rotated",
-        extra={
-            "event": "key_rotate",
-            "worker_id": worker_uuid,
-            "old_key_id": old_key_id,
-            "revoked_immediately": revoke_old,
-            "overlap_hours": overlap_hours,
-        },
-    )
-
-    return new_api_key, new_expires_at, old_key_expires_at, overlap_hours
+    except HTTPException:
+        # Re-raise HTTP exceptions (cooldown, not found)
+        raise
+    except Exception as e:
+        # Log rotation failure for security monitoring
+        security_logger.error(
+            "API key rotation failed",
+            extra={
+                "event": "key_rotate_failed",
+                "worker_id": worker_uuid,
+                "old_key_id": old_key_id,
+                "error": str(e),
+                "revoke_old": revoke_old,
+            },
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Key rotation failed. Please try again.",
+        )
 
 
 async def get_expiring_keys(
@@ -679,6 +730,10 @@ async def bulk_revoke_expired_keys(
     """
     Revoke expired API keys in bulk (Issue #226).
 
+    Uses a transaction to ensure atomicity - either all keys are revoked
+    or none are. The count and affected worker list are consistent with
+    what was actually revoked.
+
     Args:
         dry_run: If True, only return count without actually revoking
         include_grace_period: If False, only revoke keys past grace period
@@ -710,28 +765,32 @@ async def bulk_revoke_expired_keys(
         worker_api_keys.c.expires_at < cutoff,
     ]
 
-    # Get list of affected worker UUIDs before revoking
-    affected_query = (
-        sa.select(workers.c.worker_id)
-        .select_from(worker_api_keys.join(workers, worker_api_keys.c.worker_id == workers.c.id))
-        .where(sa.and_(*conditions))
-        .distinct()
-    )
-    affected_rows = await database.fetch_all(affected_query)
-    affected_worker_ids = [row["worker_id"] for row in affected_rows]
-
-    # Count keys to revoke
-    count_query = sa.select(sa.func.count()).select_from(worker_api_keys).where(sa.and_(*conditions))
-    count = await database.fetch_val(count_query) or 0
-
-    if not dry_run and count > 0:
-        # Actually revoke the keys
-        await database.execute(
-            worker_api_keys.update()
+    # Use transaction to ensure atomicity of count, affected list, and revocation
+    async with database.transaction():
+        # Get list of affected worker UUIDs
+        affected_query = (
+            sa.select(workers.c.worker_id)
+            .select_from(worker_api_keys.join(workers, worker_api_keys.c.worker_id == workers.c.id))
             .where(sa.and_(*conditions))
-            .values(revoked_at=now)
+            .distinct()
         )
+        affected_rows = await database.fetch_all(affected_query)
+        affected_worker_ids = [row["worker_id"] for row in affected_rows]
 
+        # Count keys to revoke
+        count_query = sa.select(sa.func.count()).select_from(worker_api_keys).where(sa.and_(*conditions))
+        count = await database.fetch_val(count_query) or 0
+
+        if not dry_run and count > 0:
+            # Actually revoke the keys within the same transaction
+            await database.execute(
+                worker_api_keys.update()
+                .where(sa.and_(*conditions))
+                .values(revoked_at=now)
+            )
+
+    # Log only after transaction commits successfully
+    if not dry_run and count > 0:
         security_logger.info(
             "Bulk key revocation completed",
             extra={

--- a/api/worker_schemas.py
+++ b/api/worker_schemas.py
@@ -419,3 +419,53 @@ class SegmentFinalizeResponse(BaseModel):
     status: str
     complete: bool
     missing_segments: List[str] = Field(default_factory=list)
+
+
+# =============================================================================
+# API Key Rotation Schemas (Issue #226)
+# =============================================================================
+
+
+class KeyRotationResponse(BaseModel):
+    """Response from key rotation endpoint."""
+
+    status: str
+    new_api_key: str = Field(description="New API key - only shown once, store securely")
+    expires_at: Optional[datetime] = Field(description="When the new key expires")
+    old_key_expires_at: Optional[datetime] = Field(description="When the old key will be revoked")
+    overlap_hours: int = Field(description="Hours both keys are valid simultaneously")
+
+
+class ExpiringKeyInfo(BaseModel):
+    """Information about a key that will expire soon."""
+
+    worker_id: WorkerIdStr
+    worker_name: Optional[str]
+    key_id: int
+    expires_at: datetime
+    days_until_expiration: int
+    in_grace_period: bool = Field(default=False, description="True if key is expired but in grace period")
+
+    @field_validator("worker_id")
+    @classmethod
+    def validate_worker_id(cls, v):
+        """Ensure worker_id is a valid UUID4."""
+        return validate_uuid4(v)
+
+
+class ExpiringKeysResponse(BaseModel):
+    """Response from expiring keys endpoint."""
+
+    keys: List[ExpiringKeyInfo]
+    total_count: int
+    page: int = Field(default=1)
+    per_page: int = Field(default=50)
+
+
+class BulkRevokeResponse(BaseModel):
+    """Response from bulk revoke endpoint."""
+
+    status: str
+    dry_run: bool = Field(description="True if this was a dry-run preview")
+    revoked_count: int = Field(description="Number of keys revoked (or would be revoked)")
+    affected_worker_ids: List[str] = Field(description="Worker IDs whose keys were affected")

--- a/cli/main.py
+++ b/cli/main.py
@@ -640,7 +640,7 @@ def cmd_worker(args):
 
             for w in workers:
                 worker_id = w["worker_id"][:8] + "..."
-                name = (w["worker_name"] or "-")[:18]
+                name = (w["worker_name"] or "-")[:20]
                 wtype = w["worker_type"]
                 status = w["status"]
                 heartbeat = w["last_heartbeat"][:19] if w["last_heartbeat"] else "-"
@@ -755,7 +755,7 @@ def cmd_worker(args):
 
             for key in keys:
                 worker_id = key["worker_id"]
-                name = (key["worker_name"] or "-")[:18]
+                name = (key["worker_name"] or "-")[:20]
                 expires = key["expires_at"][:19] if key.get("expires_at") else "-"
                 if key.get("in_grace_period"):
                     status = "IN GRACE PERIOD"

--- a/cli/main.py
+++ b/cli/main.py
@@ -686,6 +686,73 @@ def cmd_worker(args):
                     else:
                         print(f"  {name}: idle")
 
+        elif args.worker_command == "rotate":
+            # Rotate a worker's API key (Issue #226)
+            params = {}
+            if args.revoke_old:
+                params["revoke_old"] = "true"
+
+            response = httpx.post(
+                f"{WORKER_API_BASE}/workers/{args.worker_id}/rotate",
+                params=params,
+                headers=admin_headers,
+                timeout=DEFAULT_API_TIMEOUT,
+            )
+            result = safe_json_response(response)
+
+            print("API key rotated successfully!")
+            print()
+            print(f"  New API Key: {result['new_api_key']}")
+            if result.get("expires_at"):
+                print(f"  Expires at: {result['expires_at']}")
+            if result.get("old_key_expires_at"):
+                print(f"  Old key valid until: {result['old_key_expires_at']}")
+            print(f"  Overlap period: {result['overlap_hours']} hours")
+            print()
+            print("IMPORTANT: Save the new API key - it will not be shown again!")
+            print()
+            print("To update the worker, set the environment variable:")
+            print(f"  export VLOG_WORKER_API_KEY={result['new_api_key']}")
+
+        elif args.worker_command == "expire-warning":
+            # List expiring API keys (Issue #226)
+            params = {"days": args.days}
+            if args.include_grace:
+                params["include_grace"] = "true"
+
+            response = httpx.get(
+                f"{WORKER_API_BASE}/workers/expiring-keys",
+                params=params,
+                headers=admin_headers,
+                timeout=DEFAULT_API_TIMEOUT,
+            )
+            result = safe_json_response(response)
+
+            keys = result.get("keys", [])
+            if not keys:
+                print(f"No API keys expiring within {args.days} days.")
+                return
+
+            print(f"API keys expiring within {args.days} days: {len(keys)}")
+            print()
+            print(f"{'Worker ID':<38} {'Name':<20} {'Expires':<20} {'Status':<15}")
+            print("-" * 95)
+
+            for key in keys:
+                worker_id = key["worker_id"]
+                name = (key["worker_name"] or "-")[:18]
+                expires = key["expires_at"][:19] if key.get("expires_at") else "-"
+                if key.get("in_grace_period"):
+                    status = "IN GRACE PERIOD"
+                else:
+                    days_left = key.get("days_until_expiration", 0)
+                    status = f"{days_left} days left"
+
+                print(f"{worker_id:<38} {name:<20} {expires:<20} {status:<15}")
+
+            print()
+            print("To rotate a key: vlog worker rotate <worker-id>")
+
     except httpx.ConnectError:
         print(f"Error: Could not connect to Worker API at {WORKER_API_BASE}")
         print("Make sure the worker API server is running (port 9002).")
@@ -1610,6 +1677,25 @@ def main():
     # worker revoke
     worker_revoke = worker_subparsers.add_parser("revoke", help="Revoke a worker's API key")
     worker_revoke.add_argument("worker_id", help="Worker ID (UUID) to revoke")
+
+    # worker rotate (Issue #226)
+    worker_rotate = worker_subparsers.add_parser("rotate", help="Rotate a worker's API key")
+    worker_rotate.add_argument("worker_id", help="Worker ID (UUID) to rotate key for")
+    worker_rotate.add_argument(
+        "--revoke-old", action="store_true",
+        help="Immediately revoke old key instead of keeping it valid during overlap period"
+    )
+
+    # worker expire-warning (Issue #226)
+    worker_expire = worker_subparsers.add_parser("expire-warning", help="List API keys expiring soon")
+    worker_expire.add_argument(
+        "-d", "--days", type=positive_int, default=14,
+        help="Show keys expiring within this many days (default: 14)"
+    )
+    worker_expire.add_argument(
+        "--include-grace", action="store_true",
+        help="Also show keys in grace period (already expired but still valid)"
+    )
 
     worker_parser.set_defaults(func=cmd_worker)
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -698,6 +698,21 @@ def cmd_worker(args):
                 headers=admin_headers,
                 timeout=DEFAULT_API_TIMEOUT,
             )
+
+            # Handle 429 rate limit with user-friendly message
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After", "300")
+                try:
+                    seconds = int(retry_after)
+                    if seconds >= 60:
+                        wait_msg = f"{seconds // 60} minute(s)"
+                    else:
+                        wait_msg = f"{seconds} second(s)"
+                except ValueError:
+                    wait_msg = retry_after
+                print(f"Error: Rotation cooldown active. Please wait {wait_msg} before trying again.")
+                sys.exit(1)
+
             result = safe_json_response(response)
 
             print("API key rotated successfully!")

--- a/migrations/versions/030_add_api_key_rotation.py
+++ b/migrations/versions/030_add_api_key_rotation.py
@@ -1,0 +1,50 @@
+"""add_api_key_rotation
+
+Revision ID: 030
+Revises: 029
+Create Date: 2025-01-24
+
+Adds support for API key expiration and rotation (Issue #226):
+- rotated_from: Self-referential FK to track key rotation chain
+- Index for efficient lookup of rotation relationships
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "030"
+down_revision: Union[str, Sequence[str], None] = "029"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add rotated_from column to worker_api_keys for key rotation tracking."""
+    # Add rotated_from column - self-referential FK to track rotation chain
+    # NULL means this is an original key (not created via rotation)
+    # Points to the previous key that was rotated to create this one
+    op.add_column(
+        "worker_api_keys",
+        sa.Column(
+            "rotated_from",
+            sa.Integer,
+            sa.ForeignKey("worker_api_keys.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    # Index for looking up rotation relationships (audit trail)
+    op.create_index(
+        "ix_worker_api_keys_rotated_from",
+        "worker_api_keys",
+        ["rotated_from"],
+    )
+
+
+def downgrade() -> None:
+    """Remove rotated_from column from worker_api_keys."""
+    op.drop_index("ix_worker_api_keys_rotated_from", table_name="worker_api_keys")
+    op.drop_column("worker_api_keys", "rotated_from")

--- a/migrations/versions/030_add_api_key_rotation.py
+++ b/migrations/versions/030_add_api_key_rotation.py
@@ -43,8 +43,16 @@ def upgrade() -> None:
         ["rotated_from"],
     )
 
+    # Index for efficient expiration queries (get_expiring_keys, bulk_revoke)
+    op.create_index(
+        "ix_worker_api_keys_expires_at",
+        "worker_api_keys",
+        ["expires_at"],
+    )
+
 
 def downgrade() -> None:
-    """Remove rotated_from column from worker_api_keys."""
+    """Remove rotated_from column and indexes from worker_api_keys."""
+    op.drop_index("ix_worker_api_keys_expires_at", table_name="worker_api_keys")
     op.drop_index("ix_worker_api_keys_rotated_from", table_name="worker_api_keys")
     op.drop_column("worker_api_keys", "rotated_from")

--- a/tests/test_worker_auth.py
+++ b/tests/test_worker_auth.py
@@ -9,7 +9,7 @@ Integration tests for verify_worker_key are in test_worker_api.py.
 """
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/test_worker_auth.py
+++ b/tests/test_worker_auth.py
@@ -1,18 +1,23 @@
 """
 Unit tests for worker authentication helper functions.
 
-These tests focus on the _get_request_context() function which handles
-request context extraction for security logging, including trusted proxy
-handling and X-Forwarded-For header processing.
+These tests focus on:
+- _get_request_context(): Request context extraction for security logging
+- _check_key_expiration_with_grace(): Key expiration status with grace period (Issue #226)
 
 Integration tests for verify_worker_key are in test_worker_api.py.
 """
 
-from unittest.mock import Mock
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from api.worker_auth import _get_request_context
+from api.worker_auth import (
+    KeyExpirationStatus,
+    _check_key_expiration_with_grace,
+    _get_request_context,
+)
 
 
 @pytest.fixture
@@ -110,3 +115,139 @@ class TestGetRequestContext:
 
         assert ctx["direct_ip"] == "unknown"
         assert ctx["ip_address"] == "unknown"
+
+
+class TestCheckKeyExpirationWithGrace:
+    """Tests for _check_key_expiration_with_grace() function (Issue #226)."""
+
+    @pytest.mark.asyncio
+    async def test_none_expires_at_is_valid(self):
+        """Key with no expiration (None) should be VALID."""
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=None,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.VALID
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_future_expiration_is_valid(self):
+        """Key expiring far in the future should be VALID."""
+        future = datetime.now(timezone.utc) + timedelta(days=60)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=future,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.VALID
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_expiring_soon_within_warning_days(self):
+        """Key expiring within warning period should be EXPIRING_SOON."""
+        # Expires in 7 days, warning period is 14 days
+        future = datetime.now(timezone.utc) + timedelta(days=7)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=future,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.EXPIRING_SOON
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_expired_within_grace_period(self):
+        """Key expired but within grace period should be IN_GRACE_PERIOD."""
+        # Expired 2 hours ago, grace period is 4 hours
+        past = datetime.now(timezone.utc) - timedelta(hours=2)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=past,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.IN_GRACE_PERIOD
+        assert grace_ends is not None
+        # Grace ends 4 hours after expiration
+        expected_grace_end = past + timedelta(hours=4)
+        assert abs((grace_ends - expected_grace_end).total_seconds()) < 1
+
+    @pytest.mark.asyncio
+    async def test_expired_past_grace_period(self):
+        """Key expired past grace period should be EXPIRED."""
+        # Expired 10 hours ago, grace period is 4 hours
+        past = datetime.now(timezone.utc) - timedelta(hours=10)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=past,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.EXPIRED
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_expiration_is_in_grace(self):
+        """Key at exact expiration time should be IN_GRACE_PERIOD."""
+        # Just expired (1 second ago)
+        just_expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=just_expired,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.IN_GRACE_PERIOD
+        assert grace_ends is not None
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_grace_end_is_expired(self):
+        """Key at exact grace period end should be EXPIRED."""
+        # Expired exactly 4 hours and 1 second ago
+        grace_just_ended = datetime.now(timezone.utc) - timedelta(hours=4, seconds=1)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=grace_just_ended,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.EXPIRED
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_zero_grace_period(self):
+        """Key with 0-hour grace period expires immediately."""
+        # Expired 1 second ago with no grace
+        just_expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=just_expired,
+            grace_period_hours=0,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.EXPIRED
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_zero_warning_days(self):
+        """Key with 0 warning days never shows EXPIRING_SOON (unless days_until=0)."""
+        # Expires in 2 days - use 2 days to avoid timing edge case where
+        # timedelta(days=1).days can round to 0 due to microsecond differences
+        future = datetime.now(timezone.utc) + timedelta(days=2)
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=future,
+            grace_period_hours=4,
+            warning_days=0,
+        )
+        # With 0 warning days, key is VALID until it's on the day of expiration
+        assert status == KeyExpirationStatus.VALID
+        assert grace_ends is None
+
+    @pytest.mark.asyncio
+    async def test_naive_datetime_handled(self):
+        """Naive datetime should be converted to UTC."""
+        # Create naive datetime (no timezone)
+        naive_future = datetime.now() + timedelta(days=60)
+        # Should not raise, should treat as UTC
+        status, grace_ends = await _check_key_expiration_with_grace(
+            expires_at=naive_future,
+            grace_period_hours=4,
+            warning_days=14,
+        )
+        assert status == KeyExpirationStatus.VALID


### PR DESCRIPTION
## Summary

Implements secure API key lifecycle management for workers, addressing Issue #226.

- **Key expiration**: Configurable expiration (default 90 days, 0 = never expires)
- **Grace period**: Expired keys continue working temporarily with warnings (default 4 hours)
- **Key rotation**: Generate new keys with configurable overlap period (default 2 hours)
- **Rate limiting**: 10 rotations/hour per worker with 5-minute cooldown between rotations
- **Bulk operations**: Revoke expired keys with dry-run support

### New API Endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /api/v1/workers/{worker_id}/rotate` | Rotate a worker's API key |
| `GET /api/v1/workers/expiring-keys` | List keys expiring within N days |
| `POST /api/v1/workers/revoke-expired` | Bulk revoke expired keys (supports dry-run) |

### New CLI Commands

```bash
vlog worker rotate <worker-id> [--revoke-old]
vlog worker expire-warning [--days N] [--include-grace]
```

### New Settings

| Setting | Default | Description |
|---------|---------|-------------|
| `workers.api_key_expiration_days` | 90 | Days until key expires (0 = never) |
| `workers.api_key_grace_period_hours` | 4 | Hours expired keys still work |
| `workers.api_key_rotation_overlap_hours` | 2 | Hours old key valid after rotation |
| `workers.api_key_expiration_warning_days` | 14 | Days before expiration to warn |

### Security Review Applied

Per Bruce's security review:
- Reduced defaults: grace period 24h → 4h, overlap 24h → 2h
- Added dry-run mode for bulk revoke operations
- Added rate limiting and cooldown to prevent abuse
- All rotation events logged to audit trail

### Files Changed

- `migrations/versions/030_add_api_key_rotation.py` - New migration for `rotated_from` column
- `api/database.py` - Added `rotated_from` column to `worker_api_keys` table
- `api/settings_service.py` - Added 4 new settings
- `api/worker_auth.py` - Grace period helper, rotation logic, bulk operations
- `api/worker_api.py` - 3 new endpoints, updated registration
- `api/worker_schemas.py` - Response models for new endpoints
- `api/audit.py` - Audit actions for key rotation events
- `cli/main.py` - `rotate` and `expire-warning` subcommands

## Test plan

- [ ] Run `alembic upgrade head` to apply migration
- [ ] Run `alembic downgrade -1 && alembic upgrade head` to test reversibility
- [ ] Test settings: `vlog settings list | grep api_key`
- [ ] Register a new worker and verify key has expiration date
- [ ] Test rotation: `vlog worker rotate <worker-id>`
- [ ] Verify 5-minute cooldown blocks rapid re-rotation
- [ ] Test expired key in grace period still works with warning
- [ ] Test `vlog worker expire-warning --days 30`
- [ ] Test dry-run: `curl -X POST "/api/v1/workers/revoke-expired?dry_run=true"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)