### PR TITLE
fix(security): Use restrictive CORS default for Admin API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -353,9 +353,10 @@ VLOG_MAX_HLS_SINGLE_FILE_SIZE=524288000
 # Leave empty for same-origin only
 # VLOG_CORS_ORIGINS=http://localhost:9000,http://localhost:9001
 
-# Allowed origins for admin API (comma-separated)
-# Defaults to * since admin is internal-only
-# VLOG_ADMIN_CORS_ORIGINS=*
+# Allowed origins for admin API cross-origin requests (comma-separated)
+# Defaults to empty (same-origin only) - no configuration needed for typical setups
+# Only set this if admin UI is served from a different host than the API
+# VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
 
 # =============================================================================
 # Rate Limiting

--- a/api/admin.py
+++ b/api/admin.py
@@ -1092,11 +1092,12 @@ app.add_middleware(VersionHeaderMiddleware)
 # Only active when VLOG_ADMIN_API_SECRET is configured
 app.add_middleware(AdminAuthMiddleware)
 
-# Allow CORS for admin UI (internal-only, not exposed externally)
+# CORS for admin API - defaults to same-origin only (Issue #433)
+# Cross-origin access requires explicit VLOG_ADMIN_CORS_ORIGINS configuration
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ADMIN_CORS_ALLOWED_ORIGINS,
-    allow_credentials=True if ADMIN_CORS_ALLOWED_ORIGINS != ["*"] else False,
+    allow_credentials="*" not in ADMIN_CORS_ALLOWED_ORIGINS,  # Credentials require specific origins
     allow_methods=["*"],
     allow_headers=["*"],
     expose_headers=["X-Request-ID"],

--- a/api/admin.py
+++ b/api/admin.py
@@ -1038,6 +1038,13 @@ async def lifespan(app: FastAPI):
     await start_webhook_delivery_worker()
     logger.info("Webhook delivery worker started (with crash recovery)")
 
+    # Issue #433: Log CORS configuration for troubleshooting
+    if ADMIN_CORS_ALLOWED_ORIGINS:
+        logger.info(f"Admin API CORS: allowing origins {ADMIN_CORS_ALLOWED_ORIGINS}")
+    else:
+        logger.info("Admin API CORS: same-origin only (cross-origin requests blocked)")
+        logger.info("Set VLOG_ADMIN_CORS_ORIGINS if you access admin UI from a different host")
+
     yield
 
     # Cancel background cleanup task
@@ -1092,12 +1099,14 @@ app.add_middleware(VersionHeaderMiddleware)
 # Only active when VLOG_ADMIN_API_SECRET is configured
 app.add_middleware(AdminAuthMiddleware)
 
-# CORS for admin API - defaults to same-origin only (Issue #433)
-# Cross-origin access requires explicit VLOG_ADMIN_CORS_ORIGINS configuration
+# CORS middleware - see VLOG_ADMIN_CORS_ORIGINS configuration
+# Defaults to same-origin only (Issue #433)
+_cors_has_origins = bool(ADMIN_CORS_ALLOWED_ORIGINS)
+_cors_uses_wildcard = "*" in ADMIN_CORS_ALLOWED_ORIGINS
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ADMIN_CORS_ALLOWED_ORIGINS,
-    allow_credentials="*" not in ADMIN_CORS_ALLOWED_ORIGINS,  # Credentials require specific origins
+    allow_credentials=_cors_has_origins and not _cors_uses_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
     expose_headers=["X-Request-ID"],

--- a/config.py
+++ b/config.py
@@ -473,14 +473,13 @@ MAX_HLS_SINGLE_FILE_SIZE = get_int_env("VLOG_MAX_HLS_SINGLE_FILE_SIZE", 500 * 10
 _cors_origins_env = os.getenv("VLOG_CORS_ORIGINS", "")
 CORS_ALLOWED_ORIGINS = [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
 
-# For admin API - internal only, not exposed externally
-# Defaults to allow all origins since it's behind firewall/not public
+# For admin API - CORS origins that can make cross-origin requests to the admin API
+# Defaults to empty (same-origin only) for defense-in-depth security (Issue #433)
+# Note: Same-origin requests (accessing admin UI and API from the same host) don't need CORS
+# Only set this if you need cross-origin access (e.g., admin UI served from a different host)
+#   Example: VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
 _admin_cors_env = os.getenv("VLOG_ADMIN_CORS_ORIGINS", "")
-ADMIN_CORS_ALLOWED_ORIGINS = (
-    [origin.strip() for origin in _admin_cors_env.split(",") if origin.strip()]
-    if _admin_cors_env
-    else ["*"]  # Admin is internal-only, allow all origins by default
-)
+ADMIN_CORS_ALLOWED_ORIGINS = [origin.strip() for origin in _admin_cors_env.split(",") if origin.strip()]
 
 # Rate Limiting Configuration
 # Set to "0" or "false" to disable rate limiting entirely

--- a/config.py
+++ b/config.py
@@ -473,13 +473,44 @@ MAX_HLS_SINGLE_FILE_SIZE = get_int_env("VLOG_MAX_HLS_SINGLE_FILE_SIZE", 500 * 10
 _cors_origins_env = os.getenv("VLOG_CORS_ORIGINS", "")
 CORS_ALLOWED_ORIGINS = [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
 
-# For admin API - CORS origins that can make cross-origin requests to the admin API
-# Defaults to empty (same-origin only) for defense-in-depth security (Issue #433)
-# Note: Same-origin requests (accessing admin UI and API from the same host) don't need CORS
-# Only set this if you need cross-origin access (e.g., admin UI served from a different host)
-#   Example: VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
+# Admin API CORS configuration
+# Default: Empty list (same-origin only) for defense-in-depth security (Issue #433)
+# Only set this if you access admin UI from a different hostname than the API
+# Example: VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
 _admin_cors_env = os.getenv("VLOG_ADMIN_CORS_ORIGINS", "")
 ADMIN_CORS_ALLOWED_ORIGINS = [origin.strip() for origin in _admin_cors_env.split(",") if origin.strip()]
+
+# Validate CORS origins format (fail fast with clear errors)
+def _validate_cors_origins(origins: list, var_name: str) -> None:
+    """Validate CORS origin format at startup."""
+    has_wildcard = "*" in origins
+    has_specific = any(o != "*" for o in origins)
+
+    # Warn about mixing wildcard with specific origins (breaks credentials/session auth)
+    if has_wildcard and has_specific:
+        logger.warning(
+            f"{var_name} contains '*' mixed with specific origins. "
+            "This disables credentials (session auth won't work). "
+            "Use '*' alone or specific origins only."
+        )
+
+    for origin in origins:
+        if origin == "*":
+            continue
+        # Check for common mistakes
+        if not origin.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Invalid CORS origin in {var_name}: '{origin}' - "
+                "must start with http:// or https:// (e.g., http://192.168.1.100:3000)"
+            )
+        if origin.endswith("/"):
+            raise ValueError(
+                f"Invalid CORS origin in {var_name}: '{origin}' - "
+                "must not have trailing slash"
+            )
+
+_validate_cors_origins(CORS_ALLOWED_ORIGINS, "VLOG_CORS_ORIGINS")
+_validate_cors_origins(ADMIN_CORS_ALLOWED_ORIGINS, "VLOG_ADMIN_CORS_ORIGINS")
 
 # Rate Limiting Configuration
 # Set to "0" or "false" to disable rate limiting entirely

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -310,20 +310,21 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VLOG_CORS_ORIGINS` | (none) | Comma-separated allowed origins for public API |
-| `VLOG_ADMIN_CORS_ORIGINS` | `*` | Comma-separated allowed origins for admin API |
+| `VLOG_ADMIN_CORS_ORIGINS` | (none) | Comma-separated allowed origins for admin API |
 
 **Examples:**
 ```bash
 # Allow specific origins for public API
 VLOG_CORS_ORIGINS=http://localhost:9000,https://videos.example.com
 
-# Restrict admin API to internal network
-VLOG_ADMIN_CORS_ORIGINS=http://your-server:9001,http://192.168.1.100:9001
+# Allow cross-origin access to admin API (only needed if UI is on a different host)
+VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
 ```
 
 **Notes:**
-- Empty `VLOG_CORS_ORIGINS` = same-origin only
-- Admin API defaults to `*` since it should only be accessible internally
+- Empty/unset = same-origin only (no cross-origin requests allowed)
+- Same-origin requests (accessing UI and API from the same host) don't require CORS configuration
+- Only configure `VLOG_ADMIN_CORS_ORIGINS` if you serve the admin UI from a different host than the API
 
 ### Rate Limiting
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -83,6 +83,45 @@ vlog worker status
 
 ## Version-Specific Upgrade Notes
 
+### Security: Admin API CORS Default Change (Issue #433)
+
+**Impact:** If you access the admin UI from a different origin than the API, you MUST configure CORS.
+
+**What Changed:**
+- **Previous behavior:** Admin API allowed all origins by default (`*`)
+- **New behavior:** Admin API defaults to same-origin only (empty list)
+
+**Who is affected:**
+- Users with reverse proxy setups serving UI and API from different hosts
+- Users running development servers (e.g., Vite on :3000, API on :9001)
+- Users with Docker Compose using separate UI and API containers on different ports
+
+**Who is NOT affected:**
+- Users accessing admin UI directly from the server (same hostname) - most common setup
+- Single-origin deployments where UI and API share the same hostname
+
+**How to tell if you need to configure CORS:**
+1. After upgrading, open browser console when accessing admin UI
+2. If you see "CORS policy" errors, configure `VLOG_ADMIN_CORS_ORIGINS`
+3. Same-origin setups (typical) need no changes
+
+**Action Required (if affected):**
+```bash
+# Set the origin(s) that should access the admin API
+export VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000,http://devbox.local:3000
+
+# Restart admin API
+sudo systemctl restart vlog-admin
+```
+
+**Configuration notes:**
+- Origins must include protocol: `http://example.com:3000` (correct), `example.com:3000` (wrong)
+- Origins must NOT have trailing slash: `http://example.com:3000` (correct), `http://example.com:3000/` (wrong)
+- Do not mix `*` with specific origins - use either `*` alone or specific origins only
+- Invalid origin format will cause startup failure with clear error message
+
+---
+
 ### Upgrading to v0.0.3
 
 This version adds significant new features: playlists, chapters, sprite sheets, advanced player features, and reliability improvements.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -318,3 +318,272 @@ class TestRateLimitStorageAutoDetect:
 
             importlib.reload(config)
             assert config.RATE_LIMIT_STORAGE_URL == "memory://"
+
+
+class TestCorsOriginValidation:
+    """Tests for CORS origin validation (Issue #433).
+
+    The _validate_cors_origins function validates origin format at startup
+    to fail fast with clear errors rather than silently failing at runtime.
+    """
+
+    def test_empty_origins_allowed(self):
+        """Empty origins list should be allowed (same-origin only)."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == []
+            assert config.ADMIN_CORS_ALLOWED_ORIGINS == []
+
+    def test_valid_http_origins(self):
+        """Valid HTTP origins should be parsed correctly."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "http://localhost:3000,http://192.168.1.100:9000",
+            "VLOG_ADMIN_CORS_ORIGINS": "http://10.0.0.5:3000",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == [
+                "http://localhost:3000",
+                "http://192.168.1.100:9000",
+            ]
+            assert config.ADMIN_CORS_ALLOWED_ORIGINS == ["http://10.0.0.5:3000"]
+
+    def test_valid_https_origins(self):
+        """Valid HTTPS origins should be parsed correctly."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "https://example.com,https://api.example.com:8443",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == [
+                "https://example.com",
+                "https://api.example.com:8443",
+            ]
+
+    def test_wildcard_origin_allowed(self):
+        """Wildcard '*' should be allowed as an origin."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "*",
+            "VLOG_ADMIN_CORS_ORIGINS": "*",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == ["*"]
+            assert config.ADMIN_CORS_ALLOWED_ORIGINS == ["*"]
+
+    def test_missing_protocol_rejected(self):
+        """Origins without http:// or https:// should raise ValueError."""
+        import importlib
+        import pytest
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "localhost:3000",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            with pytest.raises(ValueError) as exc_info:
+                importlib.reload(config)
+            assert "must start with http:// or https://" in str(exc_info.value)
+            assert "localhost:3000" in str(exc_info.value)
+
+    def test_missing_protocol_ip_rejected(self):
+        """IP addresses without protocol should raise ValueError."""
+        import importlib
+        import pytest
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "",
+            "VLOG_ADMIN_CORS_ORIGINS": "192.168.1.100:3000",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            with pytest.raises(ValueError) as exc_info:
+                importlib.reload(config)
+            assert "must start with http:// or https://" in str(exc_info.value)
+            assert "192.168.1.100:3000" in str(exc_info.value)
+
+    def test_trailing_slash_rejected(self):
+        """Origins with trailing slash should raise ValueError."""
+        import importlib
+        import pytest
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "http://localhost:3000/",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            with pytest.raises(ValueError) as exc_info:
+                importlib.reload(config)
+            assert "must not have trailing slash" in str(exc_info.value)
+            assert "http://localhost:3000/" in str(exc_info.value)
+
+    def test_mixed_wildcard_warns(self, caplog):
+        """Mixing '*' with specific origins should log a warning."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "",
+            "VLOG_ADMIN_CORS_ORIGINS": "*,http://example.com:3000",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            with caplog.at_level(logging.WARNING):
+                importlib.reload(config)
+                # Should still parse, but warn
+                assert config.ADMIN_CORS_ALLOWED_ORIGINS == [
+                    "*",
+                    "http://example.com:3000",
+                ]
+                assert "mixed with specific origins" in caplog.text
+                assert "session auth won't work" in caplog.text
+
+    def test_whitespace_stripped(self):
+        """Whitespace around origins should be stripped."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "  http://localhost:3000  ,  http://example.com  ",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == [
+                "http://localhost:3000",
+                "http://example.com",
+            ]
+
+    def test_empty_entries_filtered(self):
+        """Empty entries from extra commas should be filtered out."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_CORS_ORIGINS": "http://localhost:3000,,http://example.com,",
+            "VLOG_ADMIN_CORS_ORIGINS": ",",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            assert config.CORS_ALLOWED_ORIGINS == [
+                "http://localhost:3000",
+                "http://example.com",
+            ]
+            assert config.ADMIN_CORS_ALLOWED_ORIGINS == []
+
+
+class TestAdminCorsCredentials:
+    """Tests for Admin API CORS credentials logic (Issue #433).
+
+    Verifies that allow_credentials is set correctly based on the configured origins:
+    - Empty origins: False (no CORS needed)
+    - Specific origins: True (credentials allowed)
+    - Wildcard: False (CORS spec forbids credentials with wildcard)
+    """
+
+    def test_empty_origins_no_credentials(self):
+        """Empty origins should result in allow_credentials=False."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_ADMIN_CORS_ORIGINS": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            # Verify the logic that admin.py uses
+            has_origins = bool(config.ADMIN_CORS_ALLOWED_ORIGINS)
+            uses_wildcard = "*" in config.ADMIN_CORS_ALLOWED_ORIGINS
+            allow_credentials = has_origins and not uses_wildcard
+            assert allow_credentials is False
+
+    def test_specific_origins_allow_credentials(self):
+        """Specific origins should result in allow_credentials=True."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_ADMIN_CORS_ORIGINS": "http://localhost:3000,http://192.168.1.100:3000",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            has_origins = bool(config.ADMIN_CORS_ALLOWED_ORIGINS)
+            uses_wildcard = "*" in config.ADMIN_CORS_ALLOWED_ORIGINS
+            allow_credentials = has_origins and not uses_wildcard
+            assert allow_credentials is True
+
+    def test_wildcard_no_credentials(self):
+        """Wildcard origin should result in allow_credentials=False."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_ADMIN_CORS_ORIGINS": "*",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            has_origins = bool(config.ADMIN_CORS_ALLOWED_ORIGINS)
+            uses_wildcard = "*" in config.ADMIN_CORS_ALLOWED_ORIGINS
+            allow_credentials = has_origins and not uses_wildcard
+            assert allow_credentials is False
+
+    def test_mixed_wildcard_no_credentials(self):
+        """Mixed wildcard + specific origins should result in allow_credentials=False."""
+        import importlib
+
+        env = {
+            "VLOG_TEST_MODE": "1",
+            "VLOG_ADMIN_CORS_ORIGINS": "*,http://example.com:3000",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            import config
+
+            importlib.reload(config)
+            has_origins = bool(config.ADMIN_CORS_ALLOWED_ORIGINS)
+            uses_wildcard = "*" in config.ADMIN_CORS_ALLOWED_ORIGINS
+            allow_credentials = has_origins and not uses_wildcard
+            assert allow_credentials is False


### PR DESCRIPTION
## Summary

- Changes Admin API CORS to default to same-origin only (empty list) instead of `*`
- Adds origin format validation at startup (fail fast with clear errors)
- Improves `allow_credentials` logic for consistency with public API
- Adds startup logging for CORS configuration troubleshooting
- Updates documentation with migration guide

This improves defense-in-depth security (CWE-942) while maintaining functionality for typical deployments where the admin UI and API are served from the same origin.

## Changes

### Security
- Default CORS changed from `["*"]` to `[]` (same-origin only)
- Invalid origin formats now fail at startup with clear error messages

### Reliability (from review feedback)
- **Validation**: Origins must include protocol (`http://` or `https://`), no trailing slash
- **Warning**: Mixing `*` with specific origins logs a warning (breaks session auth)
- **Logging**: CORS configuration logged at startup for troubleshooting
- **Migration guide**: Added to `docs/UPGRADING.md`

### Code Quality
- `allow_credentials` logic uses named variables for clarity
- Consistent with public API CORS pattern

## Test plan

- [x] Config tests pass (27/27)
- [x] Valid origins work: `VLOG_ADMIN_CORS_ORIGINS=http://192.168.1.100:3000`
- [x] Wildcard still works if needed: `VLOG_ADMIN_CORS_ORIGINS=*`
- [x] Missing protocol rejected: `192.168.1.100:3000` → startup error
- [x] Trailing slash rejected: `http://example.com/` → startup error
- [x] Mixed wildcard warns: `*,http://example.com` → warning logged
- [ ] Test accessing admin UI from same origin (should work without any config)
- [ ] Test cross-origin access requires explicit configuration

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)