### PR TITLE
fix(security): Apply consistent error sanitization across endpoints (#435)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -2328,7 +2328,8 @@ async def generate_thumbnail_frames(request: Request, video_id: int) -> Thumbnai
     try:
         await asyncio.gather(*tasks)
     except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=f"Failed to generate frames: {str(e)}")
+        logger.exception(f"Failed to generate frames for video {video_id}: {e}")
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"frame_generation:{video_id}"))
 
     return ThumbnailFramesResponse(video_id=video_id, frames=frames)
 
@@ -2486,7 +2487,8 @@ async def select_thumbnail_frame(
     try:
         await generate_thumbnail(source_path, thumbnail_path, timestamp=timestamp, timeout=30.0)
     except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=f"Failed to generate thumbnail: {str(e)}")
+        logger.exception(f"Failed to generate thumbnail for video {video_id}: {e}")
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"thumbnail_select:{video_id}"))
 
     # Update database
     await db_execute_with_retry(
@@ -2552,7 +2554,8 @@ async def revert_thumbnail(request: Request, video_id: int) -> ThumbnailResponse
     try:
         await generate_thumbnail(source_path, thumbnail_path, timestamp=default_timestamp, timeout=30.0)
     except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=f"Failed to generate thumbnail: {str(e)}")
+        logger.exception(f"Failed to revert thumbnail for video {video_id}: {e}")
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"thumbnail_revert:{video_id}"))
 
     # Update database
     await db_execute_with_retry(
@@ -6838,12 +6841,14 @@ async def update_setting(request: Request, key: str, data: SettingUpdate) -> Set
                 updated_by=existing.get("updated_by"),
             )
         except Exception as e:
-            raise HTTPException(status_code=400, detail=str(e))
+            logger.warning(f"Setting create failed for key {key}: {e}")
+            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_create:{key}"))
 
     try:
         await service.set(key, data.value, updated_by="admin")
     except SettingsValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning(f"Settings validation error for key {key}: {e}")
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_update:{key}"))
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Setting not found: {key}")
 
@@ -6903,10 +6908,12 @@ async def create_setting(request: Request, data: SettingCreate) -> SettingRespon
             updated_by="admin",
         )
     except SettingsValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning(f"Settings validation error for key {data.key}: {e}")
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_create:{data.key}"))
     except UniqueConstraintError as e:
         # Race condition: another request created the setting between our check and insert
-        raise HTTPException(status_code=409, detail=str(e))
+        logger.warning(f"Unique constraint error creating setting {data.key}: {e}")
+        raise HTTPException(status_code=409, detail="Setting already exists")
 
     # Audit log
     log_audit(
@@ -7654,7 +7661,7 @@ async def create_custom_field(
             try:
                 re.compile(constraints_dict["pattern"])
             except re.error as e:
-                raise HTTPException(status_code=400, detail=f"Invalid regex pattern: {e}")
+                raise HTTPException(status_code=400, detail=f"Invalid regex pattern: {sanitize_error_message(str(e), context='regex_validation')}")
 
         constraints_json = json.dumps(constraints_dict)
 
@@ -7850,7 +7857,7 @@ async def update_custom_field(
             try:
                 re.compile(constraints_dict["pattern"])
             except re.error as e:
-                raise HTTPException(status_code=400, detail=f"Invalid regex pattern: {e}")
+                raise HTTPException(status_code=400, detail=f"Invalid regex pattern: {sanitize_error_message(str(e), context='regex_validation')}")
 
         update_values["constraints"] = json.dumps(constraints_dict)
 
@@ -8214,7 +8221,7 @@ async def bulk_update_custom_fields(
                 constraints=constraints,
             )
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=f"Invalid value for field '{field['name']}': {e}")
+            raise HTTPException(status_code=400, detail=f"Invalid value for field '{field['name']}': {sanitize_error_message(str(e), context='custom_field_validation')}")
 
     # Get videos and validate they exist
     video_query = (

--- a/api/admin.py
+++ b/api/admin.py
@@ -98,7 +98,7 @@ from api.db_retry import (
     fetch_one_with_retry,
     fetch_val_with_retry,
 )
-from api.enums import TranscriptionStatus, VideoStatus
+from api.enums import ErrorLogging, TranscriptionStatus, VideoStatus
 from api.errors import is_unique_violation, sanitize_error_message, sanitize_progress_error
 from api.job_queue import JobDispatch, get_job_queue
 from api.metrics import (
@@ -2329,7 +2329,7 @@ async def generate_thumbnail_frames(request: Request, video_id: int) -> Thumbnai
         await asyncio.gather(*tasks)
     except RuntimeError as e:
         logger.exception(f"Failed to generate frames for video {video_id}: {e}")
-        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"frame_generation:{video_id}"))
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"frame_generation:{video_id}"))
 
     return ThumbnailFramesResponse(video_id=video_id, frames=frames)
 
@@ -2413,7 +2413,8 @@ async def upload_custom_thumbnail(
 
         if process.returncode != 0:
             error_msg = stderr.decode("utf-8", errors="ignore")[:200]
-            raise HTTPException(status_code=400, detail=f"Invalid image file: {error_msg}")
+            logger.warning(f"Image conversion failed for video {video_id}: {error_msg}")
+            raise HTTPException(status_code=400, detail=f"Invalid image file: {sanitize_error_message(error_msg, logging_mode=ErrorLogging.SKIP_LOGGING, context=f'thumbnail_upload:{video_id}')}")
 
         # Update database
         await db_execute_with_retry(
@@ -2488,7 +2489,7 @@ async def select_thumbnail_frame(
         await generate_thumbnail(source_path, thumbnail_path, timestamp=timestamp, timeout=30.0)
     except RuntimeError as e:
         logger.exception(f"Failed to generate thumbnail for video {video_id}: {e}")
-        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"thumbnail_select:{video_id}"))
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"thumbnail_select:{video_id}"))
 
     # Update database
     await db_execute_with_retry(
@@ -2555,7 +2556,7 @@ async def revert_thumbnail(request: Request, video_id: int) -> ThumbnailResponse
         await generate_thumbnail(source_path, thumbnail_path, timestamp=default_timestamp, timeout=30.0)
     except RuntimeError as e:
         logger.exception(f"Failed to revert thumbnail for video {video_id}: {e}")
-        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"thumbnail_revert:{video_id}"))
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"thumbnail_revert:{video_id}"))
 
     # Update database
     await db_execute_with_retry(
@@ -6842,13 +6843,13 @@ async def update_setting(request: Request, key: str, data: SettingUpdate) -> Set
             )
         except Exception as e:
             logger.warning(f"Setting create failed for key {key}: {e}")
-            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_create:{key}"))
+            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"setting_create:{key}"))
 
     try:
         await service.set(key, data.value, updated_by="admin")
     except SettingsValidationError as e:
         logger.warning(f"Settings validation error for key {key}: {e}")
-        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_update:{key}"))
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"setting_update:{key}"))
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Setting not found: {key}")
 
@@ -6909,7 +6910,7 @@ async def create_setting(request: Request, data: SettingCreate) -> SettingRespon
         )
     except SettingsValidationError as e:
         logger.warning(f"Settings validation error for key {data.key}: {e}")
-        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"setting_create:{data.key}"))
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"setting_create:{data.key}"))
     except UniqueConstraintError as e:
         # Race condition: another request created the setting between our check and insert
         logger.warning(f"Unique constraint error creating setting {data.key}: {e}")

--- a/api/admin.py
+++ b/api/admin.py
@@ -2414,7 +2414,7 @@ async def upload_custom_thumbnail(
         if process.returncode != 0:
             error_msg = stderr.decode("utf-8", errors="ignore")[:200]
             logger.warning(f"Image conversion failed for video {video_id}: {error_msg}")
-            raise HTTPException(status_code=400, detail=f"Invalid image file: {sanitize_error_message(error_msg, logging_mode=ErrorLogging.SKIP_LOGGING, context=f'thumbnail_upload:{video_id}')}")
+            raise HTTPException(status_code=400, detail="Invalid image file or unsupported format")
 
         # Update database
         await db_execute_with_retry(

--- a/api/auth/endpoints.py
+++ b/api/auth/endpoints.py
@@ -47,6 +47,7 @@ from api.auth.sessions import (
     validate_session_token,
 )
 from api.database import database, password_reset_tokens, users
+from api.enums import ErrorLogging
 from api.errors import sanitize_error_message
 from config import (
     LOGIN_LOCKOUT_DURATION_MINUTES,
@@ -631,7 +632,7 @@ async def refresh(
     except SessionError as e:
         _clear_session_cookies(response)
         logger.warning(f"Session refresh error: {e}")
-        raise HTTPException(status_code=401, detail=sanitize_error_message(str(e), context="session_refresh"))
+        raise HTTPException(status_code=401, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context="session_refresh"))
 
     # Get user info
     # We need to validate the new session to get user info

--- a/api/auth/endpoints.py
+++ b/api/auth/endpoints.py
@@ -47,6 +47,7 @@ from api.auth.sessions import (
     validate_session_token,
 )
 from api.database import database, password_reset_tokens, users
+from api.errors import sanitize_error_message
 from config import (
     LOGIN_LOCKOUT_DURATION_MINUTES,
     LOGIN_LOCKOUT_THRESHOLD,
@@ -629,7 +630,8 @@ async def refresh(
         raise HTTPException(status_code=401, detail="Session expired")
     except SessionError as e:
         _clear_session_cookies(response)
-        raise HTTPException(status_code=401, detail=str(e))
+        logger.warning(f"Session refresh error: {e}")
+        raise HTTPException(status_code=401, detail=sanitize_error_message(str(e), context="session_refresh"))
 
     # Get user info
     # We need to validate the new session to get user info

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -102,6 +102,7 @@ from api.database import (
     workers,
 )
 from api.db_retry import DatabaseLockedError, execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
+from api.errors import sanitize_error_message
 from api.logging_config import setup_logging
 from api.metrics import (
     STORAGE_VIDEOS_BYTES,
@@ -2351,7 +2352,8 @@ async def upload_quality(
             max_single_file=MAX_HLS_SINGLE_FILE_SIZE,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning(f"HLS quality upload validation error for video {video_id}: {e}")
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"quality_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -2437,7 +2439,8 @@ async def upload_finalize(
             strict_filenames=("master.m3u8", "manifest.mpd", "thumbnail.jpg"),
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning(f"Finalize upload validation error for video {video_id}: {e}")
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"finalize_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -2511,7 +2514,8 @@ async def upload_hls(
             max_single_file=MAX_HLS_SINGLE_FILE_SIZE,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        logger.warning(f"HLS upload validation error for video {video_id}: {e}")
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"hls_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -3450,7 +3454,8 @@ async def download_reencode_source(
         )
     except Exception as e:
         tmp_path.unlink(missing_ok=True)
-        raise HTTPException(status_code=500, detail=f"Failed to package files: {e}")
+        logger.exception(f"Failed to package reencode files for job {job_id}: {e}")
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"reencode_package:{job_id}"))
 
 
 @v1_router.post("/reencode/{job_id}/upload")
@@ -3507,7 +3512,8 @@ async def upload_reencode_result(
                 max_single_file=MAX_HLS_SINGLE_FILE_SIZE,
             )
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+            logger.warning(f"Reencode upload validation error for job {job_id}: {e}")
+            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"reencode_upload:{job_id}"))
         finally:
             tmp_path.unlink(missing_ok=True)
 
@@ -3549,7 +3555,8 @@ async def upload_reencode_result(
         if temp_dir.exists():
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-        raise HTTPException(status_code=500, detail=f"Upload failed: {e}")
+        logger.exception(f"Reencode upload failed for job {job_id}: {e}")
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"reencode_upload:{job_id}"))
 
 
 @v1_router.patch("/reencode/{job_id}")

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -102,6 +102,7 @@ from api.database import (
     workers,
 )
 from api.db_retry import DatabaseLockedError, execute_with_retry, fetch_all_with_retry, fetch_one_with_retry
+from api.enums import ErrorLogging
 from api.errors import sanitize_error_message
 from api.logging_config import setup_logging
 from api.metrics import (
@@ -2353,7 +2354,7 @@ async def upload_quality(
         )
     except ValueError as e:
         logger.warning(f"HLS quality upload validation error for video {video_id}: {e}")
-        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"quality_upload:{video_id}"))
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"quality_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -2440,7 +2441,7 @@ async def upload_finalize(
         )
     except ValueError as e:
         logger.warning(f"Finalize upload validation error for video {video_id}: {e}")
-        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"finalize_upload:{video_id}"))
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"finalize_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -2515,7 +2516,7 @@ async def upload_hls(
         )
     except ValueError as e:
         logger.warning(f"HLS upload validation error for video {video_id}: {e}")
-        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"hls_upload:{video_id}"))
+        raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"hls_upload:{video_id}"))
     finally:
         tmp_path.unlink(missing_ok=True)
 
@@ -3455,7 +3456,7 @@ async def download_reencode_source(
     except Exception as e:
         tmp_path.unlink(missing_ok=True)
         logger.exception(f"Failed to package reencode files for job {job_id}: {e}")
-        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"reencode_package:{job_id}"))
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"reencode_package:{job_id}"))
 
 
 @v1_router.post("/reencode/{job_id}/upload")
@@ -3513,7 +3514,7 @@ async def upload_reencode_result(
             )
         except ValueError as e:
             logger.warning(f"Reencode upload validation error for job {job_id}: {e}")
-            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), context=f"reencode_upload:{job_id}"))
+            raise HTTPException(status_code=400, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"reencode_upload:{job_id}"))
         finally:
             tmp_path.unlink(missing_ok=True)
 
@@ -3556,7 +3557,7 @@ async def upload_reencode_result(
             shutil.rmtree(temp_dir, ignore_errors=True)
 
         logger.exception(f"Reencode upload failed for job {job_id}: {e}")
-        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), context=f"reencode_upload:{job_id}"))
+        raise HTTPException(status_code=500, detail=sanitize_error_message(str(e), logging_mode=ErrorLogging.SKIP_LOGGING, context=f"reencode_upload:{job_id}"))
 
 
 @v1_router.patch("/reencode/{job_id}")


### PR DESCRIPTION
## Summary

Addresses #435 - Applies `sanitize_error_message()` consistently across all error paths to prevent information disclosure (CWE-209).

### Changes

**api/worker_api.py** (6 fixes):
- HLS quality upload validation errors
- Finalize upload validation errors  
- Legacy HLS upload validation errors
- Reencode package failures
- Reencode upload validation errors
- Reencode upload failures

**api/admin.py** (10 fixes):
- Frame generation failures
- Thumbnail selection failures
- Thumbnail revert failures
- Settings create/update validation errors
- Settings unique constraint errors
- Custom field regex pattern validation
- Custom field value validation

**api/auth/endpoints.py** (1 fix):
- Session refresh errors

### How it works

Each fix:
1. Logs the original error message for debugging
2. Sanitizes the error before returning to the client
3. Provides context for log correlation

### Before/After Example

**Before:**
```json
{"detail": "Failed to package files: [Errno 2] No such file: '/home/user/videos/abc.mp4'"}
```

**After:**
```json
{"detail": "An error occurred while processing your request. Please try again."}
```

## Test plan

- [ ] Verify endpoints return sanitized error messages (no internal paths/details)
- [ ] Verify original errors are logged for debugging
- [ ] Verify normal operation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)