### PR TITLE
test: remove two sources of CI flakiness

### DIFF
--- a/tests/test_analytics_cache.py
+++ b/tests/test_analytics_cache.py
@@ -5,6 +5,7 @@ Tests for analytics caching functionality.
 import time
 from unittest.mock import MagicMock, patch
 
+from api import analytics_cache
 from api.analytics_cache import (
     AnalyticsCache,
     RedisAnalyticsCache,
@@ -119,8 +120,14 @@ class TestAnalyticsCache:
         # Should not raise an error
         cache.invalidate("nonexistent_key")
 
-    def test_cleanup_expired(self):
+    def test_cleanup_expired(self, monkeypatch):
         """Test cleanup of expired entries."""
+        # set() runs cleanup_expired() itself with CLEANUP_PROBABILITY (1%).
+        # When that fires on the key4 set below it removes the three expired
+        # entries first, and the explicit call then reports 0 removed - a ~4%
+        # flake per run. Pin the dice so only the explicit call cleans up.
+        monkeypatch.setattr(analytics_cache.random, "random", lambda: 1.0)
+
         cache = AnalyticsCache(ttl_seconds=1)
 
         # Add some entries

--- a/tests/test_worker_hls_upload_streaming.py
+++ b/tests/test_worker_hls_upload_streaming.py
@@ -107,7 +107,14 @@ class TestHLSUploadStreaming:
 
     @pytest.mark.asyncio
     async def test_upload_hls_handles_upload_error(
-        self, worker_client, registered_worker, test_database, sample_pending_video, test_storage, monkeypatch
+        self,
+        worker_client,
+        registered_worker,
+        test_database,
+        sample_pending_video,
+        test_storage,
+        monkeypatch,
+        tmp_path,
     ):
         """Test that upload errors are handled gracefully and temp files are cleaned up."""
         # Create a transcoding job for this worker
@@ -124,10 +131,17 @@ class TestHLSUploadStreaming:
             )
         )
 
-        # Track temp directory before upload to verify cleanup
+        # Track temp directory before upload to verify cleanup.
+        # Point the upload at a private temp directory first: the endpoint uses
+        # tempfile.NamedTemporaryFile(suffix=".tar.gz"), and under `pytest -n 4`
+        # sibling tests drop their own .tar.gz files into the shared system temp
+        # directory. Scanning that shared directory made this test fail on
+        # someone else's leftovers.
         import os
 
-        temp_dir = tempfile.gettempdir()
+        temp_dir = str(tmp_path / "upload-tmp")
+        os.mkdir(temp_dir)
+        monkeypatch.setattr(tempfile, "tempdir", temp_dir)
         before_files = set(os.listdir(temp_dir))
 
         # Mock open to raise an exception to simulate upload failure


### PR DESCRIPTION
Two flaky tests were failing dependabot PRs at random. With `pytest -x`, one flake fails the entire run.

**`test_analytics_cache::test_cleanup_expired`** — `AnalyticsCache.set()` performs its own cleanup with `CLEANUP_PROBABILITY` (1%). When that fired on the `key4` set, it removed the three expired entries first, so the explicit `cleanup_expired()` returned 0 instead of 3. Four `set()` calls ≈ 4% failure rate per run. Fixed by pinning `random.random()` so only the explicit call cleans up.

**`test_worker_hls_upload_streaming::test_upload_hls_handles_upload_error`** — the test snapshotted the shared system temp directory and asserted no new `.tar.gz` appeared. Under `pytest -n 4`, sibling tests (notably `test_upload_hls_rejects_symlinks`) create `.tar.gz` files there with `delete=False`, so this test failed on *other tests'* leftovers. Fixed by pointing `tempfile` at a private directory, so the assertion only sees files the endpoint under test created.

Observed on #605/#607 (temp files) and #602 (cache cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrg8WVwMzMvNWVxeFAsgDK