### PR TITLE
fix(security): Require Admin API authentication by default (#431, #432)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -342,6 +342,44 @@ CSRF_TOKEN_HEADER = "X-CSRF-Token"
 # Falls back to static key if ADMIN_API_SECRET not configured (though CSRF is skipped in that case)
 CSRF_HMAC_KEY = (ADMIN_API_SECRET or "vlog-csrf-fallback").encode()
 
+# Permanent cache for user existence (security: never revert once True)
+# This prevents race condition attacks during the setup->authenticated transition
+_users_exist_cache: Optional[bool] = None
+
+
+async def _check_users_exist() -> bool:
+    """
+    Check if any users exist in the database.
+
+    Security: Uses permanent positive caching - once users exist,
+    the result is cached forever for this process. This prevents
+    race condition attacks during the setup->authenticated transition.
+
+    On database errors, returns True (fail-closed: require authentication).
+    This prevents attackers from accessing setup endpoint during DB outages.
+    """
+    global _users_exist_cache
+
+    # Once users exist, cache permanently (never revert)
+    if _users_exist_cache is True:
+        return True
+
+    try:
+        # Use EXISTS for efficiency - stops at first row found
+        exists = await database.fetch_val("SELECT EXISTS(SELECT 1 FROM users LIMIT 1)")
+        if exists:
+            _users_exist_cache = True  # Permanent positive cache
+        return exists
+    except Exception as e:
+        # Fail closed: on DB error, require authentication (assume users exist)
+        # This prevents setup endpoint access during database outages
+        security_logger.error(
+            "Database error checking user existence - failing closed (requiring auth)",
+            extra={"event": "db_error", "error": str(e)},
+            exc_info=True,
+        )
+        return True
+
 
 def generate_csrf_token(session_token: str) -> str:
     """
@@ -575,15 +613,57 @@ class AdminAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Skip auth for auth endpoints (login, logout, check, csrf-token)
-        if path.startswith("/api/auth/"):
+        # Skip auth for specific public auth endpoints only (not all /api/auth/*)
+        # This prevents bypass of authentication for sensitive endpoints like
+        # /api/auth/users, /api/auth/invites, /api/auth/api-keys
+        public_auth_endpoints = {
+            # Login and session endpoints
+            "/api/auth/login",
+            "/api/auth/check",
+            "/api/auth/csrf-token",
+            "/api/v1/auth/login",
+            "/api/v1/auth/check",
+            "/api/v1/auth/csrf-token",
+            # Password reset endpoints
+            "/api/auth/forgot-password",
+            "/api/auth/reset-password",
+            "/api/v1/auth/forgot-password",
+            "/api/v1/auth/reset-password",
+            # OIDC endpoints (must be public for SSO flows)
+            "/api/auth/oidc/status",
+            "/api/auth/oidc/authorize",
+            "/api/auth/oidc/callback",
+            "/api/v1/auth/oidc/status",
+            "/api/v1/auth/oidc/authorize",
+            "/api/v1/auth/oidc/callback",
+        }
+        # Normalize path (strip trailing slash) for consistent matching
+        normalized_path = path.rstrip("/")
+        if normalized_path in public_auth_endpoints:
             await self.app(scope, receive, send)
             return
 
-        # If ADMIN_API_SECRET is not configured, allow all requests (backwards compatible)
+        # Handle authentication when ADMIN_API_SECRET is not configured
+        # Issue #431: Require authentication by default instead of allowing all requests
         if not ADMIN_API_SECRET:
-            await self.app(scope, receive, send)
-            return
+            if await _check_users_exist():
+                # Users exist - require session authentication (fall through to session check)
+                pass
+            else:
+                # No users exist - ONLY allow setup endpoint
+                # Use normalized_path for consistent matching (handles trailing slashes)
+                if normalized_path in {"/api/v1/auth/setup", "/api/auth/setup"}:
+                    await self.app(scope, receive, send)
+                    return
+                # Block all other endpoints until setup is complete
+                response = JSONResponse(
+                    status_code=503,
+                    content={
+                        "detail": "Initial setup required. Visit /api/auth/setup to create an admin account."
+                    },
+                )
+                await response(scope, receive, send)
+                return
 
         # Extract client IP for logging
         client = scope.get("client")
@@ -593,28 +673,30 @@ class AdminAuthMiddleware:
         headers = dict(scope.get("headers", []))
 
         # Method 1: Check X-Admin-Secret header (for API clients/CLI)
+        # Only available when ADMIN_API_SECRET is configured
         # API clients using the secret header don't need CSRF protection
-        admin_secret = headers.get(b"x-admin-secret", b"").decode("utf-8", errors="ignore")
-        if admin_secret:
-            if hmac.compare_digest(admin_secret, ADMIN_API_SECRET):
-                # Header auth successful - no CSRF needed for API clients
-                security_logger.info(
-                    "Admin API auth successful via header",
-                    extra={"event": "auth_success", "method": "header", "path": path, "client_ip": client_ip},
-                )
-                await self.app(scope, receive, send)
-                return
-            else:
-                security_logger.warning(
-                    "Admin API auth failed: invalid secret header",
-                    extra={"event": "auth_failure", "reason": "invalid_secret", "path": path, "client_ip": client_ip},
-                )
-                response = JSONResponse(
-                    status_code=403,
-                    content={"detail": "Invalid admin secret"},
-                )
-                await response(scope, receive, send)
-                return
+        if ADMIN_API_SECRET:
+            admin_secret = headers.get(b"x-admin-secret", b"").decode("utf-8", errors="ignore")
+            if admin_secret:
+                if hmac.compare_digest(admin_secret, ADMIN_API_SECRET):
+                    # Header auth successful - no CSRF needed for API clients
+                    security_logger.info(
+                        "Admin API auth successful via header",
+                        extra={"event": "auth_success", "method": "header", "path": path, "client_ip": client_ip},
+                    )
+                    await self.app(scope, receive, send)
+                    return
+                else:
+                    security_logger.warning(
+                        "Admin API auth failed: invalid secret header",
+                        extra={"event": "auth_failure", "reason": "invalid_secret", "path": path, "client_ip": client_ip},
+                    )
+                    response = JSONResponse(
+                        status_code=403,
+                        content={"detail": "Invalid admin secret"},
+                    )
+                    await response(scope, receive, send)
+                    return
 
         # Method 2: Check session cookie (for browser UI)
         cookie_header = headers.get(b"cookie", b"")
@@ -991,6 +1073,16 @@ async def lifespan(app: FastAPI):
     create_tables()
     await database.connect()
     await configure_database()
+
+    # Issue #431: Check admin authentication status and log appropriate message
+    user_count = await database.fetch_val("SELECT COUNT(*) FROM users")
+    if not ADMIN_API_SECRET and user_count == 0:
+        logger.warning(
+            "SECURITY: Admin API requires initial setup. "
+            "Only /api/auth/setup is accessible until an admin account is created."
+        )
+    elif not ADMIN_API_SECRET and user_count > 0:
+        logger.info(f"Admin API: User-based authentication active ({user_count} users)")
 
     # Initialize Prometheus metrics
     init_app_info()

--- a/api/admin.py
+++ b/api/admin.py
@@ -1079,7 +1079,8 @@ async def lifespan(app: FastAPI):
     if not ADMIN_API_SECRET and user_count == 0:
         logger.warning(
             "SECURITY: Admin API requires initial setup. "
-            "Only /api/auth/setup is accessible until an admin account is created."
+            "API endpoints return 503 until an admin account is created via /api/auth/setup. "
+            "Public auth endpoints (login, OIDC, password reset) remain accessible."
         )
     elif not ADMIN_API_SECRET and user_count > 0:
         logger.info(f"Admin API: User-based authentication active ({user_count} users)")

--- a/api/worker_api.py
+++ b/api/worker_api.py
@@ -1013,6 +1013,14 @@ async def lifespan(app: FastAPI):
             "(or set VLOG_REDIS_URL which will be auto-detected)"
         )
 
+    # Issue #432: Warn about missing worker admin secret
+    if not WORKER_ADMIN_SECRET:
+        logger.warning(
+            "SECURITY: VLOG_WORKER_ADMIN_SECRET is not configured. "
+            "Worker management endpoints (register, list, revoke) will return 503. "
+            "Generate a secret: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+        )
+
     # Start background tasks
     stale_job_task = asyncio.create_task(check_stale_jobs())
     orphan_cleanup_task = asyncio.create_task(cleanup_orphaned_files())

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -1874,11 +1874,195 @@ TEST_ADMIN_API_SECRET = "test-admin-api-secret-12345"
 class TestAdminAPIAuth:
     """Tests for Admin API authentication middleware."""
 
-    def test_auth_disabled_allows_requests(self, admin_client):
-        """When ADMIN_API_SECRET is not set, requests should be allowed without auth."""
-        # admin_client fixture doesn't set ADMIN_API_SECRET, so auth is disabled
-        response = admin_client.get("/api/categories")
-        assert response.status_code == 200
+    def test_no_secret_no_users_returns_503_for_api_endpoints(self, test_storage, test_db_url, monkeypatch):
+        """When ADMIN_API_SECRET is not set and no users exist, API endpoints return 503."""
+        import importlib
+        import sys
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")  # Empty = not configured
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            # Reset the user cache before reloading
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # API endpoints should return 503 (setup required)
+            response = client.get("/api/categories")
+            assert response.status_code == 503
+            assert "Initial setup required" in response.json()["detail"]
+
+            # But setup endpoint should be accessible
+            response = client.get("/api/v1/auth/setup")
+            # Should return 200 or 400 (not 503) - endpoint is accessible
+            assert response.status_code != 503
+
+    def test_no_secret_no_users_setup_endpoint_accessible(self, test_storage, test_db_url, monkeypatch):
+        """When ADMIN_API_SECRET is not set and no users, setup endpoint should work."""
+        import importlib
+        import sys
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # Setup endpoint should be accessible (GET returns form/info)
+            response = client.get("/api/auth/setup")
+            # Should not be blocked by middleware (503)
+            assert response.status_code != 503
+
+    def test_no_secret_with_users_requires_session_auth(self, test_storage, test_db_url, monkeypatch):
+        """When ADMIN_API_SECRET is not set but users exist, session auth is required."""
+        import importlib
+        import sys
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app
+        from api.database import database, users
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # First, create a user to simulate existing deployment
+            import asyncio
+            from datetime import datetime, timezone
+
+            async def create_test_user():
+                await database.connect()
+                await database.execute(
+                    users.insert().values(
+                        username="testuser",
+                        email="test@example.com",
+                        password_hash="fakehash",
+                        created_at=datetime.now(timezone.utc),
+                    )
+                )
+
+            asyncio.get_event_loop().run_until_complete(create_test_user())
+
+            # Reset cache to force re-check
+            api.admin._users_exist_cache = None
+
+            # Now API endpoints should require auth (return 401, not 503)
+            response = client.get("/api/categories")
+            assert response.status_code == 401
+            assert "Authentication required" in response.json()["detail"]
+
+    def test_no_secret_public_auth_endpoints_accessible(self, test_storage, test_db_url, monkeypatch):
+        """Public auth endpoints should be accessible without auth regardless of user state."""
+        import importlib
+        import sys
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # Public auth endpoints should always be accessible
+            response = client.get("/api/auth/check")
+            assert response.status_code == 200
+
+            response = client.get("/api/auth/csrf-token")
+            assert response.status_code == 200
+
+    def test_sensitive_auth_endpoints_blocked_in_setup_mode(self, test_storage, test_db_url, monkeypatch):
+        """Sensitive auth endpoints like /api/auth/users should be blocked in setup mode."""
+        import importlib
+        import sys
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # Sensitive auth endpoints should be blocked (503) when no users exist
+            response = client.get("/api/auth/users")
+            assert response.status_code == 503
+            assert "Initial setup required" in response.json()["detail"]
+
+            response = client.get("/api/auth/invites")
+            assert response.status_code == 503
+
+            response = client.get("/api/auth/api-keys")
+            assert response.status_code == 503
 
     def test_auth_enabled_returns_401_without_header(self, test_storage, test_db_url, monkeypatch):
         """When ADMIN_API_SECRET is set, requests without header should return 401."""
@@ -2280,6 +2464,50 @@ class TestAdminAPIAuth:
                 cookies={"vlog_admin_session": session_token},
             )
             assert check_after.json()["authenticated"] is False
+
+    def test_db_error_fails_closed_requires_auth(self, test_storage, test_db_url, monkeypatch):
+        """When database errors occur in _check_users_exist, it should fail closed (require auth)."""
+        import importlib
+        import sys
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi.testclient import TestClient
+
+        import config
+
+        monkeypatch.setattr(config, "VIDEOS_DIR", test_storage["videos"])
+        monkeypatch.setattr(config, "UPLOADS_DIR", test_storage["uploads"])
+        monkeypatch.setattr(config, "ARCHIVE_DIR", test_storage["archive"])
+        monkeypatch.setattr(config, "DATABASE_URL", test_db_url)
+        monkeypatch.setattr(config, "ADMIN_API_SECRET", "")
+
+        if "api.database" in sys.modules:
+            importlib.reload(sys.modules["api.database"])
+        if "api.admin" in sys.modules:
+            import api.admin
+
+            api.admin._users_exist_cache = None
+            importlib.reload(sys.modules["api.admin"])
+
+        from api.admin import app, _check_users_exist
+
+        # Mock the database to raise an exception
+        async def mock_fetch_val_error(*args, **kwargs):
+            raise Exception("Database connection failed")
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            # Patch the database fetch_val to simulate DB error
+            with patch("api.admin.database.fetch_val", new=AsyncMock(side_effect=Exception("DB error"))):
+                # Reset cache to force the check
+                import api.admin
+
+                api.admin._users_exist_cache = None
+
+                # When DB fails, should require auth (401) not allow setup (503)
+                response = client.get("/api/categories")
+                # Should get 401 (auth required) because fail-closed returns True (users exist)
+                assert response.status_code == 401
+                assert "Authentication required" in response.json()["detail"]
 
 
 class TestCSRFProtection:


### PR DESCRIPTION
## Summary

Fixes two high-priority security vulnerabilities:

- **Issue #431**: Admin API allowed ALL requests when `ADMIN_API_SECRET` was empty - now requires authentication
- **Issue #432**: Worker API had no startup warning about missing secret - now logs prominent warning

### Changes

**Admin API (`api/admin.py`)**:

**Authentication enforcement:**
- When `ADMIN_API_SECRET` is not configured AND no users exist: only `/api/auth/setup` is accessible (503 for all other endpoints)
- When `ADMIN_API_SECRET` is not configured AND users exist: session authentication is required

**Security improvements (based on specialist review):**
- **Fail-CLOSED on DB errors**: Returns `True` (require auth) instead of `False` (allow setup) when database is unavailable - prevents setup endpoint access during outages
- **Explicit public endpoint list**: Replaced `/api/auth/*` prefix match with explicit list of public endpoints to prevent bypass via `/api/auth/users`, `/api/auth/invites`, `/api/auth/api-keys`
- **Efficient SQL query**: Use `SELECT EXISTS(...)` instead of `COUNT(*)` for better performance
- **Path normalization**: Strip trailing slashes for consistent matching
- **Error logging**: Log database errors in auth check for debugging
- **Permanent positive caching**: Once `users_exist=True`, cache never reverts to prevent race condition exploits

**Worker API (`api/worker_api.py`)**:
- Added startup warning when `VLOG_WORKER_ADMIN_SECRET` is not configured
- Informs operators that management endpoints will return 503

### Security Review Findings Addressed

| Finding | Severity | Resolution |
|---------|----------|------------|
| Auth bypass via `/api/auth/*` prefix | 🔴 CRITICAL | Replaced with explicit public endpoint list |
| Fail-OPEN exception handling | 🔴 CRITICAL | Now returns `True` (require auth) on DB errors |
| No exception logging | 🟠 HIGH | Added `security_logger.error()` with exc_info |
| SQL inefficiency | 🟠 HIGH | Changed to `SELECT EXISTS(SELECT 1 FROM users LIMIT 1)` |

## Test plan

- [ ] Start Admin API without `ADMIN_API_SECRET` and no users - verify only `/api/auth/setup` returns 200, other endpoints return 503
- [ ] Verify `/api/auth/users` returns 503 (not bypassing via prefix match)
- [ ] Complete setup via `/api/auth/setup`, verify cache is permanently set
- [ ] Verify subsequent requests without session return 401
- [ ] Simulate DB error during user check - verify it fails closed (requires auth)
- [ ] Start Admin API with `ADMIN_API_SECRET` - verify X-Admin-Secret header auth works as before
- [ ] Start Worker API without `VLOG_WORKER_ADMIN_SECRET` - verify warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)