### PR TITLE
fix: WebSocket code quality improvements (#554, #556, #561)

### DIFF
--- a/api/studio_chat_ws.py
+++ b/api/studio_chat_ws.py
@@ -345,6 +345,7 @@ async def pubsub_listener(
     Listen to Redis pub/sub for chat events and forward to WebSocket.
 
     This handles messages sent via REST API or from other server instances.
+    Notifies client on failure to avoid silent message loss.
     """
     subscriber = None
     try:
@@ -358,15 +359,25 @@ async def pubsub_listener(
                 await conn.send_json(message)
             except Exception as e:
                 logger.debug(f"Error forwarding pubsub message: {e}")
+                # Notify client that real-time updates stopped
+                await conn.send_error("pubsub_send_error", "Real-time updates interrupted")
                 break
     except asyncio.CancelledError:
         # Expected during normal shutdown (e.g., WebSocket disconnect or server shutdown)
         pass
     except Exception as e:
         logger.warning(f"Pubsub listener error for stream {stream_id}: {e}")
+        # Notify client about the failure so they know messages may be missing
+        try:
+            await conn.send_error("pubsub_error", "Real-time updates unavailable")
+        except Exception:
+            pass  # Best effort notification
     finally:
         if subscriber:
-            await subscriber.close()
+            try:
+                await subscriber.close()
+            except Exception as e:
+                logger.debug(f"Error closing pubsub subscriber: {e}")
 
 
 async def _setup_chat_connection(
@@ -477,8 +488,7 @@ async def _route_incoming_message(
             await handle_delete_message(conn, ctx.stream, ctx.user, message_id, ctx.client_ip)
         else:
             await conn.send_error("invalid_request", "message_id required")
-    elif msg_type == "pong":
-        pass  # Handled by ManagedWebSocketConnection
+    # Note: "pong" messages are filtered by ManagedWebSocketConnection.receive_json()
     else:
         await conn.send_error("unknown_type", f"Unknown message type: {msg_type}")
 
@@ -495,6 +505,8 @@ async def _cleanup_pubsub_task(
             await pubsub_task
         except asyncio.CancelledError:
             pass  # Expected during cleanup
+        except Exception as e:
+            logger.debug(f"Pubsub task cleanup error: {e}")
 
 
 @router.websocket("/{slug}/chat")

--- a/api/studio_chat_ws.py
+++ b/api/studio_chat_ws.py
@@ -8,11 +8,18 @@ Provides real-time chat functionality via WebSocket:
 - Receive settings updates
 
 Related Issue: #530
+
+Error Handling Patterns (Issue #561):
+-------------------------------------
+- _setup_chat_connection: Returns None on failure (caller handles)
+- _register_chat_connection: Returns None on failure (caller handles)
+- _cleanup_pubsub_task: Never raises (catch CancelledError, continue)
 """
 
 import asyncio
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -27,6 +34,7 @@ from api.db_retry import db_execute_with_retry, fetch_one_with_retry
 from api.live_schemas import ChatSettingsResponse, WSMessageType
 from api.pubsub import subscribe_to_stream_chat
 from api.websocket_manager import (
+    ConnectionInfo,
     ManagedWebSocketConnection,
     ConnectionLimitError,
     OriginValidationError,
@@ -37,6 +45,19 @@ from api.websocket_manager import (
 from config import LIVE_ENABLED
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatConnectionContext:
+    """Context for a chat WebSocket connection (Issue #556)."""
+
+    stream: dict
+    user: dict
+    client_ip: Optional[str]
+    user_agent: Optional[str]
+    session_token: str
+    is_moderator: bool
+    is_owner: bool
 
 # Create router for chat WebSocket
 router = APIRouter(prefix="/api/v1/studio/streams", tags=["Studio Chat WebSocket"])
@@ -303,7 +324,7 @@ async def handle_delete_message(
         },
     )
 
-    # Broadcast deletion
+    # Broadcast deletion - critical priority ensures all connections receive it (Issue #554)
     await websocket_manager.broadcast_to_stream(
         stream["id"],
         {
@@ -311,6 +332,7 @@ async def handle_delete_message(
             "message_id": message_id,
             "deleted_by": user.get("username", ""),
         },
+        priority="critical",
     )
 
 
@@ -347,34 +369,27 @@ async def pubsub_listener(
             await subscriber.close()
 
 
-@router.websocket("/{slug}/chat")
-async def chat_websocket(websocket: WebSocket, slug: str):
+async def _setup_chat_connection(
+    websocket: WebSocket,
+    slug: str,
+) -> Optional[ChatConnectionContext]:
     """
-    WebSocket endpoint for stream chat.
+    Set up a chat WebSocket connection (Issue #556).
 
-    Protocol:
-    - Connect with session cookie for authentication
-    - Server sends 'connected' message with user info and permissions
-    - Client sends 'message' type to chat
-    - Client sends 'delete' type to delete messages (requires permission)
-    - Server broadcasts chat messages and moderation events
-    - Server sends 'ping', client responds with 'pong'
+    Returns None if connection should be closed (already handled).
     """
     if not LIVE_ENABLED:
         await websocket.close(code=1008, reason="Live streaming is not enabled")
-        return
+        return None
 
-    # Verify stream exists
     stream = await verify_stream_exists(slug)
     if not stream:
         await websocket.close(code=1008, reason="Stream not found")
-        return
+        return None
 
-    # Get client info for logging
     client_ip = get_client_ip(websocket)
     user_agent = websocket.headers.get("user-agent")
 
-    # Authenticate user
     user = await authenticate_websocket(websocket, stream["id"])
     if not user:
         log_audit(
@@ -387,22 +402,39 @@ async def chat_websocket(websocket: WebSocket, slug: str):
             success=False,
         )
         await websocket.close(code=4001, reason="Authentication required")
-        return
+        return None
 
-    # Get session token for revalidation
     session_token = websocket.cookies.get("vlog_session", "")
+    is_moderator = await is_user_moderator(stream["id"], user)
+    is_owner = stream["owner_id"] == user["id"]
 
-    # Accept the WebSocket connection first
-    await websocket.accept()
+    return ChatConnectionContext(
+        stream=stream,
+        user=user,
+        client_ip=client_ip,
+        user_agent=user_agent,
+        session_token=session_token,
+        is_moderator=is_moderator,
+        is_owner=is_owner,
+    )
 
+
+async def _register_chat_connection(
+    websocket: WebSocket,
+    ctx: ChatConnectionContext,
+) -> Optional[ConnectionInfo]:
+    """
+    Register the WebSocket connection with the manager (Issue #556).
+
+    Returns None if registration failed (already handled).
+    """
     try:
-        # Register connection with manager
-        conn_info = await websocket_manager.register_connection(
+        return await websocket_manager.register_connection(
             websocket=websocket,
-            stream_id=stream["id"],
-            user=user,
-            client_ip=client_ip,
-            user_agent=user_agent,
+            stream_id=ctx.stream["id"],
+            user=ctx.user,
+            client_ip=ctx.client_ip,
+            user_agent=ctx.user_agent,
         )
     except OriginValidationError as e:
         await websocket.send_json({
@@ -411,7 +443,7 @@ async def chat_websocket(websocket: WebSocket, slug: str):
             "message": str(e),
         })
         await websocket.close(code=4003, reason="Origin validation failed")
-        return
+        return None
     except ConnectionLimitError as e:
         await websocket.send_json({
             "type": "error",
@@ -419,82 +451,108 @@ async def chat_websocket(websocket: WebSocket, slug: str):
             "message": str(e),
         })
         await websocket.close(code=4029, reason="Connection limit exceeded")
-        return
+        return None
     except Exception as e:
         logger.error(f"Error registering WebSocket connection: {e}")
         await websocket.close(code=1011, reason="Internal error")
+        return None
+
+
+async def _route_incoming_message(
+    conn: ManagedWebSocketConnection,
+    message: dict,
+    ctx: ChatConnectionContext,
+    rate_limiter: MessageRateLimiter,
+) -> None:
+    """Route and dispatch a single WebSocket message (Issue #556)."""
+    msg_type = message.get("type")
+
+    if msg_type == "message":
+        await handle_chat_message(
+            conn, ctx.stream, ctx.user, message.get("content", ""), rate_limiter
+        )
+    elif msg_type == "delete":
+        message_id = message.get("message_id")
+        if message_id:
+            await handle_delete_message(conn, ctx.stream, ctx.user, message_id, ctx.client_ip)
+        else:
+            await conn.send_error("invalid_request", "message_id required")
+    elif msg_type == "pong":
+        pass  # Handled by ManagedWebSocketConnection
+    else:
+        await conn.send_error("unknown_type", f"Unknown message type: {msg_type}")
+
+
+async def _cleanup_pubsub_task(
+    stop_event: asyncio.Event,
+    pubsub_task: Optional[asyncio.Task],
+) -> None:
+    """Clean up the pubsub listener task. Never raises (Issue #561)."""
+    stop_event.set()
+    if pubsub_task:
+        pubsub_task.cancel()
+        try:
+            await pubsub_task
+        except asyncio.CancelledError:
+            pass  # Expected during cleanup
+
+
+@router.websocket("/{slug}/chat")
+async def chat_websocket(websocket: WebSocket, slug: str):
+    """
+    WebSocket endpoint for stream chat (Issue #556 - refactored).
+
+    Protocol:
+    - Connect with session cookie for authentication
+    - Server sends 'connected' message with user info and permissions
+    - Client sends 'message' type to chat
+    - Client sends 'delete' type to delete messages (requires permission)
+    - Server broadcasts chat messages and moderation events
+    - Server sends 'ping', client responds with 'pong'
+    """
+    # Setup phase - returns None if connection should be closed
+    ctx = await _setup_chat_connection(websocket, slug)
+    if not ctx:
         return
 
-    # Create rate limiter for this connection
+    await websocket.accept()
+
+    # Register with manager - returns None if registration failed
+    conn_info = await _register_chat_connection(websocket, ctx)
+    if not conn_info:
+        return
+
     rate_limiter = MessageRateLimiter(max_messages=60, window_seconds=60)
-
-    # Check moderator status
-    is_moderator = await is_user_moderator(stream["id"], user)
-    is_owner = stream["owner_id"] == user["id"]
-
-    # Create managed connection context
     managed_conn = ManagedWebSocketConnection(
         manager=websocket_manager,
         conn_info=conn_info,
-        session_token=session_token,
+        session_token=ctx.session_token,
     )
 
-    # Create stop event for pubsub listener
     stop_event = asyncio.Event()
     pubsub_task = None
 
     try:
         async with managed_conn as conn:
-            # Send connected message
             await conn.send_json({
                 "type": WSMessageType.CONNECTED,
-                "user_id": user["id"],
-                "username": user.get("username", ""),
-                "is_moderator": is_moderator,
-                "is_owner": is_owner,
-                "settings": get_chat_settings_response(stream).model_dump(),
+                "user_id": ctx.user["id"],
+                "username": ctx.user.get("username", ""),
+                "is_moderator": ctx.is_moderator,
+                "is_owner": ctx.is_owner,
+                "settings": get_chat_settings_response(ctx.stream).model_dump(),
             })
 
-            # Start pubsub listener in background
             pubsub_task = asyncio.create_task(
-                pubsub_listener(stream["id"], conn, stop_event)
+                pubsub_listener(ctx.stream["id"], conn, stop_event)
             )
 
-            # Message handling loop
             async for message in conn.receive_messages():
-                msg_type = message.get("type")
-
-                if msg_type == "message":
-                    content = message.get("content", "")
-                    await handle_chat_message(conn, stream, user, content, rate_limiter)
-
-                elif msg_type == "delete":
-                    message_id = message.get("message_id")
-                    if message_id:
-                        await handle_delete_message(
-                            conn, stream, user, message_id, client_ip
-                        )
-                    else:
-                        await conn.send_error("invalid_request", "message_id required")
-
-                elif msg_type == "pong":
-                    # Handled internally by ManagedWebSocketConnection
-                    pass
-
-                else:
-                    await conn.send_error("unknown_type", f"Unknown message type: {msg_type}")
+                await _route_incoming_message(conn, message, ctx, rate_limiter)
 
     except WebSocketDisconnect:
         logger.debug(f"WebSocket disconnected: {conn_info.connection_id}")
     except Exception as e:
         logger.error(f"WebSocket error for {conn_info.connection_id}: {e}", exc_info=True)
     finally:
-        # Stop pubsub listener
-        stop_event.set()
-        if pubsub_task:
-            pubsub_task.cancel()
-            try:
-                await pubsub_task
-            except asyncio.CancelledError:
-                # Expected when cancelling the pubsub task during cleanup
-                pass
+        await _cleanup_pubsub_task(stop_event, pubsub_task)

--- a/api/websocket_manager.py
+++ b/api/websocket_manager.py
@@ -444,8 +444,8 @@ class WebSocketManager:
         """
         Broadcast a message to all connections on a stream.
 
-        Sends are parallelized to avoid O(n * timeout) latency. With parallel sends,
-        worst-case latency is O(timeout) = 5 seconds regardless of connection count.
+        Uses bounded concurrency (100 concurrent sends) to avoid memory spikes.
+        For non-critical priority, stops scheduling new sends after failure threshold.
 
         Args:
             stream_id: The stream to broadcast to
@@ -468,39 +468,60 @@ class WebSocketManager:
         if not targets:
             return BroadcastResult(sent_count=0, failed_count=0, early_exit=False)
 
-        message_json = json.dumps(message)
+        # Serialize message once, with error handling
+        try:
+            message_json = json.dumps(message)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                f"Failed to JSON serialize broadcast message for stream {stream_id}: {exc}",
+                extra={"stream_id": stream_id},
+            )
+            return BroadcastResult(sent_count=0, failed_count=len(targets), early_exit=False)
 
-        # Parallel send to all connections - O(timeout) instead of O(n * timeout)
-        results = await asyncio.gather(
-            *[self._send_to_one(conn, message_json) for conn in targets],
+        # Track results with thread-safe counters for early exit
+        sent_count = 0
+        failed_count = 0
+        failed_connection_ids: list[str] = []
+        early_exit = False
+        lock = asyncio.Lock()
+        semaphore = asyncio.Semaphore(100)  # Bounded concurrency
+
+        async def send_one(conn: ConnectionInfo) -> None:
+            nonlocal sent_count, failed_count, early_exit
+
+            # Check early exit before acquiring semaphore
+            if allow_early_exit and early_exit:
+                return
+
+            async with semaphore:
+                # Check again after acquiring semaphore
+                if allow_early_exit and early_exit:
+                    return
+
+                conn_id, success = await self._send_to_one(conn, message_json)
+
+                async with lock:
+                    if success:
+                        sent_count += 1
+                    else:
+                        failed_count += 1
+                        failed_connection_ids.append(conn_id)
+
+                        # Trigger early exit for subsequent sends
+                        if allow_early_exit and failed_count >= WS_BROADCAST_MAX_FAILURES:
+                            if not early_exit:
+                                early_exit = True
+                                logger.warning(
+                                    f"Broadcast early exit: {failed_count} failures "
+                                    f"(threshold: {WS_BROADCAST_MAX_FAILURES}) for stream {stream_id}",
+                                    extra={"stream_id": stream_id, "sent": sent_count, "failed": failed_count},
+                                )
+
+        # Run all sends with bounded concurrency
+        await asyncio.gather(
+            *[send_one(conn) for conn in targets],
             return_exceptions=True,
         )
-
-        sent_count = 0
-        failed_connection_ids: list[str] = []
-
-        for result in results:
-            if isinstance(result, Exception):
-                # Unexpected exception from gather
-                logger.debug(f"Unexpected broadcast exception: {result}")
-                continue
-            conn_id, success = result
-            if success:
-                sent_count += 1
-            else:
-                failed_connection_ids.append(conn_id)
-
-        failed_count = len(failed_connection_ids)
-
-        # Check early exit threshold (for logging/metrics, broadcast already complete)
-        early_exit = False
-        if allow_early_exit and failed_count >= WS_BROADCAST_MAX_FAILURES:
-            logger.warning(
-                f"Broadcast had {failed_count} failures (threshold: {WS_BROADCAST_MAX_FAILURES}) "
-                f"for stream {stream_id}",
-                extra={"stream_id": stream_id, "sent": sent_count, "failed": failed_count},
-            )
-            early_exit = True
 
         # Schedule cleanup of failed connections (tracked for shutdown)
         if failed_connection_ids:
@@ -508,13 +529,22 @@ class WebSocketManager:
                 self._cleanup_failed_connections(failed_connection_ids)
             )
             self._cleanup_tasks.add(task)
-            task.add_done_callback(self._cleanup_tasks.discard)
+            task.add_done_callback(self._on_cleanup_task_done)
 
         return BroadcastResult(
             sent_count=sent_count,
             failed_count=failed_count,
             early_exit=early_exit,
         )
+
+    def _on_cleanup_task_done(self, task: asyncio.Task) -> None:
+        """Callback to handle cleanup task completion and log any exceptions."""
+        self._cleanup_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(f"Cleanup task failed with exception: {exc}")
 
     async def _cleanup_failed_connections(self, connection_ids: list[str]) -> None:
         """
@@ -623,13 +653,19 @@ class WebSocketManager:
         """
         logger.info("Initiating WebSocket manager shutdown")
         self._shutting_down = True
+        start_time = asyncio.get_event_loop().time()
+
+        # Allocate 1/3 of timeout for cleanup tasks, 2/3 for closing connections
+        cleanup_timeout = timeout / 3
 
         # Wait for cleanup tasks before closing connections (Issue #554)
         if self._cleanup_tasks:
             logger.info(f"Waiting for {len(self._cleanup_tasks)} cleanup tasks")
-            done, pending = await asyncio.wait(self._cleanup_tasks, timeout=10.0)
+            done, pending = await asyncio.wait(self._cleanup_tasks, timeout=cleanup_timeout)
             if pending:
-                logger.warning(f"{len(pending)} cleanup tasks still pending after timeout")
+                logger.warning(f"Cancelling {len(pending)} pending cleanup tasks after timeout")
+                for task in pending:
+                    task.cancel()
 
         # Get all connection IDs
         async with self._lock:
@@ -643,7 +679,6 @@ class WebSocketManager:
             })
 
         # Close all connections
-        start_time = asyncio.get_event_loop().time()
         for conn_id in conn_ids:
             await self.close_connection(
                 conn_id,
@@ -652,7 +687,8 @@ class WebSocketManager:
             )
 
             # Check timeout
-            if asyncio.get_event_loop().time() - start_time > timeout:
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed > timeout:
                 logger.warning("Shutdown timeout reached, forcing remaining connections closed")
                 break
 

--- a/api/websocket_manager.py
+++ b/api/websocket_manager.py
@@ -407,6 +407,33 @@ class WebSocketManager:
             conn_ids = self._stream_connections.get(stream_id, set())
             return [self._connections[cid] for cid in conn_ids if cid in self._connections]
 
+    async def _send_to_one(
+        self,
+        conn: ConnectionInfo,
+        message_json: str,
+    ) -> tuple[str, bool]:
+        """
+        Send message to a single connection with timeout.
+
+        Returns:
+            (connection_id, success) tuple
+        """
+        try:
+            if conn.websocket.client_state == WebSocketState.CONNECTED:
+                await asyncio.wait_for(
+                    conn.websocket.send_text(message_json),
+                    timeout=5.0,
+                )
+                return (conn.connection_id, True)
+            else:
+                return (conn.connection_id, False)
+        except asyncio.TimeoutError:
+            logger.debug(f"Send timeout for connection {conn.connection_id}")
+            return (conn.connection_id, False)
+        except Exception as e:
+            logger.debug(f"Failed to send to connection {conn.connection_id}: {e}")
+            return (conn.connection_id, False)
+
     async def broadcast_to_stream(
         self,
         stream_id: int,
@@ -416,6 +443,9 @@ class WebSocketManager:
     ) -> BroadcastResult:
         """
         Broadcast a message to all connections on a stream.
+
+        Sends are parallelized to avoid O(n * timeout) latency. With parallel sends,
+        worst-case latency is O(timeout) = 5 seconds regardless of connection count.
 
         Args:
             stream_id: The stream to broadcast to
@@ -427,48 +457,50 @@ class WebSocketManager:
             BroadcastResult with sent/failed counts and early exit flag
         """
         connections = await self.get_stream_connections(stream_id)
-        sent_count = 0
-        failed_count = 0
-        failed_connection_ids: list[str] = []
-        early_exit = False
         allow_early_exit = priority != "critical"
+
+        # Filter excluded connection
+        targets = [
+            conn for conn in connections
+            if not (exclude_connection and conn.connection_id == exclude_connection)
+        ]
+
+        if not targets:
+            return BroadcastResult(sent_count=0, failed_count=0, early_exit=False)
 
         message_json = json.dumps(message)
 
-        for conn in connections:
-            if exclude_connection and conn.connection_id == exclude_connection:
+        # Parallel send to all connections - O(timeout) instead of O(n * timeout)
+        results = await asyncio.gather(
+            *[self._send_to_one(conn, message_json) for conn in targets],
+            return_exceptions=True,
+        )
+
+        sent_count = 0
+        failed_connection_ids: list[str] = []
+
+        for result in results:
+            if isinstance(result, Exception):
+                # Unexpected exception from gather
+                logger.debug(f"Unexpected broadcast exception: {result}")
                 continue
+            conn_id, success = result
+            if success:
+                sent_count += 1
+            else:
+                failed_connection_ids.append(conn_id)
 
-            try:
-                if conn.websocket.client_state == WebSocketState.CONNECTED:
-                    # Timeout prevents blackholed connections from blocking
-                    await asyncio.wait_for(
-                        conn.websocket.send_text(message_json),
-                        timeout=5.0,
-                    )
-                    sent_count += 1
-                else:
-                    failed_count += 1
-                    failed_connection_ids.append(conn.connection_id)
-            except asyncio.TimeoutError:
-                logger.debug(f"Send timeout for connection {conn.connection_id}")
-                failed_count += 1
-                failed_connection_ids.append(conn.connection_id)
-            except Exception as e:
-                logger.debug(f"Failed to send to connection {conn.connection_id}: {e}")
-                failed_count += 1
-                failed_connection_ids.append(conn.connection_id)
+        failed_count = len(failed_connection_ids)
 
-            # Check total failures threshold (not consecutive - iteration order is non-deterministic)
-            if allow_early_exit and failed_count >= WS_BROADCAST_MAX_FAILURES:
-                remaining = len(connections) - (sent_count + failed_count)
-                logger.warning(
-                    f"Broadcast early exit: {failed_count} total failures, "
-                    f"skipping {remaining} remaining connections for stream {stream_id}",
-                    extra={"stream_id": stream_id, "sent": sent_count, "failed": failed_count},
-                )
-                early_exit = True
-                break
+        # Check early exit threshold (for logging/metrics, broadcast already complete)
+        early_exit = False
+        if allow_early_exit and failed_count >= WS_BROADCAST_MAX_FAILURES:
+            logger.warning(
+                f"Broadcast had {failed_count} failures (threshold: {WS_BROADCAST_MAX_FAILURES}) "
+                f"for stream {stream_id}",
+                extra={"stream_id": stream_id, "sent": sent_count, "failed": failed_count},
+            )
+            early_exit = True
 
         # Schedule cleanup of failed connections (tracked for shutdown)
         if failed_connection_ids:
@@ -488,22 +520,30 @@ class WebSocketManager:
         """
         Clean up connections that failed during broadcast.
 
-        Uses "never raise" pattern - logs errors but never raises (Issue #561).
+        Uses bounded parallelism (10 concurrent) to avoid O(n * timeout) cleanup time.
+        Catches all exceptions except CancelledError to support cooperative shutdown.
         """
-        for conn_id in connection_ids:
-            try:
-                await asyncio.wait_for(
-                    self.close_connection(conn_id, code=1001, reason="Connection failed"),
-                    timeout=10.0,
-                )
-            except asyncio.TimeoutError:
-                logger.warning(f"Timeout closing connection {conn_id}, forcing unregister")
-                await self.unregister_connection(conn_id)
-            except asyncio.CancelledError:
-                logger.debug(f"Cleanup cancelled for {conn_id}")
-                raise  # Allow shutdown to proceed
-            except Exception as e:
-                logger.debug(f"Error cleaning up connection {conn_id}: {e}")
+        semaphore = asyncio.Semaphore(10)  # Max 10 concurrent cleanups
+
+        async def cleanup_one(conn_id: str) -> None:
+            async with semaphore:
+                try:
+                    await asyncio.wait_for(
+                        self.close_connection(conn_id, code=1001, reason="Connection failed"),
+                        timeout=2.0,  # Short timeout, parallelism compensates
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(f"Timeout closing connection {conn_id}, forcing unregister")
+                    await self.unregister_connection(conn_id)
+                except asyncio.CancelledError:
+                    raise  # Allow shutdown to proceed
+                except Exception as e:
+                    logger.debug(f"Error cleaning up connection {conn_id}: {e}")
+
+        await asyncio.gather(
+            *[cleanup_one(conn_id) for conn_id in connection_ids],
+            return_exceptions=True,
+        )
 
     async def send_to_connection(self, connection_id: str, message: dict) -> bool:
         """
@@ -522,8 +562,13 @@ class WebSocketManager:
 
         try:
             if conn.websocket.client_state == WebSocketState.CONNECTED:
-                await conn.websocket.send_text(json.dumps(message))
+                await asyncio.wait_for(
+                    conn.websocket.send_text(json.dumps(message)),
+                    timeout=5.0,
+                )
                 return True
+        except asyncio.TimeoutError:
+            logger.debug(f"Send timeout for connection {connection_id}")
         except Exception as e:
             logger.debug(f"Failed to send to connection {connection_id}: {e}")
 

--- a/api/websocket_manager.py
+++ b/api/websocket_manager.py
@@ -10,6 +10,20 @@ Provides infrastructure for WebSocket connections with:
 
 Related Issue: #530
 
+Error Handling Patterns (Issue #561):
+-------------------------------------
+1. Critical operations (registration, validation): Log ERROR, raise exception
+2. Optional operations (broadcasts, sends): Log DEBUG, return result indicating failure
+3. Cleanup operations: Never raise - catch all, log, continue
+4. WebSocket close codes:
+   - 1000: Normal closure
+   - 1001: Going away (shutdown, session expired)
+   - 1008: Policy violation (feature disabled, not found)
+   - 1011: Internal error
+   - 4001: Authentication required
+   - 4003: Origin validation failed
+   - 4029: Connection limit exceeded
+
 Usage:
     manager = WebSocketManager()
 
@@ -21,6 +35,7 @@ Usage:
 """
 
 import asyncio
+import json
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -37,6 +52,7 @@ from config import (
     CORS_ALLOWED_ORIGINS,
     TRUSTED_PROXIES,
     WS_ALLOWED_ORIGINS,
+    WS_BROADCAST_MAX_FAILURES,
     WS_HEARTBEAT_INTERVAL,
     WS_MAX_CONNECTIONS_GLOBAL,
     WS_MAX_CONNECTIONS_PER_STREAM,
@@ -92,6 +108,15 @@ class ConnectionInfo:
     last_session_check: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+@dataclass
+class BroadcastResult:
+    """Result of a broadcast operation (Issue #554)."""
+
+    sent_count: int
+    failed_count: int
+    early_exit: bool = False
+
+
 class WebSocketManager:
     """
     Manages WebSocket connections with limits, health checks, and lifecycle management.
@@ -116,6 +141,9 @@ class WebSocketManager:
 
         # Callbacks for message handling
         self._message_handlers: Dict[str, Callable] = {}
+
+        # Cleanup tasks tracking (Issue #554)
+        self._cleanup_tasks: Set[asyncio.Task] = set()
 
     @property
     def total_connections(self) -> int:
@@ -384,7 +412,8 @@ class WebSocketManager:
         stream_id: int,
         message: dict,
         exclude_connection: Optional[str] = None,
-    ) -> int:
+        priority: str = "normal",
+    ) -> BroadcastResult:
         """
         Broadcast a message to all connections on a stream.
 
@@ -392,14 +421,19 @@ class WebSocketManager:
             stream_id: The stream to broadcast to
             message: The message dict to send (will be JSON serialized)
             exclude_connection: Optional connection ID to exclude
+            priority: "critical" (never exit early) or "normal" (may exit early)
 
         Returns:
-            Number of connections the message was sent to
+            BroadcastResult with sent/failed counts and early exit flag
         """
-        import json
-
         connections = await self.get_stream_connections(stream_id)
         sent_count = 0
+        failed_count = 0
+        failed_connection_ids: list[str] = []
+        early_exit = False
+        allow_early_exit = priority != "critical"
+
+        message_json = json.dumps(message)
 
         for conn in connections:
             if exclude_connection and conn.connection_id == exclude_connection:
@@ -407,12 +441,69 @@ class WebSocketManager:
 
             try:
                 if conn.websocket.client_state == WebSocketState.CONNECTED:
-                    await conn.websocket.send_text(json.dumps(message))
+                    # Timeout prevents blackholed connections from blocking
+                    await asyncio.wait_for(
+                        conn.websocket.send_text(message_json),
+                        timeout=5.0,
+                    )
                     sent_count += 1
+                else:
+                    failed_count += 1
+                    failed_connection_ids.append(conn.connection_id)
+            except asyncio.TimeoutError:
+                logger.debug(f"Send timeout for connection {conn.connection_id}")
+                failed_count += 1
+                failed_connection_ids.append(conn.connection_id)
             except Exception as e:
                 logger.debug(f"Failed to send to connection {conn.connection_id}: {e}")
+                failed_count += 1
+                failed_connection_ids.append(conn.connection_id)
 
-        return sent_count
+            # Check total failures threshold (not consecutive - iteration order is non-deterministic)
+            if allow_early_exit and failed_count >= WS_BROADCAST_MAX_FAILURES:
+                remaining = len(connections) - (sent_count + failed_count)
+                logger.warning(
+                    f"Broadcast early exit: {failed_count} total failures, "
+                    f"skipping {remaining} remaining connections for stream {stream_id}",
+                    extra={"stream_id": stream_id, "sent": sent_count, "failed": failed_count},
+                )
+                early_exit = True
+                break
+
+        # Schedule cleanup of failed connections (tracked for shutdown)
+        if failed_connection_ids:
+            task = asyncio.create_task(
+                self._cleanup_failed_connections(failed_connection_ids)
+            )
+            self._cleanup_tasks.add(task)
+            task.add_done_callback(self._cleanup_tasks.discard)
+
+        return BroadcastResult(
+            sent_count=sent_count,
+            failed_count=failed_count,
+            early_exit=early_exit,
+        )
+
+    async def _cleanup_failed_connections(self, connection_ids: list[str]) -> None:
+        """
+        Clean up connections that failed during broadcast.
+
+        Uses "never raise" pattern - logs errors but never raises (Issue #561).
+        """
+        for conn_id in connection_ids:
+            try:
+                await asyncio.wait_for(
+                    self.close_connection(conn_id, code=1001, reason="Connection failed"),
+                    timeout=10.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(f"Timeout closing connection {conn_id}, forcing unregister")
+                await self.unregister_connection(conn_id)
+            except asyncio.CancelledError:
+                logger.debug(f"Cleanup cancelled for {conn_id}")
+                raise  # Allow shutdown to proceed
+            except Exception as e:
+                logger.debug(f"Error cleaning up connection {conn_id}: {e}")
 
     async def send_to_connection(self, connection_id: str, message: dict) -> bool:
         """
@@ -425,8 +516,6 @@ class WebSocketManager:
         Returns:
             True if sent successfully, False otherwise
         """
-        import json
-
         conn = await self.get_connection(connection_id)
         if not conn:
             return False
@@ -489,6 +578,13 @@ class WebSocketManager:
         """
         logger.info("Initiating WebSocket manager shutdown")
         self._shutting_down = True
+
+        # Wait for cleanup tasks before closing connections (Issue #554)
+        if self._cleanup_tasks:
+            logger.info(f"Waiting for {len(self._cleanup_tasks)} cleanup tasks")
+            done, pending = await asyncio.wait(self._cleanup_tasks, timeout=10.0)
+            if pending:
+                logger.warning(f"{len(pending)} cleanup tasks still pending after timeout")
 
         # Get all connection IDs
         async with self._lock:

--- a/config.py
+++ b/config.py
@@ -880,6 +880,12 @@ WS_MAX_CONNECTIONS_PER_USER_PER_STREAM = get_int_env("VLOG_WS_MAX_CONNECTIONS_PE
 # WebSocket heartbeat/ping interval in seconds
 WS_HEARTBEAT_INTERVAL = get_int_env("VLOG_WS_HEARTBEAT_INTERVAL", 30, min_val=10, max_val=120)
 
+# Maximum total failures before early exit from broadcast (Issue #554)
+# Uses total failures, not consecutive, since iteration order is non-deterministic
+WS_BROADCAST_MAX_FAILURES = get_int_env(
+    "VLOG_WS_BROADCAST_MAX_FAILURES", 50, min_val=10, max_val=500
+)
+
 # Session revalidation interval in seconds (matches SSE pattern)
 WS_SESSION_REVALIDATION_INTERVAL = get_int_env("VLOG_WS_SESSION_REVALIDATION_INTERVAL", 300, min_val=60)
 


### PR DESCRIPTION
## Summary

Fixes three related WebSocket code quality issues:

- **#554**: Add broadcast error accumulation limit with early exit after 50 total failures
- **#556**: Refactor `chat_websocket` (151 lines → ~50 lines) into smaller, focused functions
- **#561**: Apply consistent error handling patterns with documented conventions

## Changes

### config.py
- Add `WS_BROADCAST_MAX_FAILURES` constant (default: 50, configurable 10-500)

### api/websocket_manager.py
- Add `BroadcastResult` dataclass for broadcast operation results
- Add cleanup task tracking (`_cleanup_tasks` set) for graceful shutdown
- Refactor `broadcast_to_stream` with:
  - Priority system (`"critical"` vs `"normal"`) - critical never exits early
  - 5-second send timeout to prevent blackholed connections blocking
  - Total failure tracking with early exit at threshold
  - Spawns tracked cleanup tasks for failed connections
- Add `_cleanup_failed_connections` helper with "never raise" pattern
- Update `initiate_shutdown` to await cleanup tasks
- Document error handling patterns in module docstring

### api/studio_chat_ws.py
- Add `ChatConnectionContext` dataclass for connection state
- Extract `_setup_chat_connection` - returns `Optional[ChatConnectionContext]`
- Extract `_register_chat_connection` - returns `Optional[ConnectionInfo]`
- Extract `_route_incoming_message` - routes WebSocket messages
- Extract `_cleanup_pubsub_task` - cleanup with "never raise" pattern
- Update `handle_delete_message` to use `priority="critical"`
- Document error handling patterns in module docstring

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Total failures (not consecutive) | Dict iteration order is non-deterministic |
| Critical priority never exits early | Moderation events must reach all connections |
| Cleanup tasks tracked | Ensures graceful shutdown completes cleanup |
| 5s send timeout | Prevents blackholed connections from blocking |
| Helpers return `Optional` | Caller checks `None` for clean control flow |

## Test plan

- [x] All modified files compile (`py_compile`)
- [x] Imports work correctly
- [x] Existing test suite passes (726 passed, 5 pre-existing failures unrelated to changes)
- [ ] Manual: Broadcast with dead connections triggers early exit and cleanup
- [ ] Manual: Delete message (moderation) reaches all connections (no early exit)
- [ ] Manual: Shutdown waits for cleanup tasks to complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)