### PR TITLE
feat: VOD recording recovery for orphaned streams (#552)

### DIFF
--- a/api/live_tasks.py
+++ b/api/live_tasks.py
@@ -23,6 +23,9 @@ from config import (
     LIVE_STALE_GRACE_MULTIPLIER,
     LIVE_STALE_THRESHOLD,
     LIVE_STORAGE_PATH,
+    LIVE_VOD_RECOVERY_GRACE_PERIOD,
+    LIVE_VOD_RECOVERY_INTERVAL,
+    LIVE_VOD_RECOVERY_MAX_RETRIES,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,6 +38,13 @@ _running = False
 # Prometheus-style metrics (counter values)
 _dvr_segments_cleaned = 0
 _stale_streams_detected = 0
+_vod_recovery_attempts = 0
+_vod_recovery_successes = 0
+_vod_recovery_failures = 0
+
+# VOD recovery state
+_vod_recovery_task: Optional[asyncio.Task] = None
+_vod_recovery_retry_counts: dict = {}
 
 
 async def cleanup_dvr_segments() -> int:
@@ -178,26 +188,124 @@ async def detect_stale_streams() -> int:
             logger.info(f"Stream {stream['slug']} marked as ended (stale timeout)")
 
             # Re-fetch stream after update to verify state before VOD recording (Issue #552)
-            updated_stream = await fetch_one_with_retry(
-                live_streams.select().where(live_streams.c.id == stream["id"])
-            )
+            # Wrapped in try/except so a re-fetch failure doesn't abort processing
+            # of remaining ending streams.
+            try:
+                updated_stream = await fetch_one_with_retry(
+                    live_streams.select().where(live_streams.c.id == stream["id"])
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Stream {stream['slug']} state verification failed after update: {e}, "
+                    f"skipping VOD recording (recovery will retry later)"
+                )
+                updated_stream = None
 
-            if updated_stream and updated_stream["status"] == "ended" and updated_stream["auto_record_vod"]:
-                try:
-                    await finalize_playlists_for_vod(stream["id"])
-                    await trigger_vod_recording(stream["id"])
-                except Exception as e:
-                    logger.error(f"Failed to create VOD for stream {stream['slug']}: {e}")
-            elif not updated_stream or updated_stream["status"] != "ended":
+            # Use original stream["auto_record_vod"] for the VOD decision — the
+            # re-fetch only verifies status == "ended" to guard against races.
+            if updated_stream and updated_stream["status"] == "ended":
+                if stream["auto_record_vod"]:
+                    try:
+                        await finalize_playlists_for_vod(stream["id"])
+                        await trigger_vod_recording(stream["id"])
+                    except Exception as e:
+                        logger.error(f"Failed to create VOD for stream {stream['slug']} (id={stream['id']}): {e}")
+            elif updated_stream and updated_stream["status"] != "ended":
                 logger.warning(
                     f"Stream {stream['slug']} status verification failed after update "
-                    f"(expected 'ended', got '{updated_stream['status'] if updated_stream else 'missing'}'), "
+                    f"(expected 'ended', got '{updated_stream['status']}'), "
                     f"skipping VOD recording"
                 )
 
             transitions += 1
 
     return transitions
+
+
+async def recover_orphaned_vod_streams() -> dict:
+    """
+    Recover streams stuck in 'ended' state without a VOD recording.
+
+    Finds streams where auto_record_vod=true, status='ended', vod_video_id IS NULL,
+    and ended_at is older than the grace period. Retries VOD creation for each,
+    up to LIVE_VOD_RECOVERY_MAX_RETRIES per stream per process lifetime.
+
+    Returns dict with attempted/succeeded/failed/skipped counts.
+    """
+    global _vod_recovery_attempts, _vod_recovery_successes, _vod_recovery_failures
+
+    now = datetime.now(timezone.utc)
+    grace_cutoff = now - timedelta(seconds=LIVE_VOD_RECOVERY_GRACE_PERIOD)
+
+    result = {"attempted": 0, "succeeded": 0, "failed": 0, "skipped": 0}
+
+    orphaned = await fetch_all_with_retry(
+        live_streams.select()
+        .where(live_streams.c.status == "ended")
+        .where(live_streams.c.auto_record_vod.is_(True))
+        .where(live_streams.c.vod_video_id.is_(None))
+        .where(live_streams.c.ended_at < grace_cutoff)
+    )
+
+    for stream in orphaned:
+        stream_id = stream["id"]
+        retry_count = _vod_recovery_retry_counts.get(stream_id, 0)
+
+        if retry_count >= LIVE_VOD_RECOVERY_MAX_RETRIES:
+            if retry_count == LIVE_VOD_RECOVERY_MAX_RETRIES:
+                logger.error(
+                    f"VOD recovery: stream {stream['slug']} (id={stream_id}) "
+                    f"exceeded max retries ({LIVE_VOD_RECOVERY_MAX_RETRIES}), giving up"
+                )
+                # Increment past max so this log fires only once
+                _vod_recovery_retry_counts[stream_id] = retry_count + 1
+            result["skipped"] += 1
+            continue
+
+        _vod_recovery_retry_counts[stream_id] = retry_count + 1
+        result["attempted"] += 1
+        _vod_recovery_attempts += 1
+
+        logger.info(
+            f"VOD recovery: retrying stream {stream['slug']} (id={stream_id}), "
+            f"attempt {retry_count + 1}/{LIVE_VOD_RECOVERY_MAX_RETRIES}"
+        )
+
+        try:
+            await finalize_playlists_for_vod(stream_id)
+            await trigger_vod_recording(stream_id)
+            # Success — clean up retry tracker
+            _vod_recovery_retry_counts.pop(stream_id, None)
+            result["succeeded"] += 1
+            _vod_recovery_successes += 1
+            logger.info(
+                f"VOD recovery: successfully created VOD for stream {stream['slug']} (id={stream_id})"
+            )
+        except Exception as e:
+            result["failed"] += 1
+            _vod_recovery_failures += 1
+            logger.error(
+                f"VOD recovery: failed for stream {stream['slug']} (id={stream_id}): {e}"
+            )
+
+    return result
+
+
+async def _vod_recovery_loop():
+    """Background loop for VOD recording recovery."""
+    while _running:
+        try:
+            result = await recover_orphaned_vod_streams()
+            if result["attempted"] > 0:
+                logger.debug(
+                    f"VOD recovery: attempted={result['attempted']}, "
+                    f"succeeded={result['succeeded']}, failed={result['failed']}, "
+                    f"skipped={result['skipped']}"
+                )
+        except Exception as e:
+            logger.error(f"VOD recovery loop error: {e}")
+
+        await asyncio.sleep(LIVE_VOD_RECOVERY_INTERVAL)
 
 
 async def _dvr_cleanup_loop():
@@ -237,7 +345,7 @@ async def _stale_detection_loop():
 
 async def start_live_background_tasks():
     """Start all live streaming background tasks."""
-    global _running, _dvr_cleanup_task, _stale_detection_task
+    global _running, _dvr_cleanup_task, _stale_detection_task, _vod_recovery_task
 
     if _running:
         logger.warning("Live background tasks already running")
@@ -247,13 +355,14 @@ async def start_live_background_tasks():
 
     _dvr_cleanup_task = asyncio.create_task(_dvr_cleanup_loop())
     _stale_detection_task = asyncio.create_task(_stale_detection_loop())
+    _vod_recovery_task = asyncio.create_task(_vod_recovery_loop())
 
     logger.info("Started live streaming background tasks")
 
 
 async def stop_live_background_tasks(timeout: float = 10.0):
     """Stop all live streaming background tasks gracefully."""
-    global _running, _dvr_cleanup_task, _stale_detection_task
+    global _running, _dvr_cleanup_task, _stale_detection_task, _vod_recovery_task
 
     if not _running:
         return
@@ -265,6 +374,8 @@ async def stop_live_background_tasks(timeout: float = 10.0):
         tasks.append(_dvr_cleanup_task)
     if _stale_detection_task:
         tasks.append(_stale_detection_task)
+    if _vod_recovery_task:
+        tasks.append(_vod_recovery_task)
 
     if tasks:
         # Wait for tasks to complete with timeout
@@ -280,6 +391,7 @@ async def stop_live_background_tasks(timeout: float = 10.0):
 
     _dvr_cleanup_task = None
     _stale_detection_task = None
+    _vod_recovery_task = None
 
     logger.info("Stopped live streaming background tasks")
 
@@ -289,5 +401,8 @@ def get_live_task_metrics() -> dict:
     return {
         "dvr_segments_cleaned_total": _dvr_segments_cleaned,
         "stale_streams_detected_total": _stale_streams_detected,
+        "vod_recovery_attempts_total": _vod_recovery_attempts,
+        "vod_recovery_successes_total": _vod_recovery_successes,
+        "vod_recovery_failures_total": _vod_recovery_failures,
         "running": _running,
     }

--- a/config.py
+++ b/config.py
@@ -863,6 +863,12 @@ LIVE_ALLOWED_QUALITIES = frozenset({"2160p", "1440p", "1080p", "720p", "480p", "
 # The actual ingest happens via HTTP segment push, but users may use RTMP re-streaming
 LIVE_RTMP_INGEST_URL = os.getenv("VLOG_LIVE_RTMP_INGEST_URL", "rtmp://localhost/live")
 
+# VOD recording recovery for orphaned streams (Issue #552)
+# Streams that end but fail VOD creation are retried by a background loop
+LIVE_VOD_RECOVERY_INTERVAL = get_int_env("VLOG_LIVE_VOD_RECOVERY_INTERVAL", 120, min_val=30, max_val=600)
+LIVE_VOD_RECOVERY_GRACE_PERIOD = get_int_env("VLOG_LIVE_VOD_RECOVERY_GRACE_PERIOD", 300, min_val=60, max_val=3600)
+LIVE_VOD_RECOVERY_MAX_RETRIES = get_int_env("VLOG_LIVE_VOD_RECOVERY_MAX_RETRIES", 5, min_val=1, max_val=20)
+
 # =============================================================================
 # WebSocket Configuration (Issue #530)
 # Chat and real-time features use WebSocket connections

--- a/tests/test_vod_recovery.py
+++ b/tests/test_vod_recovery.py
@@ -1,0 +1,304 @@
+"""
+Tests for VOD recording recovery mechanism (Issue #552).
+
+Validates the background recovery loop that retries VOD creation
+for orphaned streams stuck in 'ended' state without a VOD.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ["VLOG_TEST_MODE"] = "1"
+
+
+class TestRecoverOrphanedVodStreams:
+    """Tests for recover_orphaned_vod_streams()."""
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self):
+        """Reset module-level state between tests."""
+        import api.live_tasks as lt
+
+        lt._vod_recovery_retry_counts.clear()
+        lt._vod_recovery_attempts = 0
+        lt._vod_recovery_successes = 0
+        lt._vod_recovery_failures = 0
+        yield
+        lt._vod_recovery_retry_counts.clear()
+        lt._vod_recovery_attempts = 0
+        lt._vod_recovery_successes = 0
+        lt._vod_recovery_failures = 0
+
+    @pytest.mark.asyncio
+    async def test_recovers_orphaned_stream(self):
+        """Test that an orphaned stream gets VOD recovery attempted."""
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch(
+                "api.live_tasks.finalize_playlists_for_vod",
+                new_callable=AsyncMock,
+            ) as mock_finalize,
+            patch(
+                "api.live_tasks.trigger_vod_recording",
+                new_callable=AsyncMock,
+            ) as mock_trigger,
+        ):
+            result = await recover_orphaned_vod_streams()
+
+        assert result["attempted"] == 1
+        assert result["succeeded"] == 1
+        assert result["failed"] == 0
+        assert result["skipped"] == 0
+        mock_finalize.assert_awaited_once_with(42)
+        mock_trigger.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_skips_at_max_retries(self):
+        """Test that streams at max retries are skipped."""
+        import api.live_tasks as lt
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        # Pre-fill retry counter to max
+        lt._vod_recovery_retry_counts[42] = lt.LIVE_VOD_RECOVERY_MAX_RETRIES
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch(
+                "api.live_tasks.finalize_playlists_for_vod",
+                new_callable=AsyncMock,
+            ) as mock_finalize,
+            patch(
+                "api.live_tasks.trigger_vod_recording",
+                new_callable=AsyncMock,
+            ) as mock_trigger,
+        ):
+            result = await recover_orphaned_vod_streams()
+
+        assert result["skipped"] == 1
+        assert result["attempted"] == 0
+        mock_finalize.assert_not_awaited()
+        mock_trigger.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_logs_error_once_at_max_retries(self):
+        """Test that the max-retries error is logged exactly once."""
+        import api.live_tasks as lt
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        # Set to exactly max retries (first time hitting the limit)
+        lt._vod_recovery_retry_counts[42] = lt.LIVE_VOD_RECOVERY_MAX_RETRIES
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch("api.live_tasks.finalize_playlists_for_vod", new_callable=AsyncMock),
+            patch("api.live_tasks.trigger_vod_recording", new_callable=AsyncMock),
+            patch("api.live_tasks.logger") as mock_logger,
+        ):
+            # First call at max retries — should log error
+            await recover_orphaned_vod_streams()
+            assert mock_logger.error.call_count == 1
+            assert "exceeded max retries" in mock_logger.error.call_args[0][0]
+
+            mock_logger.error.reset_mock()
+
+            # Second call — retry count now past max, should NOT log again
+            await recover_orphaned_vod_streams()
+            assert mock_logger.error.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_exception_counted_as_failure(self):
+        """Test that exceptions during VOD creation are counted as failures."""
+        import api.live_tasks as lt
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch(
+                "api.live_tasks.finalize_playlists_for_vod",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("DB timeout"),
+            ),
+            patch("api.live_tasks.trigger_vod_recording", new_callable=AsyncMock) as mock_trigger,
+        ):
+            result = await recover_orphaned_vod_streams()
+
+        assert result["attempted"] == 1
+        assert result["failed"] == 1
+        assert result["succeeded"] == 0
+        assert lt._vod_recovery_failures == 1
+        # trigger_vod_recording should not be called if finalize fails
+        mock_trigger.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_orphans_returns_zeros(self):
+        """Test that no orphaned streams returns all-zero counts."""
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        with patch(
+            "api.live_tasks.fetch_all_with_retry",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await recover_orphaned_vod_streams()
+
+        assert result == {"attempted": 0, "succeeded": 0, "failed": 0, "skipped": 0}
+
+    @pytest.mark.asyncio
+    async def test_success_clears_retry_counter(self):
+        """Test that successful recovery removes the stream from retry tracker."""
+        import api.live_tasks as lt
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        # Pre-set some retry count
+        lt._vod_recovery_retry_counts[42] = 2
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch("api.live_tasks.finalize_playlists_for_vod", new_callable=AsyncMock),
+            patch("api.live_tasks.trigger_vod_recording", new_callable=AsyncMock),
+        ):
+            await recover_orphaned_vod_streams()
+
+        assert 42 not in lt._vod_recovery_retry_counts
+
+    @pytest.mark.asyncio
+    async def test_global_counters_accumulate(self):
+        """Test that global metric counters accumulate across calls."""
+        import api.live_tasks as lt
+        from api.live_tasks import recover_orphaned_vod_streams
+
+        orphaned_stream = {
+            "id": 42,
+            "slug": "test-stream",
+            "status": "ended",
+            "auto_record_vod": True,
+            "vod_video_id": None,
+            "ended_at": datetime.now(timezone.utc) - timedelta(seconds=600),
+        }
+
+        with (
+            patch(
+                "api.live_tasks.fetch_all_with_retry",
+                new_callable=AsyncMock,
+                return_value=[orphaned_stream],
+            ),
+            patch("api.live_tasks.finalize_playlists_for_vod", new_callable=AsyncMock),
+            patch("api.live_tasks.trigger_vod_recording", new_callable=AsyncMock),
+        ):
+            await recover_orphaned_vod_streams()
+            await recover_orphaned_vod_streams()
+
+        assert lt._vod_recovery_attempts == 2
+        assert lt._vod_recovery_successes == 2
+
+
+class TestGetLiveTaskMetrics:
+    """Tests for metrics including VOD recovery keys."""
+
+    def test_metrics_include_vod_recovery_keys(self):
+        """Test that get_live_task_metrics includes VOD recovery counters."""
+        from api.live_tasks import get_live_task_metrics
+
+        metrics = get_live_task_metrics()
+
+        assert "vod_recovery_attempts_total" in metrics
+        assert "vod_recovery_successes_total" in metrics
+        assert "vod_recovery_failures_total" in metrics
+
+
+class TestVodRecoveryConfigDefaults:
+    """Tests for VOD recovery config defaults."""
+
+    def test_recovery_interval_range(self):
+        """Test that recovery interval is within valid range."""
+        from config import LIVE_VOD_RECOVERY_INTERVAL
+
+        assert 30 <= LIVE_VOD_RECOVERY_INTERVAL <= 600
+
+    def test_recovery_grace_period_range(self):
+        """Test that grace period is within valid range."""
+        from config import LIVE_VOD_RECOVERY_GRACE_PERIOD
+
+        assert 60 <= LIVE_VOD_RECOVERY_GRACE_PERIOD <= 3600
+
+    def test_recovery_max_retries_range(self):
+        """Test that max retries is within valid range."""
+        from config import LIVE_VOD_RECOVERY_MAX_RETRIES
+
+        assert 1 <= LIVE_VOD_RECOVERY_MAX_RETRIES <= 20
+
+    def test_grace_period_exceeds_interval(self):
+        """Test that grace period is longer than check interval."""
+        from config import LIVE_VOD_RECOVERY_GRACE_PERIOD, LIVE_VOD_RECOVERY_INTERVAL
+
+        assert LIVE_VOD_RECOVERY_GRACE_PERIOD > LIVE_VOD_RECOVERY_INTERVAL


### PR DESCRIPTION
## Summary

- Adds background recovery loop that detects streams stuck in `ended` state with `auto_record_vod=true` and `vod_video_id IS NULL`, and retries VOD creation
- Adds 3 config variables: `LIVE_VOD_RECOVERY_INTERVAL` (120s), `LIVE_VOD_RECOVERY_GRACE_PERIOD` (300s), `LIVE_VOD_RECOVERY_MAX_RETRIES` (5)
- In-memory retry tracking per stream, with max retries and one-time error log at exhaustion
- Addresses Copilot PR review feedback from #569: wraps re-fetch in try/except, uses original `auto_record_vod` flag for VOD decision
- Adds `(id=...)` to VOD error log messages for easier debugging

## Test plan

- [x] 12 unit tests in `tests/test_vod_recovery.py` all pass
- [ ] Verify recovery loop starts/stops with background tasks
- [ ] Verify orphaned streams get VOD created after grace period
- [ ] Verify streams at max retries are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)