### PR TITLE
fix: Performance and reliability improvements for database and caching

### DIFF
--- a/api/db_retry.py
+++ b/api/db_retry.py
@@ -35,6 +35,10 @@ DEFAULT_BASE_DELAY = 0.1  # 100ms
 DEFAULT_MAX_DELAY = 2.0  # 2 seconds
 DEFAULT_EXPONENTIAL_BASE = 2
 
+# Default timeout for database operations (Issue #549)
+# Prevents queries from hanging indefinitely under database contention
+DEFAULT_QUERY_TIMEOUT = 30.0  # 30 seconds
+
 
 class DatabaseRetryableError(Exception):
     """Raised when a database operation fails after all retries exhausted."""
@@ -131,6 +135,12 @@ def is_deadlock_error(exc: Exception) -> bool:
 
 class DeadlockError(DatabaseRetryableError):
     """Raised when too many deadlocks occur, indicating a chronic problem."""
+
+    pass
+
+
+class DatabaseTimeoutError(Exception):
+    """Raised when a database operation times out. (Issue #549)"""
 
     pass
 
@@ -257,6 +267,7 @@ async def fetch_one_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
+    timeout: float = DEFAULT_QUERY_TIMEOUT,
 ):
     """
     Execute a fetch_one query with retry logic for transient database errors.
@@ -266,18 +277,28 @@ async def fetch_one_with_retry(
         max_retries: Maximum number of retry attempts
         base_delay: Initial delay between retries (seconds)
         max_delay: Maximum delay between retries (seconds)
+        timeout: Query timeout in seconds (Issue #549)
 
     Returns:
         The query result (single row or None)
 
     Raises:
+        DatabaseTimeoutError: If query times out
         DatabaseRetryableError: If all retries are exhausted
     """
     from api.database import database
 
     async def _fetch():
         start_time = time.monotonic()
-        result = await database.fetch_one(query)
+        try:
+            result = await asyncio.wait_for(
+                database.fetch_one(query),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            query_str = str(query)[:500]
+            logger.error(f"Query timeout after {timeout}s: {query_str}")
+            raise DatabaseTimeoutError(f"Query timed out after {timeout}s")
         elapsed = time.monotonic() - start_time
         if elapsed >= SLOW_QUERY_THRESHOLD:
             # Log slow query with truncated SQL for debugging (Issue #429)
@@ -298,6 +319,7 @@ async def fetch_all_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
+    timeout: float = DEFAULT_QUERY_TIMEOUT,
 ):
     """
     Execute a fetch_all query with retry logic for transient database errors.
@@ -307,18 +329,28 @@ async def fetch_all_with_retry(
         max_retries: Maximum number of retry attempts
         base_delay: Initial delay between retries (seconds)
         max_delay: Maximum delay between retries (seconds)
+        timeout: Query timeout in seconds (Issue #549)
 
     Returns:
         The query result (list of rows)
 
     Raises:
+        DatabaseTimeoutError: If query times out
         DatabaseRetryableError: If all retries are exhausted
     """
     from api.database import database
 
     async def _fetch():
         start_time = time.monotonic()
-        result = await database.fetch_all(query)
+        try:
+            result = await asyncio.wait_for(
+                database.fetch_all(query),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            query_str = str(query)[:500]
+            logger.error(f"Query timeout after {timeout}s: {query_str}")
+            raise DatabaseTimeoutError(f"Query timed out after {timeout}s")
         elapsed = time.monotonic() - start_time
         if elapsed >= SLOW_QUERY_THRESHOLD:
             # Log slow query with truncated SQL for debugging (Issue #429)
@@ -339,6 +371,7 @@ async def fetch_val_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
+    timeout: float = DEFAULT_QUERY_TIMEOUT,
 ):
     """
     Execute a fetch_val query with retry logic for transient database errors.
@@ -348,18 +381,28 @@ async def fetch_val_with_retry(
         max_retries: Maximum number of retry attempts
         base_delay: Initial delay between retries (seconds)
         max_delay: Maximum delay between retries (seconds)
+        timeout: Query timeout in seconds (Issue #549)
 
     Returns:
         The query result (single scalar value or None)
 
     Raises:
+        DatabaseTimeoutError: If query times out
         DatabaseRetryableError: If all retries are exhausted
     """
     from api.database import database
 
     async def _fetch():
         start_time = time.monotonic()
-        result = await database.fetch_val(query)
+        try:
+            result = await asyncio.wait_for(
+                database.fetch_val(query),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            query_str = str(query)[:500]
+            logger.error(f"Query timeout after {timeout}s: {query_str}")
+            raise DatabaseTimeoutError(f"Query timed out after {timeout}s")
         elapsed = time.monotonic() - start_time
         if elapsed >= SLOW_QUERY_THRESHOLD:
             # Log slow query with truncated SQL for debugging (Issue #429)
@@ -381,6 +424,7 @@ async def db_execute_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
+    timeout: float = DEFAULT_QUERY_TIMEOUT,
 ):
     """
     Execute a database write query with retry logic for transient database errors.
@@ -391,21 +435,34 @@ async def db_execute_with_retry(
         max_retries: Maximum number of retry attempts
         base_delay: Initial delay between retries (seconds)
         max_delay: Maximum delay between retries (seconds)
+        timeout: Query timeout in seconds (Issue #549)
 
     Returns:
         The query result (typically row ID for inserts)
 
     Raises:
+        DatabaseTimeoutError: If query times out
         DatabaseRetryableError: If all retries are exhausted
     """
     from api.database import database
 
     async def _execute():
         start_time = time.monotonic()
-        if values is not None:
-            result = await database.execute(query, values)
-        else:
-            result = await database.execute(query)
+        try:
+            if values is not None:
+                result = await asyncio.wait_for(
+                    database.execute(query, values),
+                    timeout=timeout
+                )
+            else:
+                result = await asyncio.wait_for(
+                    database.execute(query),
+                    timeout=timeout
+                )
+        except asyncio.TimeoutError:
+            query_str = str(query)[:500]
+            logger.error(f"Query timeout after {timeout}s: {query_str}")
+            raise DatabaseTimeoutError(f"Query timed out after {timeout}s")
         elapsed = time.monotonic() - start_time
         if elapsed >= SLOW_QUERY_THRESHOLD:
             # Log slow query with truncated SQL for debugging (Issue #429)

--- a/api/db_retry.py
+++ b/api/db_retry.py
@@ -39,6 +39,10 @@ DEFAULT_EXPONENTIAL_BASE = 2
 # Prevents queries from hanging indefinitely under database contention
 DEFAULT_QUERY_TIMEOUT = 30.0  # 30 seconds
 
+# Default total deadline for retry operations
+# Bounds cumulative wait time across all retries (Issue #549 review feedback)
+DEFAULT_TOTAL_DEADLINE = 60.0  # 60 seconds total
+
 
 class DatabaseRetryableError(Exception):
     """Raised when a database operation fails after all retries exhausted."""
@@ -151,6 +155,7 @@ async def execute_with_retry(
     max_retries: int = DEFAULT_MAX_RETRIES,
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
+    total_deadline: Optional[float] = DEFAULT_TOTAL_DEADLINE,
     **kwargs,
 ) -> T:
     """
@@ -165,6 +170,7 @@ async def execute_with_retry(
         max_retries: Maximum number of retry attempts
         base_delay: Initial delay between retries (seconds)
         max_delay: Maximum delay between retries (seconds)
+        total_deadline: Maximum total time for all attempts (seconds). None for no limit.
         **kwargs: Keyword arguments for func
 
     Returns:
@@ -172,18 +178,27 @@ async def execute_with_retry(
 
     Raises:
         DeadlockError: If too many deadlocks occur (indicates chronic problem)
+        DatabaseTimeoutError: If total deadline is exceeded
         DatabaseRetryableError: If all retries are exhausted
         Other exceptions: Non-retryable errors are re-raised immediately
     """
     import random
 
     last_exception: Optional[Exception] = None
+    start_time = time.monotonic()
 
     # Track deadlocks separately - chronic deadlocks indicate deeper problems (Issue #460)
     MAX_DEADLOCK_RETRIES = 3
     deadlock_count = 0
 
     for attempt in range(max_retries + 1):
+        # Check total deadline before each attempt (Issue #549 review feedback)
+        if total_deadline is not None:
+            elapsed = time.monotonic() - start_time
+            if elapsed >= total_deadline:
+                logger.error(f"Database operation exceeded total deadline of {total_deadline}s after {attempt} attempts")
+                raise DatabaseTimeoutError(f"Operation exceeded total deadline of {total_deadline}s")
+
         try:
             return await func(*args, **kwargs)
         except Exception as e:
@@ -211,6 +226,12 @@ async def execute_with_retry(
                 # Add jitter (±25%) to prevent thundering herd
                 jitter = delay * 0.25 * (2 * random.random() - 1)
                 delay = max(0.01, delay + jitter)
+
+                # Ensure we don't sleep past the deadline
+                if total_deadline is not None:
+                    remaining = total_deadline - (time.monotonic() - start_time)
+                    if delay > remaining:
+                        delay = max(0.01, remaining)
 
                 logger.warning(
                     f"Database error (attempt {attempt + 1}/{max_retries + 1}), retrying in {delay:.2f}s: {e}"
@@ -429,6 +450,10 @@ async def db_execute_with_retry(
     """
     Execute a database write query with retry logic for transient database errors.
 
+    IMPORTANT: Timeouts are NOT retried for write operations because the write
+    may have committed on the database side. Retrying could cause duplicates
+    or data corruption. (Issue #549 review feedback)
+
     Args:
         query: SQLAlchemy query to execute
         values: Optional values dict for the query
@@ -441,7 +466,7 @@ async def db_execute_with_retry(
         The query result (typically row ID for inserts)
 
     Raises:
-        DatabaseTimeoutError: If query times out
+        DatabaseTimeoutError: If query times out (NOT retried - write may have committed)
         DatabaseRetryableError: If all retries are exhausted
     """
     from api.database import database
@@ -461,8 +486,9 @@ async def db_execute_with_retry(
                 )
         except asyncio.TimeoutError:
             query_str = str(query)[:500]
-            logger.error(f"Query timeout after {timeout}s: {query_str}")
-            raise DatabaseTimeoutError(f"Query timed out after {timeout}s")
+            # CRITICAL: Write timeout - do NOT retry, the write may have committed
+            logger.error(f"Write query timeout after {timeout}s (NOT retrying - write may have committed): {query_str}")
+            raise DatabaseTimeoutError(f"Write query timed out after {timeout}s - write may have committed, not retrying")
         elapsed = time.monotonic() - start_time
         if elapsed >= SLOW_QUERY_THRESHOLD:
             # Log slow query with truncated SQL for debugging (Issue #429)
@@ -470,9 +496,16 @@ async def db_execute_with_retry(
             logger.warning(f"Slow query ({elapsed:.2f}s): {query_str}")
         return result
 
-    return await execute_with_retry(
-        _execute,
-        max_retries=max_retries,
-        base_delay=base_delay,
-        max_delay=max_delay,
-    )
+    # Wrap execution to catch timeout errors and prevent retry
+    # Timeouts for writes are NOT retryable - the write may have succeeded
+    try:
+        return await execute_with_retry(
+            _execute,
+            max_retries=max_retries,
+            base_delay=base_delay,
+            max_delay=max_delay,
+        )
+    except DatabaseTimeoutError:
+        # Re-raise timeout errors immediately without retry consideration
+        # This is critical for write safety - the operation may have committed
+        raise

--- a/api/live_metrics.py
+++ b/api/live_metrics.py
@@ -39,6 +39,10 @@ _bitrate_cache: Dict[int, Tuple[Optional[int], float]] = {}
 # Each shard handles stream_ids where hash(stream_id) % SHARD_COUNT == shard_index
 _cache_locks = [asyncio.Lock() for _ in range(BITRATE_CACHE_SHARD_COUNT)]
 
+# Single lock to prevent concurrent eviction attempts (Issue #545/#553 review feedback)
+# This avoids the need to acquire all shard locks during eviction
+_eviction_lock = asyncio.Lock()
+
 
 def _get_cache_lock(stream_id: int) -> asyncio.Lock:
     """Get the appropriate sharded lock for a stream_id."""
@@ -143,40 +147,65 @@ async def _enforce_cache_size_limit(current_time: float) -> None:
     """
     Enforce the cache size limit by evicting expired and oldest entries.
 
-    This is called without holding any lock to minimize contention.
-    Uses a simple global lock for the eviction operation itself.
+    Uses a single eviction lock to prevent concurrent evictions, then
+    acquires per-shard locks only when deleting entries from that shard.
+    This allows normal cache operations on other shards to continue during eviction.
+    (Issue #545/#553 review feedback)
     """
     # Quick check without lock - if we're under limit, skip
     if len(_bitrate_cache) <= BITRATE_CACHE_MAX_SIZE:
         return
 
-    # Acquire all locks to safely modify cache during eviction
-    # This is rare (only when cache exceeds max size) so acceptable
-    for lock in _cache_locks:
-        await lock.acquire()
+    # Use eviction lock to prevent concurrent evictions
+    # This is non-blocking for normal cache operations
+    if not _eviction_lock.locked():
+        async with _eviction_lock:
+            # Re-check under lock - another eviction may have already cleaned up
+            if len(_bitrate_cache) <= BITRATE_CACHE_MAX_SIZE:
+                return
 
-    try:
-        # First, remove expired entries
-        expired_keys = [
-            k for k, (_, expiry) in _bitrate_cache.items()
-            if current_time >= expiry
-        ]
-        for k in expired_keys:
-            del _bitrate_cache[k]
+            # Build list of keys to evict (without holding shard locks)
+            keys_to_evict = []
 
-        # If still over limit, evict oldest entries by expiry time
-        if len(_bitrate_cache) > BITRATE_CACHE_MAX_SIZE:
-            items = sorted(_bitrate_cache.items(), key=lambda x: x[1][1])
-            evict_count = len(_bitrate_cache) - BITRATE_CACHE_MAX_SIZE
-            for k, _ in items[:evict_count]:
-                del _bitrate_cache[k]
-            logger.warning(
-                f"Bitrate cache exceeded max size ({BITRATE_CACHE_MAX_SIZE}), "
-                f"evicted {evict_count + len(expired_keys)} entries"
-            )
-    finally:
-        for lock in _cache_locks:
-            lock.release()
+            # First, collect expired entries
+            for k, (_, expiry) in list(_bitrate_cache.items()):
+                if current_time >= expiry:
+                    keys_to_evict.append(k)
+
+            # If still over limit after removing expired, find oldest entries
+            remaining_after_expired = len(_bitrate_cache) - len(keys_to_evict)
+            if remaining_after_expired > BITRATE_CACHE_MAX_SIZE:
+                # Sort non-expired entries by expiry time (oldest first)
+                non_expired = [
+                    (k, v) for k, v in _bitrate_cache.items()
+                    if k not in keys_to_evict
+                ]
+                non_expired.sort(key=lambda x: x[1][1])
+                evict_count = remaining_after_expired - BITRATE_CACHE_MAX_SIZE
+                keys_to_evict.extend(k for k, _ in non_expired[:evict_count])
+
+            # Delete entries, acquiring only the relevant shard lock for each
+            # Group by shard to minimize lock acquisitions
+            by_shard: Dict[int, list] = {}
+            for k in keys_to_evict:
+                shard = k % BITRATE_CACHE_SHARD_COUNT
+                if shard not in by_shard:
+                    by_shard[shard] = []
+                by_shard[shard].append(k)
+
+            evicted = 0
+            for shard, keys in by_shard.items():
+                async with _cache_locks[shard]:
+                    for k in keys:
+                        if k in _bitrate_cache:
+                            del _bitrate_cache[k]
+                            evicted += 1
+
+            if evicted > 0:
+                logger.warning(
+                    f"Bitrate cache exceeded max size ({BITRATE_CACHE_MAX_SIZE}), "
+                    f"evicted {evicted} entries"
+                )
 
 
 async def _compute_bitrate_uncached(stream_id: int, window_seconds: int) -> Optional[int]:

--- a/api/live_metrics.py
+++ b/api/live_metrics.py
@@ -175,10 +175,12 @@ async def _enforce_cache_size_limit(current_time: float) -> None:
             # If still over limit after removing expired, find oldest entries
             remaining_after_expired = len(_bitrate_cache) - len(keys_to_evict)
             if remaining_after_expired > BITRATE_CACHE_MAX_SIZE:
+                # Convert to set for O(1) membership check (Copilot review feedback)
+                keys_to_evict_set = set(keys_to_evict)
                 # Sort non-expired entries by expiry time (oldest first)
                 non_expired = [
                     (k, v) for k, v in _bitrate_cache.items()
-                    if k not in keys_to_evict
+                    if k not in keys_to_evict_set
                 ]
                 non_expired.sort(key=lambda x: x[1][1])
                 evict_count = remaining_after_expired - BITRATE_CACHE_MAX_SIZE

--- a/api/live_metrics.py
+++ b/api/live_metrics.py
@@ -24,10 +24,25 @@ BITRATE_WINDOW_SECONDS = 30
 # Cache TTL for bitrate estimates (seconds) - prevents query amplification
 BITRATE_CACHE_TTL_SECONDS = 3.0
 
+# Maximum cache size to prevent unbounded memory growth (Issue #553)
+BITRATE_CACHE_MAX_SIZE = 1000
+
+# Number of sharded locks to reduce contention (Issue #545)
+# Using 16 shards allows ~16x more concurrent access
+BITRATE_CACHE_SHARD_COUNT = 16
+
 # Simple in-memory cache for bitrate estimates
 # Format: {stream_id: (bitrate_kbps, expiry_time)}
 _bitrate_cache: Dict[int, Tuple[Optional[int], float]] = {}
-_cache_lock = asyncio.Lock()
+
+# Sharded locks to reduce contention under high load (Issue #545)
+# Each shard handles stream_ids where hash(stream_id) % SHARD_COUNT == shard_index
+_cache_locks = [asyncio.Lock() for _ in range(BITRATE_CACHE_SHARD_COUNT)]
+
+
+def _get_cache_lock(stream_id: int) -> asyncio.Lock:
+    """Get the appropriate sharded lock for a stream_id."""
+    return _cache_locks[stream_id % BITRATE_CACHE_SHARD_COUNT]
 
 
 async def compute_and_publish_metrics(stream_id: int) -> bool:
@@ -100,9 +115,10 @@ async def estimate_bitrate(stream_id: int, window_seconds: int = BITRATE_WINDOW_
     """
     import time
     current_time = time.monotonic()
+    cache_lock = _get_cache_lock(stream_id)
 
-    # Check cache first (with lock to prevent race conditions)
-    async with _cache_lock:
+    # Check cache first (with sharded lock to reduce contention - Issue #545)
+    async with cache_lock:
         if stream_id in _bitrate_cache:
             cached_value, expiry_time = _bitrate_cache[stream_id]
             if current_time < expiry_time:
@@ -111,20 +127,56 @@ async def estimate_bitrate(stream_id: int, window_seconds: int = BITRATE_WINDOW_
     # Cache miss or expired - compute fresh value
     bitrate_kbps = await _compute_bitrate_uncached(stream_id, window_seconds)
 
-    # Update cache
-    async with _cache_lock:
+    # Update cache (with sharded lock)
+    async with cache_lock:
         _bitrate_cache[stream_id] = (bitrate_kbps, current_time + BITRATE_CACHE_TTL_SECONDS)
 
-        # Clean up old cache entries periodically (every 100 entries)
-        if len(_bitrate_cache) > 100:
-            expired_keys = [
-                k for k, (_, expiry) in _bitrate_cache.items()
-                if current_time >= expiry
-            ]
-            for k in expired_keys:
-                del _bitrate_cache[k]
+    # Enforce cache size limit (Issue #553)
+    # Use a separate check to avoid holding lock during eviction scan
+    if len(_bitrate_cache) > BITRATE_CACHE_MAX_SIZE:
+        await _enforce_cache_size_limit(current_time)
 
     return bitrate_kbps
+
+
+async def _enforce_cache_size_limit(current_time: float) -> None:
+    """
+    Enforce the cache size limit by evicting expired and oldest entries.
+
+    This is called without holding any lock to minimize contention.
+    Uses a simple global lock for the eviction operation itself.
+    """
+    # Quick check without lock - if we're under limit, skip
+    if len(_bitrate_cache) <= BITRATE_CACHE_MAX_SIZE:
+        return
+
+    # Acquire all locks to safely modify cache during eviction
+    # This is rare (only when cache exceeds max size) so acceptable
+    for lock in _cache_locks:
+        await lock.acquire()
+
+    try:
+        # First, remove expired entries
+        expired_keys = [
+            k for k, (_, expiry) in _bitrate_cache.items()
+            if current_time >= expiry
+        ]
+        for k in expired_keys:
+            del _bitrate_cache[k]
+
+        # If still over limit, evict oldest entries by expiry time
+        if len(_bitrate_cache) > BITRATE_CACHE_MAX_SIZE:
+            items = sorted(_bitrate_cache.items(), key=lambda x: x[1][1])
+            evict_count = len(_bitrate_cache) - BITRATE_CACHE_MAX_SIZE
+            for k, _ in items[:evict_count]:
+                del _bitrate_cache[k]
+            logger.warning(
+                f"Bitrate cache exceeded max size ({BITRATE_CACHE_MAX_SIZE}), "
+                f"evicted {evict_count + len(expired_keys)} entries"
+            )
+    finally:
+        for lock in _cache_locks:
+            lock.release()
 
 
 async def _compute_bitrate_uncached(stream_id: int, window_seconds: int) -> Optional[int]:

--- a/api/live_schemas.py
+++ b/api/live_schemas.py
@@ -404,9 +404,10 @@ class ChatMessageListResponse(BaseModel):
     """Response for listing chat messages with cursor-based pagination."""
 
     messages: List[ChatMessageResponse]
-    total: int = Field(
-        description="Count of messages returned in this response (not total in database). "
-        "Use 'has_more' for pagination decisions."
+    total: Optional[int] = Field(
+        default=None,
+        description="Deprecated: Always returns None. Use 'has_more' for pagination. "
+        "Previously returned total count but was removed for performance (Issue #546)."
     )
     has_more: bool = Field(
         description="True if more messages exist before the oldest message in this response"

--- a/api/live_schemas.py
+++ b/api/live_schemas.py
@@ -401,12 +401,20 @@ class ChatMessageResponse(BaseModel):
 
 
 class ChatMessageListResponse(BaseModel):
-    """Response for listing chat messages."""
+    """Response for listing chat messages with cursor-based pagination."""
 
     messages: List[ChatMessageResponse]
-    total: int
-    has_more: bool
-    before_id: Optional[int] = None  # For pagination
+    total: int = Field(
+        description="Count of messages returned in this response (not total in database). "
+        "Use 'has_more' for pagination decisions."
+    )
+    has_more: bool = Field(
+        description="True if more messages exist before the oldest message in this response"
+    )
+    before_id: Optional[int] = Field(
+        default=None,
+        description="ID of the oldest message returned. Use as 'before_id' param for next page."
+    )
 
 
 class ChatMessageSend(BaseModel):

--- a/api/studio_chat.py
+++ b/api/studio_chat.py
@@ -214,7 +214,8 @@ async def list_chat_messages(
 
     stream = await verify_stream_access(slug, user)
 
-    # Build query
+    # Build query - fetch limit+1 to determine has_more efficiently (Issue #546)
+    effective_limit = min(limit, 100)
     query = (
         sa.select(
             chat_messages,
@@ -226,7 +227,7 @@ async def list_chat_messages(
         .where(chat_messages.c.stream_id == stream["id"])
         .where(chat_messages.c.deleted_at.is_(None))  # Exclude deleted messages
         .order_by(chat_messages.c.id.desc())
-        .limit(min(limit, 100))  # Cap at 100
+        .limit(effective_limit + 1)  # Fetch one extra to detect has_more
     )
 
     if before_id:
@@ -234,18 +235,10 @@ async def list_chat_messages(
 
     messages = await fetch_all_with_retry(query)
 
-    # Get total count (for has_more)
-    count_query = (
-        sa.select(sa.func.count())
-        .select_from(chat_messages)
-        .where(chat_messages.c.stream_id == stream["id"])
-        .where(chat_messages.c.deleted_at.is_(None))
-    )
-    if before_id:
-        count_query = count_query.where(chat_messages.c.id < before_id)
-
-    total = await fetch_one_with_retry(count_query)
-    total_count = total[0] if total else 0
+    # Determine has_more by checking if we got more than the limit
+    has_more = len(messages) > effective_limit
+    if has_more:
+        messages = messages[:effective_limit]  # Return only requested amount
 
     return ChatMessageListResponse(
         messages=[
@@ -260,8 +253,8 @@ async def list_chat_messages(
             )
             for msg in messages
         ],
-        total=total_count,
-        has_more=len(messages) == min(limit, 100),
+        total=len(messages),  # Count of returned messages
+        has_more=has_more,
         before_id=messages[-1]["id"] if messages else None,
     )
 

--- a/api/studio_chat.py
+++ b/api/studio_chat.py
@@ -253,10 +253,9 @@ async def list_chat_messages(
             )
             for msg in messages
         ],
-        # Note: 'total' is count of returned messages, NOT total in database.
-        # This is intentional for cursor-based pagination - use 'has_more' for pagination.
+        # total is deprecated and always None - use has_more for pagination
         # (Issue #546 - removed expensive COUNT query for performance)
-        total=len(messages),
+        total=None,
         has_more=has_more,
         before_id=messages[-1]["id"] if messages else None,
     )

--- a/api/studio_chat.py
+++ b/api/studio_chat.py
@@ -253,7 +253,10 @@ async def list_chat_messages(
             )
             for msg in messages
         ],
-        total=len(messages),  # Count of returned messages
+        # Note: 'total' is count of returned messages, NOT total in database.
+        # This is intentional for cursor-based pagination - use 'has_more' for pagination.
+        # (Issue #546 - removed expensive COUNT query for performance)
+        total=len(messages),
         has_more=has_more,
         before_id=messages[-1]["id"] if messages else None,
     )

--- a/api/studio_vod.py
+++ b/api/studio_vod.py
@@ -226,34 +226,19 @@ async def list_vods(
     if status and status in ("pending", "processing", "ready", "failed"):
         query = query.where(videos.c.status == status)
 
-    # Count total
-    count_query = (
-        sa.select(sa.func.count())
-        .select_from(
-            videos.outerjoin(
-                live_streams,
-                live_streams.c.vod_video_id == videos.c.id
-            )
-        )
-        .where(videos.c.deleted_at.is_(None))
+    # Add window function for total count (Issue #544)
+    # This computes total in a single query, avoiding a separate COUNT query
+    query = query.add_columns(
+        sa.func.count().over().label("total_count")
     )
-    if not has_manage_any:
-        count_query = count_query.where(
-            sa.or_(
-                videos.c.owner_id == user["id"],
-                live_streams.c.owner_id == user["id"],
-            )
-        )
-    if status and status in ("pending", "processing", "ready", "failed"):
-        count_query = count_query.where(videos.c.status == status)
 
-    total = await database.fetch_val(count_query) or 0
-
-    # Fetch page
+    # Fetch page with total count included
     query = query.order_by(videos.c.created_at.desc())
     query = query.offset(offset).limit(page_size)
     rows = await fetch_all_with_retry(query)
 
+    # Extract total from first row (all rows have same total_count)
+    total = rows[0]["total_count"] if rows else 0
     vods = [vod_to_response(dict(row)) for row in rows]
 
     return StudioVODListResponse(

--- a/api/studio_vod.py
+++ b/api/studio_vod.py
@@ -38,7 +38,7 @@ from api.auth.middleware import require_auth
 from api.auth.permissions import Permission, Role, has_permission
 from api.common import get_real_ip, get_request_id, require_valid_slug
 from api.database import database, live_streams, videos, playback_sessions, viewers
-from api.db_retry import db_execute_with_retry, fetch_one_with_retry, fetch_all_with_retry
+from api.db_retry import db_execute_with_retry, fetch_one_with_retry, fetch_all_with_retry, fetch_val_with_retry
 from api.live_schemas import (
     StudioVODResponse,
     StudioVODListResponse,
@@ -228,6 +228,7 @@ async def list_vods(
 
     # Add window function for total count (Issue #544)
     # This computes total in a single query, avoiding a separate COUNT query
+    # Note: Requires index on (deleted_at, owner_id, created_at) for optimal performance
     query = query.add_columns(
         sa.func.count().over().label("total_count")
     )
@@ -238,7 +239,33 @@ async def list_vods(
     rows = await fetch_all_with_retry(query)
 
     # Extract total from first row (all rows have same total_count)
-    total = rows[0]["total_count"] if rows else 0
+    # If rows is empty (e.g., page past last page), fallback to COUNT query
+    # to avoid returning incorrect total=0 (Copilot review feedback)
+    if rows:
+        total = rows[0]["total_count"]
+    else:
+        # Fallback COUNT for empty pages - only runs for invalid page requests
+        count_query = (
+            sa.select(sa.func.count())
+            .select_from(
+                videos.outerjoin(
+                    live_streams,
+                    live_streams.c.vod_video_id == videos.c.id
+                )
+            )
+            .where(videos.c.deleted_at.is_(None))
+        )
+        if not has_manage_any:
+            count_query = count_query.where(
+                sa.or_(
+                    videos.c.owner_id == user["id"],
+                    live_streams.c.owner_id == user["id"],
+                )
+            )
+        if status and status in ("pending", "processing", "ready", "failed"):
+            count_query = count_query.where(videos.c.status == status)
+        total = await fetch_val_with_retry(count_query) or 0
+
     vods = [vod_to_response(dict(row)) for row in rows]
 
     return StudioVODListResponse(

--- a/tests/test_db_retry.py
+++ b/tests/test_db_retry.py
@@ -11,8 +11,10 @@ import pytest
 from api.db_retry import (
     DatabaseLockedError,
     DatabaseRetryableError,
+    DatabaseTimeoutError,
     execute_with_retry,
     fetch_val_with_retry,
+    fetch_one_with_retry,
     is_database_locked_error,
     is_retryable_database_error,
     with_db_retry,
@@ -414,3 +416,134 @@ class TestFetchValWithRetry:
             result = await fetch_val_with_retry("SELECT NULL")
 
         assert result is None
+
+
+class TestDatabaseTimeoutError:
+    """Tests for database timeout functionality (Issue #549)."""
+
+    @pytest.mark.asyncio
+    async def test_query_timeout_raises_database_timeout_error(self):
+        """Should raise DatabaseTimeoutError when query times out."""
+        import asyncio
+
+        mock_db = AsyncMock()
+        # Simulate a query that takes longer than timeout
+        async def slow_query(*args, **kwargs):
+            await asyncio.sleep(10)  # Sleep longer than timeout
+            return "result"
+
+        mock_db.fetch_one = slow_query
+
+        with patch("api.database.database", mock_db):
+            with pytest.raises(DatabaseTimeoutError) as exc_info:
+                await fetch_one_with_retry("SELECT 1", timeout=0.01)
+
+        assert "timed out" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_not_retried_for_fetch(self):
+        """DatabaseTimeoutError from fetch should not be retried (not a retryable error)."""
+        import asyncio
+
+        call_count = 0
+        mock_db = AsyncMock()
+
+        async def slow_query(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(10)  # Sleep longer than timeout
+            return "result"
+
+        mock_db.fetch_one = slow_query
+
+        with patch("api.database.database", mock_db):
+            with pytest.raises(DatabaseTimeoutError):
+                await fetch_one_with_retry(
+                    "SELECT 1",
+                    timeout=0.01,
+                    max_retries=5,  # Would retry 5 times if timeout was retryable
+                )
+
+        # Should only be called once - DatabaseTimeoutError is not retryable
+        assert call_count == 1
+
+
+class TestTotalDeadline:
+    """Tests for total_deadline parameter (Issue #549 review feedback)."""
+
+    @pytest.mark.asyncio
+    async def test_total_deadline_stops_retries(self):
+        """Should stop retries when total_deadline is exceeded."""
+        call_count = 0
+        mock_time = 0.0
+
+        async def failing_func():
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("database is locked")
+
+        def mock_monotonic():
+            nonlocal mock_time
+            # Simulate time advancing by 0.05s on each call
+            mock_time += 0.05
+            return mock_time
+
+        with patch("api.db_retry.asyncio.sleep", new_callable=AsyncMock):
+            with patch("api.db_retry.time.monotonic", mock_monotonic):
+                with pytest.raises(DatabaseTimeoutError) as exc_info:
+                    await execute_with_retry(
+                        failing_func,
+                        max_retries=100,  # High retry count
+                        total_deadline=0.1,  # But short deadline (2 iterations)
+                        base_delay=0.01,
+                    )
+
+        assert "deadline" in str(exc_info.value).lower()
+        # Should have stopped due to deadline after ~2-3 attempts
+        assert call_count < 10
+
+    @pytest.mark.asyncio
+    async def test_total_deadline_none_allows_full_retries(self):
+        """Should allow all retries when total_deadline is None."""
+        call_count = 0
+
+        async def failing_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "success"
+
+        with patch("api.db_retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await execute_with_retry(
+                failing_then_succeed,
+                max_retries=5,
+                total_deadline=None,  # No deadline
+                base_delay=0.01,
+            )
+
+        assert result == "success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_success_before_deadline(self):
+        """Should succeed normally if within deadline."""
+        call_count = 0
+
+        async def succeed_on_second():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return "success"
+
+        with patch("api.db_retry.asyncio.sleep", new_callable=AsyncMock):
+            result = await execute_with_retry(
+                succeed_on_second,
+                max_retries=5,
+                total_deadline=60.0,  # Long deadline
+                base_delay=0.01,
+            )
+
+        assert result == "success"
+        assert call_count == 2


### PR DESCRIPTION
## Summary

- **#549**: Add 30s timeout to all database retry operations to prevent queries from hanging indefinitely under database contention
- **#544**: Replace VOD list COUNT query with `COUNT(*) OVER()` window function for efficient O(1) pagination
- **#546**: Replace chat pagination COUNT query with limit+1 pattern, eliminating O(n) table scans
- **#545**: Add sharded locks (16 shards) to bitrate cache to reduce lock contention under high load
- **#553**: Add max size limit (1000 entries) to bitrate cache to prevent unbounded memory growth

## Test plan

- [x] All db_retry tests pass (31/31)
- [x] All modified modules import cleanly
- [ ] Verify VOD list pagination still works correctly
- [ ] Verify chat message pagination still works correctly
- [ ] Verify bitrate estimation under concurrent load

Closes #544, #545, #546, #549, #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)